### PR TITLE
Filter invalid project-level permissions during migration

### DIFF
--- a/src/operations/apply_filter.py
+++ b/src/operations/apply_filter.py
@@ -1,3 +1,6 @@
+from logs import log_event
+
+
 def process_chunk(chunk):
     results = []
     for obj in chunk:
@@ -8,7 +11,7 @@ def process_chunk(chunk):
     return results
 
 
-def execute(left, right, operator, **kwargs):
+def execute(left, right, operator, warn_message=None, **kwargs):
     allowed = True
     if operator == 'neq':
         allowed = left != right
@@ -26,4 +29,7 @@ def execute(left, right, operator, **kwargs):
         allowed = left >= right
     elif operator == 'lte':
         allowed = left <= right
+    if not allowed and warn_message:
+        log_event(level='WARNING', status='anomalous', process_type='apply_filter',
+                  payload=dict(message=f"{warn_message}: '{left}'"))
     return allowed

--- a/src/tasks/migrate/setProjectGroupPermissions/cloud.json
+++ b/src/tasks/migrate/setProjectGroupPermissions/cloud.json
@@ -70,6 +70,31 @@
       }
     },
     {
+      "operation": "apply_filter",
+      "kwargs": {
+        "left": {
+          "value": {
+            "path": "permission"
+          }
+        },
+        "right": {
+          "value": {
+            "raw": ["admin", "codeviewer", "issueadmin", "securityhotspotadmin", "scan", "user"]
+          }
+        },
+        "operator": {
+          "value": {
+            "raw": "in"
+          }
+        },
+        "warn_message": {
+          "value": {
+            "raw": "Skipping invalid project permission"
+          }
+        }
+      }
+    },
+    {
       "operation": "http_request",
       "kwargs": {
         "url": {


### PR DESCRIPTION
## Summary
- Added an `apply_filter` step in `setProjectGroupPermissions` to only allow valid project-level permissions: `admin`, `codeviewer`, `issueadmin`, `securityhotspotadmin`, `scan`, `user`
- Invalid permissions like `applicationcreator` and `portfoliocreator` are now skipped instead of being sent to `/api/permissions/add_group`
- Added optional `warn_message` parameter to `apply_filter` operation to log warnings when permissions are skipped

Fixes #71

## Test plan
- [ ] Run a migration with projects that have `applicationcreator` or `portfoliocreator` permissions and verify they are skipped
- [ ] Verify the skipped permissions appear as warnings in the request log
- [ ] Verify valid project permissions (`admin`, `codeviewer`, `issueadmin`, `securityhotspotadmin`, `scan`, `user`) are still set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)