### PR TITLE
Filter invalid global permissions during migration

### DIFF
--- a/src/tasks/migrate/setOrgGroupPermissions/cloud.json
+++ b/src/tasks/migrate/setOrgGroupPermissions/cloud.json
@@ -74,6 +74,31 @@
       }
     },
     {
+      "operation": "apply_filter",
+      "kwargs": {
+        "left": {
+          "value": {
+            "path": "permission"
+          }
+        },
+        "right": {
+          "value": {
+            "raw": ["admin", "gateadmin", "profileadmin", "provisioning", "scan"]
+          }
+        },
+        "operator": {
+          "value": {
+            "raw": "in"
+          }
+        },
+        "warn_message": {
+          "value": {
+            "raw": "Skipping invalid global permission"
+          }
+        }
+      }
+    },
+    {
       "operation": "http_request",
       "kwargs": {
         "url": {


### PR DESCRIPTION
## Summary
- Added apply_filter in setOrgGroupPermissions to only allow valid global permissions: admin, gateadmin, profileadmin, provisioning, scan
- Invalid permissions like applicationcreator and portfoliocreator are now skipped instead of being sent to /api/permissions/add_group
- Skipped permissions are logged as warnings

Fixes #69

## Test plan
- [ ] Run a migration with groups that have applicationcreator or portfoliocreator global permissions and verify they are skipped
- [ ] Verify the skipped permissions appear as warnings in the request log
- [ ] Verify valid global permissions are still set correctly

Generated with [Claude Code](https://claude.com/claude-code)