### PR TITLE
Handle null status codes from SQC during migration

### DIFF
--- a/src/operations/http_request/base.py
+++ b/src/operations/http_request/base.py
@@ -99,13 +99,26 @@ async def async_safe_json_request(client, method, url, log_attributes: dict, rai
         status_code, js = process_errors(
             url=url, exc=exc, method=method, log_attributes=log_attributes
         )
+    except Exception as exc:
+        status_code, js = None, dict()
+        log_event(
+            level='error', status='failure', process_type='request_completed', payload=dict(
+                method=method,
+                url=url,
+                status=None,
+                created_ts=datetime.now(tz=timezone.utc).timestamp(),
+                error=str(exc),
+                **log_attributes,
+            ),
+            logger_name='http_request'
+        )
     return status_code, js
 
 
 def process_response(resp, raise_over):
     status = resp.status_code
     js = format_response_body(response=resp)
-    if status >= raise_over:
+    if status is not None and status >= raise_over:
         resp.raise_for_status()
     return status, js
 
@@ -124,6 +137,8 @@ def process_errors(exc, method, url, log_attributes):
             logger_name='http_request'
         )
     elif isinstance(exc, httpx.HTTPStatusError):
+        js = format_response_body(response=exc.response)
+        status_code = exc.response.status_code
         log_event(
             level='error', status='failure', process_type='request_completed', payload=dict(
                 method=method,
@@ -135,8 +150,6 @@ def process_errors(exc, method, url, log_attributes):
             ),
             logger_name='http_request'
         )
-        js = format_response_body(response=exc.response)
-        status_code = exc.response.status_code
     return status_code, js
 
 


### PR DESCRIPTION
## Summary
- Adds a catch-all exception handler in async_safe_json_request so unexpected errors (e.g. TypeError from a malformed response) return (None, {}) instead of crashing the migration
- Guards the status code comparison in process_response against None to prevent TypeError
- Fixes logging order in process_errors for HTTPStatusError so the log shows the actual status code instead of null

Fixes #61

## Test plan
- [ ] Run a migration against SQC and verify it no longer crashes when a null status code is returned
- [ ] Verify that normal 400/500 errors are still handled and logged correctly
- [ ] Verify that successful requests are unaffected