### PR TITLE
Issue #152 Mark portfolios with subportfolios as Partial in migration report

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -81,6 +81,14 @@ func collectSection(store *common.DataStore, def sectionDef,
 		skipped = append(skipped, collectExtractSkipped(def, exportDir, extractMapping, store)...)
 	}
 
+	// SonarQube Cloud has no portfolio hierarchy: any source portfolio that
+	// has subportfolios is migrated as a flat project list, so its perimeter
+	// may differ from the source. Mark those as Partial.
+	if def.Name == "Portfolios" && extractMapping != nil {
+		parents := portfoliosWithSubportfolios(exportDir, extractMapping)
+		succeeded, partial = markPartialPortfolios(store, succeeded, partial, parents)
+	}
+
 	return Section{
 		Name:      def.Name,
 		Succeeded: succeeded,

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -383,6 +383,88 @@ func TestCollectSummaryPartialProfileChangeParent(t *testing.T) {
 	}
 }
 
+func TestCollectSummaryPortfolioHierarchyPartial(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	// Extract describes a top-level portfolio "Top" with one subportfolio
+	// "Mid" which itself has one subportfolio "Leaf"; plus a stand-alone
+	// portfolio "Solo" with no children.
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	writeTaskJSONL(t, extractDir, "getPortfolioDetails", []map[string]any{
+		{
+			"key":  "topKey",
+			"name": "Top",
+			"subViews": []map[string]any{
+				{
+					"key":  "midKey",
+					"name": "Mid",
+					"subViews": []map[string]any{
+						{"key": "leafKey", "name": "Leaf"},
+					},
+				},
+			},
+		},
+		{"key": "soloKey", "name": "Solo"},
+	})
+
+	// createPortfolios JSONL — all four portfolios were created successfully.
+	writeTaskJSONL(t, runDir, "createPortfolios", []map[string]any{
+		{"name": "Top", "server_url": "https://sq.example.com", "source_portfolio_key": "topKey", "cloud_portfolio_id": "1"},
+		{"name": "Mid", "server_url": "https://sq.example.com", "source_portfolio_key": "midKey", "cloud_portfolio_id": "2"},
+		{"name": "Leaf", "server_url": "https://sq.example.com", "source_portfolio_key": "leafKey", "cloud_portfolio_id": "3"},
+		{"name": "Solo", "server_url": "https://sq.example.com", "source_portfolio_key": "soloKey", "cloud_portfolio_id": "4"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	portfolios := findSection(summary, "Portfolios")
+	if portfolios == nil {
+		t.Fatal("missing Portfolios section")
+	}
+
+	succeededNames := map[string]bool{}
+	for _, item := range portfolios.Succeeded {
+		succeededNames[item.Name] = true
+	}
+	partialNames := map[string]bool{}
+	for _, item := range portfolios.Partial {
+		partialNames[item.Name] = true
+	}
+
+	// Top and Mid have subportfolios → Partial.
+	if !partialNames["Top"] || !partialNames["Mid"] {
+		t.Errorf("expected Top and Mid in Partial, got %v", partialNames)
+	}
+	// Leaf (subportfolio with no children) and Solo (standalone) → Success.
+	if !succeededNames["Leaf"] {
+		t.Errorf("expected Leaf in Succeeded, got %v", succeededNames)
+	}
+	if !succeededNames["Solo"] {
+		t.Errorf("expected Solo in Succeeded, got %v", succeededNames)
+	}
+	if succeededNames["Top"] || succeededNames["Mid"] {
+		t.Errorf("Top/Mid should not remain in Succeeded, got %v", succeededNames)
+	}
+
+	// Issue text should explain the hierarchy.
+	for _, item := range portfolios.Partial {
+		if len(item.Issues) == 0 {
+			t.Errorf("portfolio %q has no issues attached", item.Name)
+			continue
+		}
+		if !strings.Contains(item.Issues[0], "subportfolios") {
+			t.Errorf("portfolio %q: issue does not mention subportfolios: %q", item.Name, item.Issues[0])
+		}
+	}
+}
+
 // --- helpers ---
 
 func findSection(s *MigrationSummary, name string) *Section {

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -259,9 +259,21 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		})
 	}
 
+	const lineH = 6.0
 	pdf.SetFont(pdfFontFamily, "", 8)
 	for i, row := range rows {
-		checkPageBreak(pdf, 7)
+		// Compute wrapped line count for the Details column so the whole row
+		// (Name, Organization, Outcome) can match that height. SplitLines
+		// already accounts for the cell's internal margin.
+		detailsText := sanitizeForPDF(row.details)
+		detailsCol := len(widths) - 1
+		lineCount := len(pdf.SplitLines([]byte(detailsText), widths[detailsCol]))
+		if lineCount < 1 {
+			lineCount = 1
+		}
+		rowHeight := float64(lineCount) * lineH
+
+		checkPageBreak(pdf, rowHeight)
 		if i%2 == 0 {
 			setFillColor(pdf, colorLightGray)
 		} else {
@@ -274,22 +286,23 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		if hideOrg {
 			nameLimit = 60
 		}
-		pdf.CellFormat(widths[col], 6, truncate(row.displayName(), nameLimit), "1", 0, "L", true, 0, "")
+		pdf.CellFormat(widths[col], rowHeight, truncate(row.displayName(), nameLimit), "1", 0, "L", true, 0, "")
 		col++
 		if !hideOrg {
-			pdf.CellFormat(widths[col], 6, truncate(row.org, 24), "1", 0, "L", true, 0, "")
+			pdf.CellFormat(widths[col], rowHeight, truncate(row.org, 24), "1", 0, "L", true, 0, "")
 			col++
 		}
 		// Outcome cell in its color, bold.
 		setColor(pdf, row.color)
 		pdf.SetFont(pdfFontFamily, "B", 8)
-		pdf.CellFormat(widths[col], 6, row.outcome, "1", 0, "C", true, 0, "")
+		pdf.CellFormat(widths[col], rowHeight, row.outcome, "1", 0, "C", true, 0, "")
 		col++
-		// Details in black, regular.
+		// Details in black, regular — MultiCell wraps long text across lines
+		// rather than truncating. lineH is per-line so the cell ends up at
+		// rowHeight, matching the row.
 		setColor(pdf, colorBlack)
 		pdf.SetFont(pdfFontFamily, "", 8)
-		pdf.CellFormat(widths[col], 6, truncate(row.details, 56), "1", 0, "L", true, 0, "")
-		pdf.Ln(-1)
+		pdf.MultiCell(widths[col], lineH, detailsText, "1", "L", true)
 	}
 }
 

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -259,7 +259,14 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		})
 	}
 
-	const lineH = 6.0
+	// Single-line rows render at the original 6mm height; when the Details
+	// text wraps, each extra line is set to a tighter 3.6mm so the row does
+	// not balloon vertically. This still leaves enough breathing room above
+	// and below 8pt text for legibility.
+	const (
+		singleLineH  = 6.0
+		wrappedLineH = 3.6
+	)
 	pdf.SetFont(pdfFontFamily, "", 8)
 	for i, row := range rows {
 		// Compute wrapped line count for the Details column so the whole row
@@ -271,7 +278,14 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		if lineCount < 1 {
 			lineCount = 1
 		}
-		rowHeight := float64(lineCount) * lineH
+		var lineH, rowHeight float64
+		if lineCount == 1 {
+			lineH = singleLineH
+			rowHeight = singleLineH
+		} else {
+			lineH = wrappedLineH
+			rowHeight = float64(lineCount) * wrappedLineH
+		}
 
 		checkPageBreak(pdf, rowHeight)
 		if i%2 == 0 {

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -8,6 +8,36 @@ import (
 	"time"
 )
 
+func TestRenderPDFLongDetailsWrap(t *testing.T) {
+	// The portfolio Partial issue text is intentionally long. Verify it does
+	// not cause a render failure and that the resulting PDF is well-formed.
+	longIssue := "Source portfolio has subportfolios; SonarQube Cloud has no hierarchy — migrated as a flat project list and the perimeter may differ from the source"
+	summary := &MigrationSummary{
+		RunID:       "wrap-run",
+		GeneratedAt: time.Now(),
+		Sections: []Section{
+			{
+				Name: "Portfolios",
+				Partial: []EntityItem{
+					{Name: "Top", Detail: "42", Issues: []string{longIssue}},
+				},
+			},
+		},
+	}
+
+	pdfBytes, err := RenderPDF(summary)
+	if err != nil {
+		t.Fatalf("RenderPDF with long details: %v", err)
+	}
+	if string(pdfBytes[:5]) != "%PDF-" {
+		t.Errorf("expected PDF header, got %q", string(pdfBytes[:5]))
+	}
+	// A valid embedded-font PDF for one section + one row is >>10KB.
+	if len(pdfBytes) < 10_000 {
+		t.Errorf("expected non-trivial PDF size, got %d bytes", len(pdfBytes))
+	}
+}
+
 func TestRenderPDFUnicodeNames(t *testing.T) {
 	summary := &MigrationSummary{
 		RunID:       "unicode-run",

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -1,0 +1,107 @@
+package summary
+
+import (
+	"encoding/json"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+)
+
+// partialPortfolioIssue is the human-readable issue text attached to a
+// portfolio that has at least one subportfolio in the source. SonarQube Cloud
+// has no portfolio hierarchy, so such portfolios are migrated as a flat
+// project list (snapshot of the resolved projects at extract time). New
+// projects that match a regex/tags subportfolio after migration will not
+// appear in the SQC portfolio until it is updated manually.
+const partialPortfolioIssue = "Source portfolio has subportfolios; SonarQube Cloud has no hierarchy — migrated as a flat project list and the perimeter may differ from the source"
+
+// portfoliosWithSubportfolios walks getPortfolioDetails across all extracts
+// and returns the set of portfolio keys that have at least one direct
+// subportfolio (i.e. non-empty subViews). Leaf portfolios — including
+// subportfolios that do not themselves have children — are not included.
+//
+// Keys are returned as composite serverURL|portfolioKey strings so they can
+// be matched against createPortfolios JSONL entries (which carry both
+// server_url and source_portfolio_key).
+func portfoliosWithSubportfolios(exportDir string, mapping structure.ExtractMapping) map[string]bool {
+	set := make(map[string]bool)
+	items, err := structure.ReadExtractData(exportDir, mapping, "getPortfolioDetails")
+	if err != nil || len(items) == 0 {
+		return set
+	}
+	for _, item := range items {
+		var obj map[string]any
+		if err := json.Unmarshal(item.Data, &obj); err != nil {
+			continue
+		}
+		markPortfolioParents(item.ServerURL, obj, set)
+	}
+	return set
+}
+
+// markPortfolioParents walks a portfolio object (recursively through its
+// subViews) and records every node whose subViews list is non-empty.
+func markPortfolioParents(serverURL string, portfolio map[string]any, set map[string]bool) {
+	subViewsRaw, ok := portfolio["subViews"]
+	if !ok {
+		return
+	}
+	subViews, ok := subViewsRaw.([]any)
+	if !ok || len(subViews) == 0 {
+		return
+	}
+	if key, ok := portfolio["key"].(string); ok && key != "" {
+		set[serverURL+"|"+key] = true
+	}
+	for _, sub := range subViews {
+		if subMap, ok := sub.(map[string]any); ok {
+			markPortfolioParents(serverURL, subMap, set)
+		}
+	}
+}
+
+// markPartialPortfolios moves portfolios that have at least one subportfolio
+// from Succeeded to Partial, adding partialPortfolioIssue to the entry. Leaf
+// portfolios stay in Succeeded. The match is done on the composite
+// serverURL|source_portfolio_key key, which both getPortfolioDetails (via the
+// walker above) and createPortfolios JSONL produce.
+func markPartialPortfolios(store *common.DataStore, succeeded, partial []EntityItem,
+	parents map[string]bool) ([]EntityItem, []EntityItem) {
+
+	if len(parents) == 0 || len(succeeded) == 0 {
+		return succeeded, partial
+	}
+
+	// Build name → composite key map from createPortfolios output. The
+	// EntityItem.Name comes from the same JSONL "name" field, so this is a
+	// reliable join.
+	items, err := store.ReadAll("createPortfolios")
+	if err != nil || len(items) == 0 {
+		return succeeded, partial
+	}
+	nameToCompositeKey := make(map[string]string, len(items))
+	for _, item := range items {
+		name := jsonStr(item, "name")
+		if name == "" {
+			continue
+		}
+		serverURL := jsonStr(item, "server_url")
+		sourceKey := jsonStr(item, "source_portfolio_key")
+		if serverURL == "" || sourceKey == "" {
+			continue
+		}
+		nameToCompositeKey[name] = serverURL + "|" + sourceKey
+	}
+
+	kept := succeeded[:0:0]
+	for _, item := range succeeded {
+		composite := nameToCompositeKey[item.Name]
+		if composite != "" && parents[composite] {
+			item.Issues = append(item.Issues, partialPortfolioIssue)
+			partial = append(partial, item)
+			continue
+		}
+		kept = append(kept, item)
+	}
+	return kept, partial
+}

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -13,7 +13,7 @@ import (
 // project list (snapshot of the resolved projects at extract time). New
 // projects that match a regex/tags subportfolio after migration will not
 // appear in the SQC portfolio until it is updated manually.
-const partialPortfolioIssue = "Source portfolio has subportfolios; SonarQube Cloud has no hierarchy — migrated as a flat project list and the perimeter may differ from the source"
+const partialPortfolioIssue = "The source portfolio has subportfolios. The target portfolio is migrated as a flat list of projects. The portfolio project perimeter may be slightly different on SonarQube Cloud"
 
 // portfoliosWithSubportfolios walks getPortfolioDetails across all extracts
 // and returns the set of portfolio keys that have at least one direct


### PR DESCRIPTION
## Summary

SonarQube Cloud has no portfolio hierarchy. When a SonarQube Server portfolio has subportfolios, it is migrated as a flat snapshot of its resolved projects (the SQS `api/views/projects_status` endpoint already returns the flattened list, regardless of selection mode). The migration is therefore not 100% faithful: regex/tag subportfolios resolve to a snapshot at extract time, and the SQC portfolio will not pick up new matching projects automatically. Closes #152.

- `portfolio_hierarchy.go` walks `getPortfolioDetails.subViews` across all extracts and marks any portfolio (top-level or mid-tier) whose `subViews` array is non-empty.
- `collectSection` for Portfolios moves matched entries from `Succeeded` to `Partial` with a clear explanation: *"The source portfolio has subportfolios. The target portfolio is migrated as a flat list of projects. The portfolio project perimeter may be slightly different on SonarQube Cloud."*
- Leaf portfolios — including subportfolios with no children of their own — remain `Success`.
- Details column now uses `MultiCell` so long Partial explanations wrap onto multiple lines instead of being truncated. Single-line rows keep their 6mm height; wrapped rows use a compact 3.6mm per line to keep the table tight.

## Test plan

- [x] `go test ./...`
- [x] `TestCollectSummaryPortfolioHierarchyPartial`: Top → Mid → Leaf chain plus stand-alone Solo. Top & Mid → Partial, Leaf & Solo → Success.
- [x] `TestRenderPDFLongDetailsWrap` confirms long Partial issue text renders without error.
- [ ] Generate a real migration PDF against a SQS instance that has hierarchical portfolios and visually verify Partial classification + the wrapped Details text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)