### PR TITLE
Fix profileAdmin permission spelling to profileadmin

### DIFF
--- a/src/tasks/migrate/addMigrationOrgGroupPermissions/cloud.json
+++ b/src/tasks/migrate/addMigrationOrgGroupPermissions/cloud.json
@@ -14,7 +14,7 @@
       "kwargs": {
         "inputs": {
           "value": {
-            "raw": ["admin", "profileAdmin", "gateadmin", "securityhotspotadmin", "scan", "provisioning"]
+            "raw": ["admin", "profileadmin", "gateadmin", "securityhotspotadmin", "scan", "provisioning"]
           }
         },
         "resultKey": {


### PR DESCRIPTION
## Summary
- Fixed incorrect `profileAdmin` (camelCase) permission to `profileadmin` (all lowercase) in the migration task config for `addMigrationOrgGroupPermissions`
- The SonarQube Cloud `/api/permissions/add_group` API expects lowercase `profileadmin`, causing the permission grant to fail during migration

Fixes #70

## Test plan
- [ ] Run a migration and verify that the `profileadmin` permission is successfully set via `/api/permissions/add_group`

🤖 Generated with [Claude Code](https://claude.com/claude-code)