### PR TITLE
Skip non-settable SQC parameters during migration

### DIFF
--- a/src/tasks/migrate/filterProjectSettingsValue/cloud.json
+++ b/src/tasks/migrate/filterProjectSettingsValue/cloud.json
@@ -43,7 +43,19 @@
               "sonar.core.serverBaseURL",
               "sonaranalyzer-vbnet.staticResourceName",
               "sonaranalyzer-cs.nuget.packageVersion",
-              "sonaranalyzer.security.cs.pluginVersion"
+              "sonaranalyzer.security.cs.pluginVersion",
+              "sonar.cs.analyzer.dotnet.pluginVersion",
+              "sonar.cs.analyzer.dotnet.staticResourceName",
+              "sonar.vbnet.analyzer.dotnet.pluginVersion",
+              "sonar.vbnet.analyzer.dotnet.staticResourceName",
+              "sonaranalyzer.security.cs.analyzerId",
+              "sonaranalyzer.security.cs.ruleNamespace",
+              "sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByMonth",
+              "sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByWeek",
+              "sonar.forceAuthentication",
+              "sonar.global.exclusions",
+              "sonar.lf.enableGravatar",
+              "sonar.qualityProfiles.allowDisableInheritedRules"
             ]
           }
         },

--- a/src/tasks/migrate/filterProjectSettingsValues/cloud.json
+++ b/src/tasks/migrate/filterProjectSettingsValues/cloud.json
@@ -43,7 +43,19 @@
               "sonar.core.serverBaseURL",
               "sonaranalyzer-vbnet.staticResourceName",
               "sonaranalyzer-cs.nuget.packageVersion",
-              "sonaranalyzer.security.cs.pluginVersion"
+              "sonaranalyzer.security.cs.pluginVersion",
+              "sonar.cs.analyzer.dotnet.pluginVersion",
+              "sonar.cs.analyzer.dotnet.staticResourceName",
+              "sonar.vbnet.analyzer.dotnet.pluginVersion",
+              "sonar.vbnet.analyzer.dotnet.staticResourceName",
+              "sonaranalyzer.security.cs.analyzerId",
+              "sonaranalyzer.security.cs.ruleNamespace",
+              "sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByMonth",
+              "sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByWeek",
+              "sonar.forceAuthentication",
+              "sonar.global.exclusions",
+              "sonar.lf.enableGravatar",
+              "sonar.qualityProfiles.allowDisableInheritedRules"
             ]
           }
         },


### PR DESCRIPTION
## Summary
- Adds 12 SQS-only settings to the migration skip list in both filterProjectSettingsValue and filterProjectSettingsValues filters
- These parameters do not exist on SQC and were causing thousands of useless, failing POST requests (each taking 200-300ms), significantly slowing down large migrations

Fixes #62

## Settings added to skip list
- sonar.cs.analyzer.dotnet.pluginVersion
- sonar.cs.analyzer.dotnet.staticResourceName
- sonar.vbnet.analyzer.dotnet.pluginVersion
- sonar.vbnet.analyzer.dotnet.staticResourceName
- sonaranalyzer.security.cs.analyzerId
- sonaranalyzer.security.cs.ruleNamespace
- sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByMonth
- sonar.dbcleaner.weeksBeforeKeepingOnlyOneSnapshotByWeek
- sonar.forceAuthentication
- sonar.global.exclusions
- sonar.lf.enableGravatar
- sonar.qualityProfiles.allowDisableInheritedRules

## Test plan
- [ ] Run a migration and verify the 12 listed settings are no longer sent to SQC
- [ ] Verify other project settings are still migrated correctly