### PR TITLE
Use values parameter for multi-valued settings API

### DIFF
--- a/src/tasks/migrate/setProjectSettingValues/cloud.json
+++ b/src/tasks/migrate/setProjectSettingValues/cloud.json
@@ -102,7 +102,7 @@
                   "path": "key"
                 }
               },
-              "value": {
+              "values": {
                 "value": {
                   "source": "filterProjectSettingsValues",
                   "path": "values"


### PR DESCRIPTION
## Summary
- Fixed setProjectSettingValues to use the `values` API parameter instead of `value` when calling `/api/settings/set` for multi-valued settings
- The API requires `values=firstValue&values=secondValue` for multi-valued settings (e.g. file suffixes), but the code was incorrectly sending them as a single `value` parameter

Fixes #72

## Test plan
- [ ] Run a migration with multi-valued project settings (e.g. `sonar.shell.file.suffixes`) and verify they are set correctly on SonarQube Cloud
- [ ] Verify mono-valued settings still work correctly via the separate setProjectSettingValue task

Generated with [Claude Code](https://claude.com/claude-code)