### PR TITLE
Issue #162 Improve migration summary report

### DIFF
--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -31,7 +31,7 @@ organization keys to organizations.csv.`,
 			return err
 		}
 		runDir := filepath.Join(cfg.ExportDirectory, runID)
-		if pdfPath, pdfErr := summary.GeneratePDFReport(runDir, cfg.ExportDirectory); pdfErr == nil {
+		if pdfPath, pdfErr := summary.GeneratePDFReport(runDir, cfg.ExportDirectory, cfg.ExportDirectory); pdfErr == nil {
 			fmt.Printf("PDF summary report: %s\n", pdfPath)
 		}
 		return nil

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -2,26 +2,40 @@ package summary
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/analysis"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
 // CollectSummary reads task JSONL outputs and the analysis report to build
-// a MigrationSummary for PDF rendering.
-func CollectSummary(runDir string) (*MigrationSummary, error) {
+// a MigrationSummary for PDF rendering. exportDir is the root export directory
+// containing extract runs and the run directory; if empty it defaults to the
+// parent of runDir.
+func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
+	if exportDir == "" {
+		exportDir = filepath.Dir(runDir)
+	}
+
 	store := common.NewDataStore(runDir)
 	failuresByType, err := collectFailures(runDir)
 	if err != nil {
 		return nil, err
 	}
 
+	configFailures, err := collectConfigFailures(runDir)
+	if err != nil {
+		return nil, err
+	}
+
 	scanHistoryMap := collectScanHistory(store)
+	extractMapping, _ := structure.GetUniqueExtracts(exportDir)
 
 	var sections []Section
 	for _, def := range sectionDefs {
-		section := collectSection(store, def, failuresByType)
+		section := collectSection(store, def, failuresByType, configFailures, exportDir, extractMapping)
 		if def.Name == "Projects" {
 			attachScanHistory(section.Succeeded, scanHistoryMap)
 		}
@@ -51,15 +65,26 @@ func collectFailures(runDir string) (map[string][]analysis.ReportRow, error) {
 	return result, nil
 }
 
-// collectSection builds a Section from task JSONL data and analysis failures.
-func collectSection(store *common.DataStore, def sectionDef, failuresByType map[string][]analysis.ReportRow) Section {
+// collectSection builds a Section from task JSONL data, analysis failures and extract data.
+func collectSection(store *common.DataStore, def sectionDef,
+	failuresByType map[string][]analysis.ReportRow,
+	configFailures []configFailure,
+	exportDir string, extractMapping structure.ExtractMapping) Section {
+
 	succeeded := collectSucceeded(store, def)
 	skipped := collectSkipped(store, def)
 	failed := collectFailed(failuresByType, def)
+	partial := collectPartial(def, configFailures, succeeded)
+
+	// Augment skipped with built-in / unused items derived from extract data.
+	if def.ExtractTask != "" && extractMapping != nil {
+		skipped = append(skipped, collectExtractSkipped(def, exportDir, extractMapping, store)...)
+	}
 
 	return Section{
 		Name:      def.Name,
 		Succeeded: succeeded,
+		Partial:   partial,
 		Failed:    failed,
 		Skipped:   skipped,
 	}
@@ -75,6 +100,7 @@ func collectSucceeded(store *common.DataStore, def sectionDef) []EntityItem {
 	for _, item := range items {
 		result = append(result, EntityItem{
 			Name:         jsonStr(item, def.NameField),
+			Language:     jsonStr(item, "language"),
 			Organization: jsonStr(item, "sonarcloud_org_key"),
 			Detail:       jsonStr(item, def.DetailField),
 		})
@@ -95,12 +121,99 @@ func collectSkipped(store *common.DataStore, def sectionDef) []EntityItem {
 		if orgKey == "" || orgKey == skippedOrgSentinel {
 			result = append(result, EntityItem{
 				Name:         jsonStr(item, def.NameField),
+				Language:     jsonStr(item, "language"),
 				Organization: jsonStr(item, "sonarqube_org_key"),
 				Detail:       "Organization skipped",
+				SkipReason:   SkipReasonOrgSkipped,
 			})
 		}
 	}
 	return result
+}
+
+// collectExtractSkipped derives skipped entries directly from extract data
+// for sections that have a source extract task (Quality Gates, Quality Profiles).
+// It marks isBuiltIn items as "built-in" and items that are not referenced in
+// the generated mappings as "unused".
+func collectExtractSkipped(def sectionDef, exportDir string,
+	mapping structure.ExtractMapping, store *common.DataStore) []EntityItem {
+
+	items, err := structure.ReadExtractData(exportDir, mapping, def.ExtractTask)
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+
+	mappedKeys := buildMappedKeys(def, store)
+
+	var result []EntityItem
+	seen := make(map[string]bool)
+	for _, item := range items {
+		name := common.ExtractField(item.Data, "name")
+		if name == "" {
+			continue
+		}
+		language := common.ExtractField(item.Data, "language")
+		isBuiltIn := common.ExtractBool(item.Data, "isBuiltIn")
+		key := extractKeyFor(def, name, language, item.ServerURL)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		if isBuiltIn {
+			result = append(result, EntityItem{
+				Name:       name,
+				Language:   language,
+				Detail:     "Built-in, not migrated",
+				SkipReason: SkipReasonBuiltIn,
+			})
+			continue
+		}
+		mapKey := mappedKeyFor(def, name, language)
+		if mappedKeys[mapKey] {
+			continue
+		}
+		result = append(result, EntityItem{
+			Name:       name,
+			Language:   language,
+			Detail:     "Not used by any migrated project",
+			SkipReason: SkipReasonUnused,
+		})
+	}
+	return result
+}
+
+// buildMappedKeys returns the set of (name[+language]) keys present in the
+// generate*Mappings task output. Used to detect unused extract items.
+func buildMappedKeys(def sectionDef, store *common.DataStore) map[string]bool {
+	items, err := store.ReadAll(def.InputTask)
+	if err != nil {
+		return nil
+	}
+	set := make(map[string]bool, len(items))
+	for _, item := range items {
+		name := jsonStr(item, def.NameField)
+		if name == "" {
+			continue
+		}
+		language := jsonStr(item, "language")
+		set[mappedKeyFor(def, name, language)] = true
+	}
+	return set
+}
+
+func mappedKeyFor(def sectionDef, name, language string) string {
+	if def.Name == "Quality Profiles" {
+		return name + "|" + language
+	}
+	return name
+}
+
+func extractKeyFor(def sectionDef, name, language, serverURL string) string {
+	if def.Name == "Quality Profiles" {
+		return serverURL + "|" + name + "|" + language
+	}
+	return serverURL + "|" + name
 }
 
 // collectFailed maps analysis report failure rows to EntityItems.

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 func TestCollectSummaryEmpty(t *testing.T) {
 	dir := t.TempDir()
-	summary, err := CollectSummary(dir)
+	summary, err := CollectSummary(dir, "")
 	if err != nil {
 		t.Fatalf("CollectSummary: %v", err)
 	}
@@ -42,7 +43,7 @@ func TestCollectSummaryWithData(t *testing.T) {
 		{"name": "Custom Gate", "sonarcloud_org_key": "org1", "cloud_gate_id": "gate-1"},
 	})
 
-	summary, err := CollectSummary(dir)
+	summary, err := CollectSummary(dir, "")
 	if err != nil {
 		t.Fatalf("CollectSummary: %v", err)
 	}
@@ -85,7 +86,7 @@ func TestCollectSummaryWithScanHistory(t *testing.T) {
 		{"cloud_project_key": "org1_proj2", "status": "failed", "branch": "main", "error": "CE failed"},
 	})
 
-	summary, err := CollectSummary(dir)
+	summary, err := CollectSummary(dir, "")
 	if err != nil {
 		t.Fatalf("CollectSummary: %v", err)
 	}
@@ -131,7 +132,7 @@ func TestCollectSummaryWithFailures(t *testing.T) {
 	logBytes, _ := json.Marshal(logEntry)
 	os.WriteFile(filepath.Join(dir, "requests.log"), logBytes, 0o644)
 
-	summary, err := CollectSummary(dir)
+	summary, err := CollectSummary(dir, "")
 	if err != nil {
 		t.Fatalf("CollectSummary: %v", err)
 	}
@@ -189,6 +190,199 @@ func TestScanStatusLabel(t *testing.T) {
 	}
 }
 
+func TestCollectSummaryGateBuiltInAndUnused(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	// Extract data: 3 gates — 1 built-in, 1 used, 1 unused.
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	writeTaskJSONL(t, extractDir, "getGates", []map[string]any{
+		{"name": "Sonar way", "isBuiltIn": true},
+		{"name": "Used Gate", "isBuiltIn": false},
+		{"name": "Unused Gate", "isBuiltIn": false},
+	})
+
+	// Mapping says only "Used Gate" is migrated.
+	writeTaskJSONL(t, runDir, "generateGateMappings", []map[string]any{
+		{"name": "Used Gate", "sonarcloud_org_key": "org1"},
+	})
+	writeTaskJSONL(t, runDir, "createGates", []map[string]any{
+		{"name": "Used Gate", "sonarcloud_org_key": "org1", "cloud_gate_id": "42"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	gates := findSection(summary, "Quality Gates")
+	if gates == nil {
+		t.Fatal("missing Quality Gates section")
+	}
+	if len(gates.Succeeded) != 1 || gates.Succeeded[0].Name != "Used Gate" {
+		t.Errorf("expected 1 succeeded gate (Used Gate), got %+v", gates.Succeeded)
+	}
+
+	counts := map[string]int{}
+	for _, item := range gates.Skipped {
+		counts[item.SkipReason]++
+	}
+	if counts[SkipReasonBuiltIn] != 1 {
+		t.Errorf("expected 1 built-in skipped, got %d", counts[SkipReasonBuiltIn])
+	}
+	if counts[SkipReasonUnused] != 1 {
+		t.Errorf("expected 1 unused skipped, got %d", counts[SkipReasonUnused])
+	}
+}
+
+func TestCollectSummaryProfileBuiltInAndUnused(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	writeTaskJSONL(t, extractDir, "getProfiles", []map[string]any{
+		{"name": "Sonar way", "language": "java", "isBuiltIn": true},
+		{"name": "Custom", "language": "java", "isBuiltIn": false},
+		{"name": "Unused", "language": "java", "isBuiltIn": false},
+		// Same name on different language — independent.
+		{"name": "Custom", "language": "js", "isBuiltIn": false},
+	})
+
+	writeTaskJSONL(t, runDir, "generateProfileMappings", []map[string]any{
+		{"name": "Custom", "language": "java", "sonarcloud_org_key": "org1"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	profiles := findSection(summary, "Quality Profiles")
+	if profiles == nil {
+		t.Fatal("missing Quality Profiles section")
+	}
+	counts := map[string]int{}
+	for _, item := range profiles.Skipped {
+		counts[item.SkipReason]++
+	}
+	if counts[SkipReasonBuiltIn] != 1 {
+		t.Errorf("expected 1 built-in profile skipped, got %d (skipped: %+v)", counts[SkipReasonBuiltIn], profiles.Skipped)
+	}
+	// Custom/js and Unused/java are both unused.
+	if counts[SkipReasonUnused] != 2 {
+		t.Errorf("expected 2 unused profiles skipped, got %d", counts[SkipReasonUnused])
+	}
+}
+
+func TestCollectSummaryPartialGateCondition(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	// A gate was created successfully.
+	writeTaskJSONL(t, runDir, "createGates", []map[string]any{
+		{"name": "My Gate", "sonarcloud_org_key": "org1", "cloud_gate_id": "42"},
+	})
+
+	// A condition failed for that gate.
+	logEntry := map[string]any{
+		"process_type": "request_completed",
+		"status":       "failure",
+		"payload": map[string]any{
+			"method": "POST",
+			"url":    "/api/qualitygates/create_condition",
+			"status": float64(400),
+			"data": map[string]any{
+				"gateId":       "42",
+				"organization": "org1",
+				"metric":       "unknown_metric",
+				"op":           "GT",
+				"error":        "10",
+			},
+			"response": `{"errors":[{"msg":"metric does not exist"}]}`,
+		},
+	}
+	logBytes, _ := json.Marshal(logEntry)
+	os.WriteFile(filepath.Join(runDir, "requests.log"), logBytes, 0o644)
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	gates := findSection(summary, "Quality Gates")
+	if len(gates.Partial) != 1 {
+		t.Fatalf("expected 1 partial gate entry, got %d", len(gates.Partial))
+	}
+	item := gates.Partial[0]
+	if len(item.Issues) == 0 {
+		t.Fatal("expected at least one issue")
+	}
+	if !strings.Contains(item.Issues[0], "unknown_metric") {
+		t.Errorf("expected metric in issue, got %q", item.Issues[0])
+	}
+	if !strings.Contains(item.Issues[0], "metric does not exist") {
+		t.Errorf("expected error message in issue, got %q", item.Issues[0])
+	}
+}
+
+func TestCollectSummaryPartialProfileChangeParent(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	writeTaskJSONL(t, runDir, "createProfiles", []map[string]any{
+		{"name": "Child", "language": "java", "sonarcloud_org_key": "org1", "cloud_profile_key": "p1"},
+	})
+
+	logEntry := map[string]any{
+		"process_type": "request_completed",
+		"status":       "failure",
+		"payload": map[string]any{
+			"method": "POST",
+			"url":    "/api/qualityprofiles/change_parent",
+			"status": float64(400),
+			"data": map[string]any{
+				"language":             "java",
+				"qualityProfile":       "Child",
+				"parentQualityProfile": "Parent",
+				"organization":         "org1",
+			},
+			"response": `{"errors":[{"msg":"parent not found"}]}`,
+		},
+	}
+	logBytes, _ := json.Marshal(logEntry)
+	os.WriteFile(filepath.Join(runDir, "requests.log"), logBytes, 0o644)
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	profiles := findSection(summary, "Quality Profiles")
+	if len(profiles.Partial) != 1 {
+		t.Fatalf("expected 1 partial profile entry, got %d", len(profiles.Partial))
+	}
+	item := profiles.Partial[0]
+	if item.Name != "Child" {
+		t.Errorf("expected profile name 'Child', got %q", item.Name)
+	}
+	if item.Detail != "p1" {
+		t.Errorf("expected cloud_profile_key 'p1' to be carried over, got %q", item.Detail)
+	}
+	if len(item.Issues) == 0 || !strings.Contains(item.Issues[0], "Set parent profile") {
+		t.Errorf("expected 'Set parent profile' in issue, got %v", item.Issues)
+	}
+}
+
 // --- helpers ---
 
 func findSection(s *MigrationSummary, name string) *Section {
@@ -198,6 +392,17 @@ func findSection(s *MigrationSummary, name string) *Section {
 		}
 	}
 	return nil
+}
+
+func writeExtractMeta(t *testing.T, extractDir, url string) {
+	t.Helper()
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	b, _ := json.Marshal(map[string]any{"url": url})
+	if err := os.WriteFile(filepath.Join(extractDir, "extract.json"), b, 0o644); err != nil {
+		t.Fatalf("write extract.json: %v", err)
+	}
 }
 
 func writeTaskJSONL(t *testing.T, dir, taskName string, items []map[string]any) {

--- a/go/internal/report/summary/generate.go
+++ b/go/internal/report/summary/generate.go
@@ -7,13 +7,18 @@ import (
 )
 
 // GeneratePDFReport collects migration data from runDir and writes a PDF
-// summary report to outputDir. Returns the path to the generated PDF.
-func GeneratePDFReport(runDir, outputDir string) (string, error) {
+// summary report to outputDir. exportDir is the root export directory used
+// to locate extract data; pass "" to default to filepath.Dir(runDir).
+// Returns the path to the generated PDF.
+func GeneratePDFReport(runDir, outputDir, exportDir string) (string, error) {
 	if outputDir == "" {
 		outputDir = filepath.Dir(runDir)
 	}
+	if exportDir == "" {
+		exportDir = filepath.Dir(runDir)
+	}
 
-	summary, err := CollectSummary(runDir)
+	summary, err := CollectSummary(runDir, exportDir)
 	if err != nil {
 		return "", fmt.Errorf("collecting summary: %w", err)
 	}

--- a/go/internal/report/summary/partial.go
+++ b/go/internal/report/summary/partial.go
@@ -1,0 +1,308 @@
+package summary
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// configFailure describes a failed request against a configuration endpoint
+// (e.g. adding a gate condition, restoring a profile backup, setting a parent).
+// These represent partial migrations: the parent entity exists on SQC, but a
+// follow-up configuration step did not complete successfully.
+type configFailure struct {
+	Section      string // "Quality Gates" or "Quality Profiles"
+	Operation    string // human-readable label for the failed operation
+	EntityName   string // gate/profile name (best-effort, may be empty)
+	Organization string
+	Language     string // profile language, when applicable
+	Detail       string // extra context (e.g., metric for conditions)
+	Error        string
+}
+
+// configFailureMatcher maps an endpoint suffix to section + operation label.
+type configFailureMatcher struct {
+	URLSuffix string
+	Section   string
+	Operation string
+}
+
+var configFailureMatchers = []configFailureMatcher{
+	{URLSuffix: "/api/qualitygates/create_condition", Section: "Quality Gates", Operation: "Add condition"},
+	{URLSuffix: "/api/qualitygates/set_as_default", Section: "Quality Gates", Operation: "Set as default"},
+	{URLSuffix: "/api/qualitygates/select", Section: "Quality Gates", Operation: "Assign to project"},
+	{URLSuffix: "/api/qualityprofiles/restore", Section: "Quality Profiles", Operation: "Restore rules from backup"},
+	{URLSuffix: "/api/qualityprofiles/change_parent", Section: "Quality Profiles", Operation: "Set parent profile"},
+	{URLSuffix: "/api/qualityprofiles/set_default", Section: "Quality Profiles", Operation: "Set as default"},
+	{URLSuffix: "/api/qualityprofiles/add_project", Section: "Quality Profiles", Operation: "Assign to project"},
+	{URLSuffix: "/api/qualityprofiles/add_group", Section: "Quality Profiles", Operation: "Grant group permission"},
+}
+
+// collectConfigFailures re-parses requests.log and returns failures from
+// configuration endpoints (i.e. follow-up steps after the initial create).
+// These describe partial migrations of Quality Gates / Quality Profiles.
+func collectConfigFailures(runDir string) ([]configFailure, error) {
+	logPath := filepath.Join(runDir, "requests.log")
+	f, err := os.Open(logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	var failures []configFailure
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+
+	for scanner.Scan() {
+		entry, ok := parseConfigLogLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if cf, ok := classifyConfigFailure(entry); ok {
+			failures = append(failures, cf)
+		}
+	}
+	return failures, scanner.Err()
+}
+
+func parseConfigLogLine(line string) (map[string]any, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil, false
+	}
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(line), &entry); err != nil {
+		return nil, false
+	}
+	return entry, true
+}
+
+// classifyConfigFailure returns a configFailure if the log entry represents
+// a failed POST to a known configuration endpoint.
+func classifyConfigFailure(entry map[string]any) (configFailure, bool) {
+	if asString(entry["process_type"]) != "request_completed" {
+		return configFailure{}, false
+	}
+	payload, ok := entry["payload"].(map[string]any)
+	if !ok {
+		return configFailure{}, false
+	}
+	if asString(payload["method"]) != "POST" {
+		return configFailure{}, false
+	}
+
+	url := asString(payload["url"])
+	matcher, ok := matchConfigEndpoint(url)
+	if !ok {
+		return configFailure{}, false
+	}
+
+	status := payload["status"]
+	logStatus := asString(entry["status"])
+	if !isFailure(status, logStatus) {
+		return configFailure{}, false
+	}
+
+	body := configRequestBody(payload)
+	cf := configFailure{
+		Section:      matcher.Section,
+		Operation:    matcher.Operation,
+		Organization: asString(body["organization"]),
+		Language:     asString(body["language"]),
+		Error:        extractFailureError(payload),
+	}
+	cf.EntityName, cf.Detail = entityNameAndDetail(matcher, body)
+	return cf, true
+}
+
+func matchConfigEndpoint(url string) (configFailureMatcher, bool) {
+	for _, m := range configFailureMatchers {
+		if strings.HasSuffix(url, m.URLSuffix) || url == m.URLSuffix {
+			return m, true
+		}
+	}
+	return configFailureMatcher{}, false
+}
+
+// entityNameAndDetail returns (entity name, extra detail) extracted from the
+// request body based on the endpoint family.
+func entityNameAndDetail(m configFailureMatcher, body map[string]any) (string, string) {
+	switch {
+	case strings.HasSuffix(m.URLSuffix, "/create_condition"):
+		// Body contains gateId and metric; we cannot resolve gateId -> name
+		// without a join, so prefer leaving the entity name empty and put
+		// the metric into the detail column.
+		metric := asString(body["metric"])
+		op := asString(body["op"])
+		errVal := asString(body["error"])
+		detail := metric
+		if op != "" {
+			detail = fmt.Sprintf("%s %s %s", metric, op, errVal)
+		}
+		return "", strings.TrimSpace(detail)
+	case strings.HasSuffix(m.URLSuffix, "/qualitygates/set_as_default"),
+		strings.HasSuffix(m.URLSuffix, "/qualitygates/select"):
+		return asString(body["gateName"]), ""
+	case strings.HasSuffix(m.URLSuffix, "/qualityprofiles/restore"):
+		// Body has backup XML only; name is inside the XML.
+		return "", ""
+	case strings.HasSuffix(m.URLSuffix, "/qualityprofiles/change_parent"),
+		strings.HasSuffix(m.URLSuffix, "/qualityprofiles/set_default"),
+		strings.HasSuffix(m.URLSuffix, "/qualityprofiles/add_project"),
+		strings.HasSuffix(m.URLSuffix, "/qualityprofiles/add_group"):
+		return asString(body["qualityProfile"]), ""
+	}
+	return "", ""
+}
+
+// configRequestBody extracts the request body map from a payload, supporting
+// the same shapes as analysis.getRequestBody (data/json/params).
+func configRequestBody(payload map[string]any) map[string]any {
+	for _, key := range []string{"data", "json", "params"} {
+		if v, ok := payload[key]; ok && v != nil {
+			if m, ok := v.(map[string]any); ok {
+				return m
+			}
+			if s, ok := v.(string); ok {
+				var m map[string]any
+				if json.Unmarshal([]byte(s), &m) == nil {
+					return m
+				}
+			}
+		}
+	}
+	return map[string]any{}
+}
+
+func isFailure(status any, logStatus string) bool {
+	if n, ok := numericStatus(status); ok {
+		return n >= 400
+	}
+	return logStatus == "failure"
+}
+
+func numericStatus(v any) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+func extractFailureError(payload map[string]any) string {
+	val := payload["response"]
+	if val == nil {
+		val = payload["content"]
+	}
+	if val == nil {
+		return ""
+	}
+	switch v := val.(type) {
+	case map[string]any:
+		return joinErrorMessages(v)
+	case string:
+		if v == "" {
+			return ""
+		}
+		var parsed map[string]any
+		if json.Unmarshal([]byte(v), &parsed) == nil {
+			if msg := joinErrorMessages(parsed); msg != "" {
+				return msg
+			}
+		}
+		return v
+	}
+	return ""
+}
+
+func joinErrorMessages(obj map[string]any) string {
+	errs, ok := obj["errors"].([]any)
+	if !ok {
+		return ""
+	}
+	var msgs []string
+	for _, e := range errs {
+		if m, ok := e.(map[string]any); ok {
+			if s := asString(m["msg"]); s != "" {
+				msgs = append(msgs, s)
+			}
+		}
+	}
+	return strings.Join(msgs, "; ")
+}
+
+func asString(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+// collectPartial returns partial migration entries for a section. A partial
+// entry surfaces a follow-up configuration failure that prevented the entity
+// from being migrated 100% identically to the source.
+//
+// When a config failure cannot be attributed to a specific successful entity,
+// it is still reported (with an empty name) so that the issue is visible.
+func collectPartial(def sectionDef, failures []configFailure, succeeded []EntityItem) []EntityItem {
+	if len(failures) == 0 {
+		return nil
+	}
+	succeededByName := make(map[string]int)
+	for i, item := range succeeded {
+		if item.Name != "" {
+			succeededByName[item.Name] = i
+		}
+	}
+
+	var partial []EntityItem
+	merged := make(map[string]int) // partial index by entity name
+	for _, cf := range failures {
+		if cf.Section != def.Name {
+			continue
+		}
+		issue := cf.Operation
+		if cf.Detail != "" {
+			issue = cf.Operation + ": " + cf.Detail
+		}
+		if cf.Error != "" {
+			issue = issue + " — " + cf.Error
+		}
+
+		if cf.EntityName != "" {
+			if idx, ok := merged[cf.EntityName]; ok {
+				partial[idx].Issues = append(partial[idx].Issues, issue)
+				continue
+			}
+			item := EntityItem{
+				Name:         cf.EntityName,
+				Language:     cf.Language,
+				Organization: cf.Organization,
+				Issues:       []string{issue},
+			}
+			// Carry over detail (cloud_id) from the matching success entry, if any.
+			if sIdx, ok := succeededByName[cf.EntityName]; ok {
+				item.Detail = succeeded[sIdx].Detail
+			}
+			merged[cf.EntityName] = len(partial)
+			partial = append(partial, item)
+			continue
+		}
+		// Unattributed failure — append as its own row.
+		partial = append(partial, EntityItem{
+			Language:     cf.Language,
+			Organization: cf.Organization,
+			ErrorMessage: cf.Error,
+			Issues:       []string{issue},
+		})
+	}
+	return partial
+}

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -3,21 +3,51 @@ package summary
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/go-pdf/fpdf"
 )
+
+// sectionsSortedByName lists section names whose unified table should be
+// sorted alphabetically by the Name column rather than grouped by outcome.
+var sectionsSortedByName = map[string]bool{
+	"Quality Gates": true,
+	"Groups":        true,
+	"Portfolios":    true,
+	"Projects":      true,
+}
 
 // Color constants for the PDF report.
 var (
 	colorDarkBlue  = [3]int{26, 60, 110}
 	colorMedBlue   = [3]int{45, 95, 154}
 	colorLightGray = [3]int{245, 245, 245}
-	colorFailedBg  = [3]int{255, 235, 235}
 	colorWhite     = [3]int{255, 255, 255}
 	colorBlack     = [3]int{0, 0, 0}
 	colorGreen     = [3]int{34, 139, 34}
 	colorRed       = [3]int{200, 0, 0}
+	colorAmber     = [3]int{200, 110, 0}
+	colorDarkGray  = [3]int{90, 90, 90}
+)
+
+// Skip reason display order and labels.
+var skipReasonOrder = []struct {
+	Reason string
+	Label  string
+}{
+	{SkipReasonOrgSkipped, "Organization skipped"},
+	{SkipReasonBuiltIn, "Built-in"},
+	{SkipReasonUnused, "Unused"},
+	{"", "Other"},
+}
+
+// Outcome labels used in the unified per-section table.
+const (
+	outcomeSuccess = "Success"
+	outcomePartial = "Partial"
+	outcomeFailed  = "Failed"
+	outcomeSkipped = "Skipped"
 )
 
 // RenderPDF builds a PDF document from the migration summary and returns the bytes.
@@ -79,8 +109,8 @@ func renderTitlePage(pdf *fpdf.Fpdf, summary *MigrationSummary) {
 }
 
 func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
-	headers := []string{"Section", "Succeeded", "Failed", "Skipped", "Total"}
-	widths := []float64{55, 30, 30, 30, 30}
+	headers := []string{"Section", "Succeeded", "Partial", "Failed", "Skipped", "Total"}
+	widths := []float64{50, 25, 25, 25, 25, 25}
 
 	setFillColor(pdf, colorDarkBlue)
 	pdf.SetTextColor(255, 255, 255)
@@ -95,10 +125,11 @@ func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
 	pdf.Ln(-1)
 
 	pdf.SetFont("Helvetica", "", 10)
-	var totalS, totalF, totalSk int
+	var totalS, totalP, totalF, totalSk int
 	for i, sec := range sections {
-		s, f, sk := len(sec.Succeeded), len(sec.Failed), len(sec.Skipped)
+		s, p, f, sk := len(sec.Succeeded), len(sec.Partial), len(sec.Failed), len(sec.Skipped)
 		totalS += s
+		totalP += p
 		totalF += f
 		totalSk += sk
 
@@ -110,10 +141,11 @@ func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
 		setColor(pdf, colorBlack)
 		pdf.CellFormat(widths[0], 7, sec.Name, "1", 0, "L", true, 0, "")
 		renderCountCell(pdf, widths[1], s, colorGreen)
-		renderCountCell(pdf, widths[2], f, colorRed)
+		renderCountCell(pdf, widths[2], p, colorAmber)
+		renderCountCell(pdf, widths[3], f, colorRed)
+		renderCountCell(pdf, widths[4], sk, colorDarkGray)
 		setColor(pdf, colorBlack)
-		pdf.CellFormat(widths[3], 7, itoa(sk), "1", 0, "C", true, 0, "")
-		pdf.CellFormat(widths[4], 7, itoa(s+f+sk), "1", 0, "C", true, 0, "")
+		pdf.CellFormat(widths[5], 7, itoa(s+p+f+sk), "1", 0, "C", true, 0, "")
 		pdf.Ln(-1)
 	}
 
@@ -123,9 +155,10 @@ func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
 	pdf.SetFont("Helvetica", "B", 10)
 	pdf.CellFormat(widths[0], 8, "Total", "1", 0, "L", true, 0, "")
 	pdf.CellFormat(widths[1], 8, itoa(totalS), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[2], 8, itoa(totalF), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[3], 8, itoa(totalSk), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[4], 8, itoa(totalS+totalF+totalSk), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[2], 8, itoa(totalP), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[3], 8, itoa(totalF), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[4], 8, itoa(totalSk), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[5], 8, itoa(totalS+totalP+totalF+totalSk), "1", 0, "C", true, 0, "")
 	pdf.Ln(-1)
 }
 
@@ -139,7 +172,8 @@ func renderCountCell(pdf *fpdf.Fpdf, w float64, count int, color [3]int) {
 }
 
 func renderSection(pdf *fpdf.Fpdf, section Section) {
-	if len(section.Succeeded) == 0 && len(section.Failed) == 0 && len(section.Skipped) == 0 {
+	total := len(section.Succeeded) + len(section.Partial) + len(section.Failed) + len(section.Skipped)
+	if total == 0 {
 		return
 	}
 
@@ -152,58 +186,211 @@ func renderSection(pdf *fpdf.Fpdf, section Section) {
 
 	setColor(pdf, colorBlack)
 	pdf.SetFont("Helvetica", "", 9)
-	counts := fmt.Sprintf("%d succeeded, %d failed, %d skipped",
-		len(section.Succeeded), len(section.Failed), len(section.Skipped))
-	pdf.CellFormat(0, 6, counts, "", 1, "L", false, 0, "")
+	pdf.CellFormat(0, 6, sectionCountSummary(section), "", 1, "L", false, 0, "")
 	pdf.Ln(2)
 
-	if len(section.Succeeded) > 0 {
-		renderSubsection(pdf, "Succeeded", section.Succeeded, false)
-	}
-	if len(section.Failed) > 0 {
-		renderSubsection(pdf, "Failed", section.Failed, true)
-	}
-	if len(section.Skipped) > 0 {
-		renderSubsection(pdf, "Skipped", section.Skipped, false)
-	}
+	renderUnifiedTable(pdf, section)
 }
 
-func renderSubsection(pdf *fpdf.Fpdf, label string, items []EntityItem, isFailed bool) {
-	checkPageBreak(pdf, 20)
+// unifiedRow is one row in the per-section unified table.
+type unifiedRow struct {
+	name     string
+	language string // populated for Quality Profiles
+	org      string
+	outcome  string
+	color    [3]int
+	details  string
+}
 
-	pdf.SetFont("Helvetica", "B", 9)
-	setColor(pdf, colorBlack)
-	pdf.CellFormat(0, 6, label, "", 1, "L", false, 0, "")
+// displayName returns the row's name as displayed in the Name column.
+// For Quality Profiles rows (language != ""), it prefixes the language.
+func (r unifiedRow) displayName() string {
+	if r.language != "" {
+		return r.language + " / " + r.name
+	}
+	return r.name
+}
 
-	headers, widths := subsectionColumns(isFailed, items)
+// renderUnifiedTable renders the 4-column per-section table:
+//   Name | Organization | Outcome (colored) | Details
+func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
+	headers := []string{"Name", "Organization", "Outcome", "Details"}
+	widths := []float64{55, 35, 25, 81}
+
 	renderTableHeader(pdf, headers, widths)
 
+	rows := buildUnifiedRows(section)
+	if section.Name == "Quality Profiles" {
+		sort.SliceStable(rows, func(i, j int) bool {
+			li, lj := strings.ToLower(rows[i].language), strings.ToLower(rows[j].language)
+			if li != lj {
+				return li < lj
+			}
+			return strings.ToLower(rows[i].name) < strings.ToLower(rows[j].name)
+		})
+	} else if sectionsSortedByName[section.Name] {
+		sort.SliceStable(rows, func(i, j int) bool {
+			return strings.ToLower(rows[i].name) < strings.ToLower(rows[j].name)
+		})
+	}
+
 	pdf.SetFont("Helvetica", "", 8)
-	for i, item := range items {
+	for i, row := range rows {
 		checkPageBreak(pdf, 7)
-		renderItemRow(pdf, item, widths, isFailed, i%2 == 0)
+		if i%2 == 0 {
+			setFillColor(pdf, colorLightGray)
+		} else {
+			setFillColor(pdf, colorWhite)
+		}
+		// Name + Organization in black on alternating background.
+		setColor(pdf, colorBlack)
+		pdf.CellFormat(widths[0], 6, truncate(row.displayName(), 36), "1", 0, "L", true, 0, "")
+		pdf.CellFormat(widths[1], 6, truncate(row.org, 24), "1", 0, "L", true, 0, "")
+		// Outcome cell in its color, bold.
+		setColor(pdf, row.color)
+		pdf.SetFont("Helvetica", "B", 8)
+		pdf.CellFormat(widths[2], 6, row.outcome, "1", 0, "C", true, 0, "")
+		// Details in black, regular.
+		setColor(pdf, colorBlack)
+		pdf.SetFont("Helvetica", "", 8)
+		pdf.CellFormat(widths[3], 6, truncate(row.details, 56), "1", 0, "L", true, 0, "")
+		pdf.Ln(-1)
 	}
 }
 
-func subsectionColumns(isFailed bool, items []EntityItem) ([]string, []float64) {
-	if isFailed {
-		return []string{"Name", "Organization", "Error"},
-			[]float64{50, 40, 106}
+// buildUnifiedRows flattens the section's four buckets into ordered rows:
+// Succeeded → Partial → Failed → Skipped (skipped grouped by reason order).
+func buildUnifiedRows(section Section) []unifiedRow {
+	var rows []unifiedRow
+
+	for _, item := range section.Succeeded {
+		rows = append(rows, unifiedRow{
+			name:     item.Name,
+			language: item.Language,
+			org:      item.Organization,
+			outcome:  outcomeSuccess,
+			color:    colorGreen,
+			details:  successDetails(item),
+		})
 	}
-	// Check if any item has scan history info in Detail
-	hasScanHistory := false
-	for _, item := range items {
-		if strings.Contains(item.Detail, "|scan:") {
-			hasScanHistory = true
-			break
+	for _, item := range section.Partial {
+		name := item.Name
+		if name == "" {
+			name = "(unknown)"
+		}
+		rows = append(rows, unifiedRow{
+			name:     name,
+			language: item.Language,
+			org:      item.Organization,
+			outcome:  outcomePartial,
+			color:    colorAmber,
+			details:  partialDetails(item),
+		})
+	}
+	for _, item := range section.Failed {
+		rows = append(rows, unifiedRow{
+			name:     item.Name,
+			language: item.Language,
+			org:      item.Organization,
+			outcome:  outcomeFailed,
+			color:    colorRed,
+			details:  item.ErrorMessage,
+		})
+	}
+	// Skipped — preserve group ordering by SkipReason.
+	skippedGroups := make(map[string][]EntityItem)
+	for _, item := range section.Skipped {
+		skippedGroups[item.SkipReason] = append(skippedGroups[item.SkipReason], item)
+	}
+	for _, entry := range skipReasonOrder {
+		for _, item := range skippedGroups[entry.Reason] {
+			rows = append(rows, unifiedRow{
+				name:     item.Name,
+				language: item.Language,
+				org:      item.Organization,
+				outcome:  outcomeSkipped,
+				color:    colorDarkGray,
+				details:  skippedDetails(item),
+			})
 		}
 	}
-	if hasScanHistory {
-		return []string{"Name", "Organization", "Cloud Key", "Scan History"},
-			[]float64{45, 35, 75, 41}
+	return rows
+}
+
+// successDetails formats the Details column for a Succeeded item, including
+// scan-history status (projects only) when present.
+func successDetails(item EntityItem) string {
+	cloudKey, scan := parseScanHistory(item.Detail)
+	if scan == "" {
+		return cloudKey
 	}
-	return []string{"Name", "Organization", "Detail"},
-		[]float64{50, 40, 106}
+	return fmt.Sprintf("%s — scan history: %s", cloudKey, scanStatusLabel(scan))
+}
+
+// partialDetails formats the Details column for a Partial item — joined issues,
+// and the cloud key if known.
+func partialDetails(item EntityItem) string {
+	issues := strings.Join(item.Issues, "; ")
+	if item.Detail != "" && issues != "" {
+		return item.Detail + " — " + issues
+	}
+	if issues != "" {
+		return issues
+	}
+	return item.Detail
+}
+
+// skippedDetails formats the Details column for a Skipped item — prefer the
+// explicit detail message; otherwise fall back to the skip reason label.
+func skippedDetails(item EntityItem) string {
+	if item.Detail != "" {
+		return item.Detail
+	}
+	for _, entry := range skipReasonOrder {
+		if entry.Reason == item.SkipReason {
+			return entry.Label
+		}
+	}
+	return ""
+}
+
+// sectionCountSummary returns a one-line counts summary for a section,
+// breaking down skipped items by reason.
+func sectionCountSummary(section Section) string {
+	parts := []string{
+		fmt.Sprintf("%d succeeded", len(section.Succeeded)),
+	}
+	if len(section.Partial) > 0 {
+		parts = append(parts, fmt.Sprintf("%d partial", len(section.Partial)))
+	}
+	parts = append(parts, fmt.Sprintf("%d failed", len(section.Failed)))
+
+	skipTotal := len(section.Skipped)
+	if skipTotal == 0 {
+		parts = append(parts, "0 skipped")
+		return strings.Join(parts, ", ")
+	}
+	breakdown := skipBreakdown(section.Skipped)
+	if len(breakdown) == 0 {
+		parts = append(parts, fmt.Sprintf("%d skipped", skipTotal))
+	} else {
+		parts = append(parts, fmt.Sprintf("%d skipped (%s)", skipTotal, strings.Join(breakdown, ", ")))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func skipBreakdown(skipped []EntityItem) []string {
+	counts := make(map[string]int)
+	for _, item := range skipped {
+		counts[item.SkipReason]++
+	}
+	var parts []string
+	for _, entry := range skipReasonOrder {
+		if c := counts[entry.Reason]; c > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", c, strings.ToLower(entry.Label)))
+		}
+	}
+	return parts
 }
 
 func renderTableHeader(pdf *fpdf.Fpdf, headers []string, widths []float64) {
@@ -212,44 +399,6 @@ func renderTableHeader(pdf *fpdf.Fpdf, headers []string, widths []float64) {
 	pdf.SetFont("Helvetica", "B", 8)
 	for i, h := range headers {
 		pdf.CellFormat(widths[i], 6, h, "1", 0, "L", true, 0, "")
-	}
-	pdf.Ln(-1)
-}
-
-func renderItemRow(pdf *fpdf.Fpdf, item EntityItem, widths []float64, isFailed bool, even bool) {
-	if isFailed {
-		setFillColor(pdf, colorFailedBg)
-	} else if even {
-		setFillColor(pdf, colorLightGray)
-	} else {
-		setFillColor(pdf, colorWhite)
-	}
-	setColor(pdf, colorBlack)
-
-	if isFailed {
-		renderFailedRow(pdf, item, widths)
-	} else {
-		renderSuccessRow(pdf, item, widths)
-	}
-}
-
-func renderFailedRow(pdf *fpdf.Fpdf, item EntityItem, widths []float64) {
-	pdf.CellFormat(widths[0], 6, truncate(item.Name, 30), "1", 0, "L", true, 0, "")
-	pdf.CellFormat(widths[1], 6, truncate(item.Organization, 24), "1", 0, "L", true, 0, "")
-	pdf.CellFormat(widths[2], 6, truncate(item.ErrorMessage, 65), "1", 0, "L", true, 0, "")
-	pdf.Ln(-1)
-}
-
-func renderSuccessRow(pdf *fpdf.Fpdf, item EntityItem, widths []float64) {
-	detail, scanStatus := parseScanHistory(item.Detail)
-
-	pdf.CellFormat(widths[0], 6, truncate(item.Name, 28), "1", 0, "L", true, 0, "")
-	pdf.CellFormat(widths[1], 6, truncate(item.Organization, 22), "1", 0, "L", true, 0, "")
-	pdf.CellFormat(widths[2], 6, truncate(detail, 46), "1", 0, "L", true, 0, "")
-
-	if len(widths) > 3 {
-		label := scanStatusLabel(scanStatus)
-		pdf.CellFormat(widths[3], 6, label, "1", 0, "C", true, 0, "")
 	}
 	pdf.Ln(-1)
 }

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -3,6 +3,7 @@ package summary
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -102,7 +103,7 @@ func TestGeneratePDFReport(t *testing.T) {
 		{"name": "Proj1", "sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj1"},
 	})
 
-	pdfPath, err := GeneratePDFReport(runDir, dir)
+	pdfPath, err := GeneratePDFReport(runDir, dir, dir)
 	if err != nil {
 		t.Fatalf("GeneratePDFReport: %v", err)
 	}
@@ -130,38 +131,62 @@ func TestTruncate(t *testing.T) {
 	}
 }
 
-func TestSubsectionColumnsWithScanHistory(t *testing.T) {
-	items := []EntityItem{
-		{Detail: "proj1|scan:success"},
+func TestBuildUnifiedRowsOrdering(t *testing.T) {
+	section := Section{
+		Name: "Quality Gates",
+		Succeeded: []EntityItem{
+			{Name: "GateA", Organization: "org1", Detail: "42"},
+		},
+		Partial: []EntityItem{
+			{Name: "GateB", Organization: "org1", Detail: "43", Issues: []string{"Add condition: foo"}},
+		},
+		Failed: []EntityItem{
+			{Name: "GateC", Organization: "org1", ErrorMessage: "boom"},
+		},
+		Skipped: []EntityItem{
+			{Name: "GateD", SkipReason: SkipReasonUnused, Detail: "Not used"},
+			{Name: "GateE", SkipReason: SkipReasonBuiltIn, Detail: "Built-in"},
+		},
 	}
-	headers, widths := subsectionColumns(false, items)
-	if len(headers) != 4 {
-		t.Errorf("expected 4 columns with scan history, got %d", len(headers))
+
+	rows := buildUnifiedRows(section)
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(rows))
 	}
-	if headers[3] != "Scan History" {
-		t.Errorf("expected 'Scan History' column, got %q", headers[3])
+	expectedOutcomes := []string{
+		outcomeSuccess, outcomePartial, outcomeFailed, outcomeSkipped, outcomeSkipped,
 	}
-	if len(widths) != 4 {
-		t.Errorf("expected 4 widths, got %d", len(widths))
+	for i, want := range expectedOutcomes {
+		if rows[i].outcome != want {
+			t.Errorf("row %d: expected outcome %q, got %q", i, want, rows[i].outcome)
+		}
+	}
+	// Skipped ordering: built-in comes before unused per skipReasonOrder.
+	if rows[3].name != "GateE" {
+		t.Errorf("expected built-in skipped first, got name %q", rows[3].name)
+	}
+	if rows[4].name != "GateD" {
+		t.Errorf("expected unused skipped second, got name %q", rows[4].name)
+	}
+	if rows[1].details != "43 — Add condition: foo" {
+		t.Errorf("expected partial details to combine cloud key + issues, got %q", rows[1].details)
 	}
 }
 
-func TestSubsectionColumnsWithoutScanHistory(t *testing.T) {
-	items := []EntityItem{
-		{Detail: "proj1"},
+func TestUnifiedRowDisplayNameWithLanguage(t *testing.T) {
+	row := unifiedRow{name: "Custom", language: "java"}
+	if got := row.displayName(); got != "java / Custom" {
+		t.Errorf("expected 'java / Custom', got %q", got)
 	}
-	headers, _ := subsectionColumns(false, items)
-	if len(headers) != 3 {
-		t.Errorf("expected 3 columns without scan history, got %d", len(headers))
+	row2 := unifiedRow{name: "Gate"}
+	if got := row2.displayName(); got != "Gate" {
+		t.Errorf("expected 'Gate', got %q", got)
 	}
 }
 
-func TestSubsectionColumnsFailure(t *testing.T) {
-	items := []EntityItem{
-		{ErrorMessage: "error"},
-	}
-	headers, _ := subsectionColumns(true, items)
-	if len(headers) != 3 || headers[2] != "Error" {
-		t.Errorf("expected failure columns, got %v", headers)
+func TestSuccessDetailsScanHistory(t *testing.T) {
+	got := successDetails(EntityItem{Detail: "proj1|scan:failed"})
+	if !strings.Contains(got, "proj1") || !strings.Contains(got, "Failed") {
+		t.Errorf("expected scan history in details, got %q", got)
 	}
 }

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -14,6 +14,7 @@ type MigrationSummary struct {
 type Section struct {
 	Name      string
 	Succeeded []EntityItem
+	Partial   []EntityItem // created on SQC but follow-up configuration was incomplete
 	Failed    []EntityItem
 	Skipped   []EntityItem
 }
@@ -21,10 +22,20 @@ type Section struct {
 // EntityItem represents a single entity in the report.
 type EntityItem struct {
 	Name         string
+	Language     string   // populated for Quality Profiles only; empty otherwise
 	Organization string
-	Detail       string // cloud key for successes, scan history status, skip reason
-	ErrorMessage string // failures only
+	Detail       string   // cloud key for successes, scan history status, skip reason
+	ErrorMessage string   // failures only
+	SkipReason   string   // for skipped items: SkipReason* constants below
+	Issues       []string // for partial migrations: human-readable list of issues
 }
+
+// Skip reason constants used when classifying skipped entities.
+const (
+	SkipReasonOrgSkipped = "org-skipped"
+	SkipReasonBuiltIn    = "built-in"
+	SkipReasonUnused     = "unused"
+)
 
 // sectionDef maps a report section to its corresponding task names and analysis entity type.
 type sectionDef struct {
@@ -34,17 +45,19 @@ type sectionDef struct {
 	AnalysisEntity string // entity type in analysis report (for failures)
 	NameField      string // JSONL field to extract entity name
 	DetailField    string // JSONL field for detail column (e.g., cloud key)
+	ExtractTask    string // extract task for source data (empty if not applicable)
 }
 
 // sectionDefs defines the sections in report order.
 var sectionDefs = []sectionDef{
 	{
-		Name:           "Projects",
-		InputTask:      "generateProjectMappings",
-		OutputTask:     "createProjects",
-		AnalysisEntity: "Project",
+		Name:           "Quality Gates",
+		InputTask:      "generateGateMappings",
+		OutputTask:     "createGates",
+		AnalysisEntity: "Quality Gate",
 		NameField:      "name",
-		DetailField:    "cloud_project_key",
+		DetailField:    "cloud_gate_id",
+		ExtractTask:    "getGates",
 	},
 	{
 		Name:           "Quality Profiles",
@@ -53,22 +66,7 @@ var sectionDefs = []sectionDef{
 		AnalysisEntity: "Quality Profile",
 		NameField:      "name",
 		DetailField:    "cloud_profile_key",
-	},
-	{
-		Name:           "Quality Gates",
-		InputTask:      "generateGateMappings",
-		OutputTask:     "createGates",
-		AnalysisEntity: "Quality Gate",
-		NameField:      "name",
-		DetailField:    "cloud_gate_id",
-	},
-	{
-		Name:           "Groups",
-		InputTask:      "generateGroupMappings",
-		OutputTask:     "createGroups",
-		AnalysisEntity: "Group",
-		NameField:      "name",
-		DetailField:    "cloud_group_id",
+		ExtractTask:    "getProfiles",
 	},
 	{
 		Name:           "Permission Templates",
@@ -79,12 +77,28 @@ var sectionDefs = []sectionDef{
 		DetailField:    "cloud_template_id",
 	},
 	{
+		Name:           "Groups",
+		InputTask:      "generateGroupMappings",
+		OutputTask:     "createGroups",
+		AnalysisEntity: "Group",
+		NameField:      "name",
+		DetailField:    "cloud_group_id",
+	},
+	{
 		Name:           "Portfolios",
 		InputTask:      "generatePortfolioMappings",
 		OutputTask:     "createPortfolios",
 		AnalysisEntity: "Portfolio",
 		NameField:      "name",
 		DetailField:    "cloud_portfolio_id",
+	},
+	{
+		Name:           "Projects",
+		InputTask:      "generateProjectMappings",
+		OutputTask:     "createProjects",
+		AnalysisEntity: "Project",
+		NameField:      "name",
+		DetailField:    "cloud_project_key",
 	},
 }
 

--- a/go/internal/wizard/phases.go
+++ b/go/internal/wizard/phases.go
@@ -464,7 +464,7 @@ func generateAnalysisReport(p Prompter, exportDir, runID string) {
 		p.DisplayMessage(fmt.Sprintf("Analysis report: %d entries written to %s/final_analysis_report.csv", len(rows), runID))
 	}
 
-	pdfPath, pdfErr := summary.GeneratePDFReport(runDir, exportDir)
+	pdfPath, pdfErr := summary.GeneratePDFReport(runDir, exportDir, exportDir)
 	if pdfErr != nil {
 		p.DisplayWarning("Could not generate PDF summary: " + pdfErr.Error())
 		return


### PR DESCRIPTION
## Summary

Improves the post-migration PDF summary so it more accurately reflects what was migrated, what was deliberately not migrated, and what was migrated only partially. Closes #162.

- **Skipped breakdown** — Quality Gates and Quality Profiles now distinguish:
  - `built-in` — items with `isBuiltIn=true` in the source extract
  - `unused` — items present in the extract but not referenced by any migrated project / mapping
  - `org-skipped` — wizard-skipped organization (previous behavior, now tagged)
- **Partial migrations** — follow-up configuration failures (gate conditions, profile restore / change_parent / set_default, set as default, assign to project, group permission) are re-parsed from `requests.log`, attributed to the parent gate/profile when the body identifies it, and rendered as `Partial` rows carrying the cloud key and a human-readable issue list.
- **Unified per-section table** — each section is now a single 4-column table (`Name`, `Organization`, `Outcome`, `Details`) with outcome cells colored green / amber / red / dark grey. Executive summary gains a `Partial` column.
- **Section ordering** — Quality Gates → Quality Profiles → Permission Templates → Groups → Portfolios → Projects.
- **Sorting** — Quality Gates, Groups, Portfolios, Projects sorted alphabetically by `Name`. Quality Profiles sorted by `language` then `name` and displayed as `<language> / <name>` (the language prefix is applied across success/partial/failed/skipped rows, including org-skipped).
- `summary.GeneratePDFReport` and `CollectSummary` now take the export directory so extract data can be read to compute built-in/unused (callers in `cmd/migrate.go` and `internal/wizard/phases.go` updated).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] New tests cover: built-in/unused gate categorization, built-in/unused profile categorization (incl. multi-language), partial QG condition tracking, partial QP `change_parent` with cloud-key carry-over, unified-row ordering, `<language> / <name>` display.
- [ ] Generate a real migration PDF against a sample run and visually verify per-section tables, sorting, and color coding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)