### PR TITLE
Skip unsupported languages during profile migration

### DIFF
--- a/src/tasks/migrate/createProfiles/cloud.json
+++ b/src/tasks/migrate/createProfiles/cloud.json
@@ -11,6 +11,32 @@
   ],
   "operations": [
     {
+      "operation": "apply_filter",
+      "kwargs": {
+        "left": {
+          "value": {
+            "source": "generateProfileMappings",
+            "path": "language"
+          }
+        },
+        "right": {
+          "value": {
+            "raw": ["c++", "grvy", "ps"]
+          }
+        },
+        "operator": {
+          "value": {
+            "raw": "nin"
+          }
+        },
+        "warn_message": {
+          "value": {
+            "raw": "Skipping unsupported language"
+          }
+        }
+      }
+    },
+    {
       "operation": "http_request",
       "kwargs": {
         "url": {

--- a/src/tasks/migrate/setProjectProfiles/cloud.json
+++ b/src/tasks/migrate/setProjectProfiles/cloud.json
@@ -50,6 +50,31 @@
       }
     },
     {
+      "operation": "apply_filter",
+      "kwargs": {
+        "left": {
+          "value": {
+            "path": "$.profile.language"
+          }
+        },
+        "right": {
+          "value": {
+            "raw": ["c++", "grvy", "ps"]
+          }
+        },
+        "operator": {
+          "value": {
+            "raw": "nin"
+          }
+        },
+        "warn_message": {
+          "value": {
+            "raw": "Skipping unsupported language"
+          }
+        }
+      }
+    },
+    {
       "operation": "http_request",
       "kwargs": {
         "url": {


### PR DESCRIPTION
## Summary
- Filter out profiles for unsupported languages (c++, grvy, ps) that do not exist on SonarQube Cloud
- Added apply_filter in createProfiles task config, which also prevents all downstream profile tasks (restoreProfiles, setDefaultProfiles, setProfileParent, setProfileGroupPermissions) from processing those profiles
- Added apply_filter in setProjectProfiles task config, which sources profiles independently from project data
- Skipped languages are logged as warnings via the warn_message feature

Fixes #73

## Test plan
- [ ] Run a migration with profiles for c++, grvy, or ps languages and verify they are skipped
- [ ] Verify skipped languages appear as warnings in the request log
- [ ] Verify profiles for valid languages are still created and assigned correctly

Generated with [Claude Code](https://claude.com/claude-code)