### PR TITLE
Issue #161 Add --version flag and log tool version at startup

### DIFF
--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -1,20 +1,38 @@
 package cmd
 
 import (
+	"log/slog"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/version"
 	"github.com/spf13/cobra"
 )
 
+const helpTemplate = `{{.Root.Name}} version {{.Root.Version}}
+
+{{with (or .Long .Short)}}{{. | trimTrailingWhitespaces}}
+
+{{end}}{{if or .Runnable .HasSubCommands}}{{.UsageString}}{{end}}`
+
+const versionTemplate = `{{.Root.Name}} version {{.Root.Version}}
+`
+
 var rootCmd = &cobra.Command{
-	Use:   "sonar-migration-tool",
-	Short: "Migrate SonarQube Server instances to SonarQube Cloud",
+	Use:     version.ToolName,
+	Version: version.Version,
+	Short:   "Migrate SonarQube Server instances to SonarQube Cloud",
 	Long: `CLI tool for migrating SonarQube Server instances to SonarQube Cloud.
 Extracts configuration from a Server instance, transforms it, and applies
 it to a Cloud organization. Also updates CI/CD pipelines post-migration.`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		logStartupVersion()
+	},
 }
 
 func init() {
+	rootCmd.SetVersionTemplate(versionTemplate)
+	rootCmd.SetHelpTemplate(helpTemplate)
 	addCommands()
 }
 
@@ -30,6 +48,10 @@ func addCommands() {
 		resetCmd,
 		analysisReportCmd,
 	)
+}
+
+func logStartupVersion() {
+	slog.Default().Info(version.ToolName+" starting", "version", version.Version)
 }
 
 // Execute runs the root command.

--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+const Version = "0.1.0"
+
+const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary
- New `internal/version` package holds `Version` (`0.1.0`) and `ToolName` constants
- Wire cobra `rootCmd.Version` so `sonar-migration-tool --version` prints the tool version
- Custom help template shows `sonar-migration-tool version 0.1.0` at the top of `--help`/`-h` output (including for subcommands)
- `PersistentPreRun` logs the version at INFO via `slog.Default()` when any subcommand runs — covers CLI and GUI mode

Fixes #161.

## Test plan
- [x] `sonar-migration-tool --version` prints `sonar-migration-tool version 0.1.0`
- [x] `sonar-migration-tool --help` shows version on the first line
- [x] `sonar-migration-tool <subcommand> --help` shows version on the first line
- [x] Running a subcommand emits `INFO sonar-migration-tool starting version=0.1.0` before any other log output
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)