### PR TITLE
add unit test for missing plugin data, replace missing plugin data with N/A

### DIFF
--- a/src/report/generate.py
+++ b/src/report/generate.py
@@ -187,12 +187,13 @@ def format_quality_gates(extract_directory, gate_mapping):
 
 
 def process_plugins(extract_directory):
-    "\n".join(["| {name} | {description} | {version} | {url} |".format(name=plugin['name'],
-                                                                       description=plugin['description'],
-                                                                       version=plugin['version'],
-                                                                       url=plugin['homepageUrl']) for plugin in
-               object_reader(directory=extract_directory, key='getPlugins') if
-               "sonar" not in plugin['organizationName'].lower()])
+    return "\n".join(["| {name} | {description} | {version} | {url} |".format(
+        name=plugin.get('name') if plugin.get('name') is not None else 'N/A',
+        description=plugin.get('description') if plugin.get('description') is not None else 'N/A',
+        version=plugin.get('version') if plugin.get('version') is not None else 'N/A',
+        url=plugin.get('homepageUrl') if plugin.get('homepageUrl') is not None else 'N/A'
+    ) for plugin in object_reader(directory=extract_directory, key='getPlugins') if
+        "sonar" not in plugin.get('organizationName', '').lower()])
 
 
 def process_permission_templates(extract_directory):

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -9,5 +9,7 @@ RUN pip install -r /app/requirements.txt
 
 COPY /src/ /app/
 
+COPY /tests/ /app/tests/
+
 WORKDIR /app/
 ENTRYPOINT ["pytest", "/app/tests", "--cov-config=/app/.coveragerc", "--cov=/app", "--cov-report", "xml:/app/files/coverage.xml", "--asyncio-mode", "auto", "-rfE", "-p", "no:warnings"]

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -9,7 +9,5 @@ RUN pip install -r /app/requirements.txt
 
 COPY /src/ /app/
 
-COPY /tests/ /app/tests/
-
 WORKDIR /app/
 ENTRYPOINT ["pytest", "/app/tests", "--cov-config=/app/.coveragerc", "--cov=/app", "--cov-report", "xml:/app/files/coverage.xml", "--asyncio-mode", "auto", "-rfE", "-p", "no:warnings"]

--- a/tests/structure/test_generate.py
+++ b/tests/structure/test_generate.py
@@ -1,0 +1,42 @@
+import unittest
+from report.generate import process_plugins
+
+class TestProcessPlugins(unittest.TestCase):
+    def setUp(self):
+        self.maxDiff = None
+
+    def test_process_plugins_with_missing_data(self):
+        extract_directory = 'test_directory'
+        plugins = [
+            {'name': 'Plugin1', 'description': 'Description1', 'version': '1.0', 'homepageUrl': 'http://example.com'},
+            {'name': 'Plugin2', 'description': 'Description2', 'version': '2.0', 'homepageUrl': None},
+            {'name': 'Plugin3', 'description': 'Description3', 'version': None},
+            {'name': 'Plugin4', 'description': None, 'version': '4.0'},
+            {'name': None, 'description': 'Description5', 'version': '5.0'},
+            {}
+        ]
+        
+        def mock_object_reader(directory, key):
+            return plugins
+        
+        # Replace the object_reader function with the mock
+        original_object_reader = process_plugins.__globals__['object_reader']
+        process_plugins.__globals__['object_reader'] = mock_object_reader
+        
+        try:
+            result = process_plugins(extract_directory)
+            expected = (
+                "| Plugin1 | Description1 | 1.0 | http://example.com |\n"
+                "| Plugin2 | Description2 | 2.0 | N/A |\n"
+                "| Plugin3 | Description3 | N/A | N/A |\n"
+                "| Plugin4 | N/A | 4.0 | N/A |\n"
+                "| N/A | Description5 | 5.0 | N/A |\n"
+                "| N/A | N/A | N/A | N/A |"
+            )
+            self.assertEqual(result, expected)
+        finally:
+            # Restore the original object_reader function
+            process_plugins.__globals__['object_reader'] = original_object_reader
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When the report command is run and a plugin is missing data. (like the homepageURL) An error is thrown. 


```
PS C:\work> docker run -v ./sonar:/app/files [ghcr.io/sonarsource-demos/sonar-reports:latest](http://ghcr.io/sonarsource-demos/sonar-reports:latest) report

Traceback (most recent call last):

  File "/app/main.py", line 232, in <module>

    cli()

    ~~~^^

  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1157, in __call__

    return self.main(*args, **kwargs)

           ~~~~~~~~~^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1078, in main

    rv = self.invoke(ctx)

  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1688, in invoke

    return _process_result(sub_ctx.command.invoke(sub_ctx))

                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^

  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 1434, in invoke

    return ctx.invoke(self.callback, **ctx.params)

           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/local/lib/python3.13/site-packages/click/core.py", line 783, in invoke

    return __callback(*args, **kwargs)

  File "/app/main.py", line 85, in report

    generate_markdown(extract_directory=os.path.join(export_directory, extract_id.strip() + '/'))

    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/report/generate.py", line 348, in generate_markdown

    plugins=format_plugins(extract_directory=extract_directory),

            ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/report/generate.py", line 222, in format_plugins

    url=plugin['homepageUrl']) for plugin in

        ~~~~~~^^^^^^^^^^^^^^^

KeyError: 'homepageUrl'
```

Let's ensure a default value is set for this data so that the process doesn't halt when the report is being created. 

