### PR TITLE
Remove Node.js frontend build from release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,13 +67,6 @@ jobs:
             suffix: windows-arm64.exe
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-      - name: Build frontend
-        working-directory: web
-        run: npm install --ignore-scripts --registry=https://registry.npmjs.org/ && npm run build
       - name: Set up Go
         uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Summary
- Remove Node.js setup and Svelte frontend build steps from release job
- The Go binary now embeds templates via `//go:embed` — no frontend build needed

## Test plan
- [ ] Tag triggers release workflow
- [ ] Binary builds succeed without frontend step

🤖 Generated with [Claude Code](https://claude.com/claude-code)