### PR TITLE
Issue #117 Migrate quality gates with override + #143 closest-metric mapping

### DIFF
--- a/go/internal/migrate/gate_metric_mapping.go
+++ b/go/internal/migrate/gate_metric_mapping.go
@@ -1,0 +1,114 @@
+package migrate
+
+// metricMapping maps a SonarQube Server quality-gate metric that does not
+// exist on SonarQube Cloud to its closest SQC equivalent(s). The mapping
+// follows the table maintained in issue #143.
+//
+// Semantics:
+//
+//   - A single-element slice replaces the source metric with that target
+//     metric. The source condition's op + threshold are preserved.
+//   - A multi-element slice (composite mapping) emits one SQC condition per
+//     target metric, each preserving the source op + threshold. This is the
+//     best-effort translation of the "metric_a + metric_b" entries in
+//     the issue table.
+//   - An empty slice means the source metric has no meaningful SQC
+//     equivalent — the condition is dropped and the gate is migrated with
+//     one fewer condition. The migration logs this at Warn level.
+//
+// Metrics that already exist verbatim on SQC are intentionally absent from
+// this map: lookupMetricReplacement returns ok=false for them and the
+// caller forwards the condition unchanged.
+var metricMapping = map[string][]string{
+	// *_with_aica / *_without_aica variants — drop the AICA suffix.
+	"new_maintainability_rating_with_aica":     {"new_maintainability_rating"},
+	"new_maintainability_rating_without_aica":  {"new_maintainability_rating"},
+	"new_reliability_rating_with_aica":         {"new_reliability_rating"},
+	"new_reliability_rating_without_aica":      {"new_reliability_rating"},
+	"new_security_rating_with_aica":            {"new_security_rating"},
+	"new_security_rating_without_aica":         {"new_security_rating"},
+	"new_security_review_rating_with_aica":     {"new_security_review_rating"},
+	"new_security_review_rating_without_aica":  {"new_security_review_rating"},
+	"reliability_rating_with_aica":             {"reliability_rating"},
+	"reliability_rating_without_aica":          {"reliability_rating"},
+	"security_rating_with_aica":                {"security_rating"},
+	"security_rating_without_aica":             {"security_rating"},
+	"security_review_rating_with_aica":         {"security_review_rating"},
+	"security_review_rating_without_aica":      {"security_review_rating"},
+	"sqale_rating_with_aica":                   {"sqale_rating"},
+	"sqale_rating_without_aica":                {"sqale_rating"},
+
+	// software_quality_* (classic / SQS-only) → classic SQC equivalents.
+	"software_quality_maintainability_debt_ratio":          {"sqale_debt_ratio"},
+	"software_quality_maintainability_rating":              {"sqale_rating"},
+	"software_quality_maintainability_rating_with_aica":    {"sqale_rating"},
+	"software_quality_maintainability_rating_without_aica": {"sqale_rating"},
+	"software_quality_reliability_rating_with_aica":        {"reliability_rating"},
+	"software_quality_reliability_rating_without_aica":     {"reliability_rating"},
+	"software_quality_security_rating":                     {"security_rating"},
+	"software_quality_security_rating_with_aica":           {"security_rating"},
+	"software_quality_security_rating_without_aica":        {"security_rating"},
+
+	// new_software_quality_* → new_* equivalents.
+	"new_software_quality_maintainability_debt_ratio":          {"new_sqale_debt_ratio"},
+	"new_software_quality_maintainability_issues":              {"new_issues"},
+	"new_software_quality_maintainability_rating":              {"new_sqale_debt_ratio"},
+	"new_software_quality_maintainability_rating_with_aica":    {"new_maintainability_rating"},
+	"new_software_quality_maintainability_rating_without_aica": {"new_maintainability_rating"},
+	"new_software_quality_reliability_rating":                  {"new_reliability_rating"},
+	"new_software_quality_reliability_rating_with_aica":        {"new_reliability_rating"},
+	"new_software_quality_reliability_rating_without_aica":     {"new_reliability_rating"},
+	"new_software_quality_security_rating":                     {"new_security_rating"},
+
+	// Composite mappings — one source condition becomes multiple target
+	// conditions, each preserving the source op and threshold. The set of
+	// target metrics matches the right-hand column of issue #143.
+	"software_quality_blocker_issues": {"security_review_rating", "reliability_rating"},
+	"software_quality_high_issues":    {"security_review_rating", "reliability_rating"},
+	"software_quality_medium_issues":  {"security_review_rating", "reliability_rating"},
+	"software_quality_low_issues":     {"security_rating", "reliability_rating"},
+	"software_quality_info_issues":    {"security_rating", "reliability_rating"},
+
+	"new_software_quality_blocker_issues": {"new_security_review_rating", "new_reliability_rating"},
+	"new_software_quality_high_issues":    {"new_security_review_rating", "new_reliability_rating"},
+	"new_software_quality_medium_issues":  {"new_security_review_rating", "new_reliability_rating"},
+	"new_software_quality_low_issues":     {"new_security_review_rating", "new_reliability_rating"},
+	"new_software_quality_info_issues":    {"new_security_review_rating", "new_reliability_rating"},
+
+	"new_software_quality_reliability_issues": {"new_reliability_rating"},
+	"new_software_quality_security_issues":    {"new_security_rating"},
+
+	// Source metrics with no meaningful SQC equivalent — drop the condition.
+	"contains_ai_code":                                 {},
+	"effort_to_reach_software_quality_maintainability_rating_a": {},
+	"filename_size":                                    {},
+	"filename_size_rating":                             {},
+	"ncloc_with_aica":                                  {},
+	"ncloc_without_aica":                               {},
+	"new_software_quality_maintainability_remediation_effort": {},
+	"new_software_quality_reliability_remediation_effort":     {},
+	"new_software_quality_security_remediation_effort":        {},
+	"prioritized_rule_issues":                          {},
+	"releasability_rating":                             {},
+	"releasability_rating_with_aica":                   {},
+	"releasability_rating_without_aica":                {},
+	"software_quality_maintainability_issues":          {},
+	"software_quality_maintainability_remediation_effort": {},
+	"software_quality_reliability_issues":              {},
+	"software_quality_reliability_rating":              {},
+	"software_quality_reliability_remediation_effort":  {},
+	"software_quality_security_issues":                 {},
+	"software_quality_security_remediation_effort":     {},
+}
+
+// lookupMetricReplacement returns the list of SonarQube Cloud metrics that
+// should be used in place of the given source metric. The bool indicates
+// whether the source metric is known to the mapping table:
+//
+//   - ok=true,  len(targets)>0  → replace with these target metric(s)
+//   - ok=true,  len(targets)==0 → drop the condition (no SQC equivalent)
+//   - ok=false                  → metric exists verbatim on SQC, pass through
+func lookupMetricReplacement(sourceMetric string) (targets []string, ok bool) {
+	t, ok := metricMapping[sourceMetric]
+	return t, ok
+}

--- a/go/internal/migrate/gate_metric_mapping.go
+++ b/go/internal/migrate/gate_metric_mapping.go
@@ -1,114 +1,186 @@
 package migrate
 
-// metricMapping maps a SonarQube Server quality-gate metric that does not
-// exist on SonarQube Cloud to its closest SQC equivalent(s). The mapping
-// follows the table maintained in issue #143.
+// replacementCondition describes how a single SonarQube Cloud condition is
+// derived from a SonarQube Server condition during migration. Op and Error
+// override the source values when non-empty; otherwise the source op /
+// threshold is preserved as-is.
+type replacementCondition struct {
+	Metric string
+	Op     string // "" = inherit source condition op
+	Error  string // "" = inherit source condition threshold
+}
+
+// Convenience helpers for the table below.
+func keep(metric string) []replacementCondition {
+	return []replacementCondition{{Metric: metric}}
+}
+
+func ratingWorseThan(metric string, letter string) replacementCondition {
+	// SonarQube rating quality-gate conditions use op=GT with the numeric
+	// rating value as the threshold. "metric <= D" in the issue table means
+	// "fire when the rating is worse than D", i.e. value greater than 4.
+	letterToValue := map[string]string{
+		"A": "1",
+		"B": "2",
+		"C": "3",
+		"D": "4",
+	}
+	v, ok := letterToValue[letter]
+	if !ok {
+		v = "1"
+	}
+	return replacementCondition{Metric: metric, Op: "GT", Error: v}
+}
+
+// metricMapping maps a SonarQube Server quality-gate metric to one or more
+// SonarQube Cloud conditions, following the table maintained in issue #143.
 //
 // Semantics:
 //
-//   - A single-element slice replaces the source metric with that target
-//     metric. The source condition's op + threshold are preserved.
-//   - A multi-element slice (composite mapping) emits one SQC condition per
-//     target metric, each preserving the source op + threshold. This is the
-//     best-effort translation of the "metric_a + metric_b" entries in
-//     the issue table.
-//   - An empty slice means the source metric has no meaningful SQC
-//     equivalent — the condition is dropped and the gate is migrated with
-//     one fewer condition. The migration logs this at Warn level.
+//   - A non-empty slice replaces the source condition with the listed target
+//     conditions (one CreateCondition call per element). Per-entry Op/Error
+//     overrides the source values; "" means inherit.
+//   - An empty slice means the source metric has no SQC equivalent — the
+//     condition is dropped and the gate is migrated with one fewer
+//     condition. The migration logs this at Warn level.
 //
-// Metrics that already exist verbatim on SQC are intentionally absent from
-// this map: lookupMetricReplacement returns ok=false for them and the
-// caller forwards the condition unchanged.
-var metricMapping = map[string][]string{
-	// *_with_aica / *_without_aica variants — drop the AICA suffix.
-	"new_maintainability_rating_with_aica":     {"new_maintainability_rating"},
-	"new_maintainability_rating_without_aica":  {"new_maintainability_rating"},
-	"new_reliability_rating_with_aica":         {"new_reliability_rating"},
-	"new_reliability_rating_without_aica":      {"new_reliability_rating"},
-	"new_security_rating_with_aica":            {"new_security_rating"},
-	"new_security_rating_without_aica":         {"new_security_rating"},
-	"new_security_review_rating_with_aica":     {"new_security_review_rating"},
-	"new_security_review_rating_without_aica":  {"new_security_review_rating"},
-	"reliability_rating_with_aica":             {"reliability_rating"},
-	"reliability_rating_without_aica":          {"reliability_rating"},
-	"security_rating_with_aica":                {"security_rating"},
-	"security_rating_without_aica":             {"security_rating"},
-	"security_review_rating_with_aica":         {"security_review_rating"},
-	"security_review_rating_without_aica":      {"security_review_rating"},
-	"sqale_rating_with_aica":                   {"sqale_rating"},
-	"sqale_rating_without_aica":                {"sqale_rating"},
+// Metrics that already exist verbatim on SQC are intentionally absent: the
+// caller leaves the condition unchanged when lookupMetricReplacement
+// returns ok=false.
+var metricMapping = map[string][]replacementCondition{
+	// *_with_aica / *_without_aica variants — drop the AICA suffix,
+	// preserve op + threshold.
+	"new_maintainability_rating_with_aica":     keep("new_maintainability_rating"),
+	"new_maintainability_rating_without_aica":  keep("new_maintainability_rating"),
+	"new_reliability_rating_with_aica":         keep("new_reliability_rating"),
+	"new_reliability_rating_without_aica":      keep("new_reliability_rating"),
+	"new_security_rating_with_aica":            keep("new_security_rating"),
+	"new_security_rating_without_aica":         keep("new_security_rating"),
+	"new_security_review_rating_with_aica":     keep("new_security_review_rating"),
+	"new_security_review_rating_without_aica":  keep("new_security_review_rating"),
+	"reliability_rating_with_aica":             keep("reliability_rating"),
+	"reliability_rating_without_aica":          keep("reliability_rating"),
+	"security_rating_with_aica":                keep("security_rating"),
+	"security_rating_without_aica":             keep("security_rating"),
+	"security_review_rating_with_aica":         keep("security_review_rating"),
+	"security_review_rating_without_aica":      keep("security_review_rating"),
+	"sqale_rating_with_aica":                   keep("sqale_rating"),
+	"sqale_rating_without_aica":                keep("sqale_rating"),
 
-	// software_quality_* (classic / SQS-only) → classic SQC equivalents.
-	"software_quality_maintainability_debt_ratio":          {"sqale_debt_ratio"},
-	"software_quality_maintainability_rating":              {"sqale_rating"},
-	"software_quality_maintainability_rating_with_aica":    {"sqale_rating"},
-	"software_quality_maintainability_rating_without_aica": {"sqale_rating"},
-	"software_quality_reliability_rating_with_aica":        {"reliability_rating"},
-	"software_quality_reliability_rating_without_aica":     {"reliability_rating"},
-	"software_quality_security_rating":                     {"security_rating"},
-	"software_quality_security_rating_with_aica":           {"security_rating"},
-	"software_quality_security_rating_without_aica":        {"security_rating"},
+	// software_quality_* (SQS-only) → classic SQC equivalents, preserve
+	// op + threshold.
+	"software_quality_maintainability_debt_ratio":          keep("sqale_debt_ratio"),
+	"software_quality_maintainability_rating":              keep("sqale_rating"),
+	"software_quality_maintainability_rating_with_aica":    keep("sqale_rating"),
+	"software_quality_maintainability_rating_without_aica": keep("sqale_rating"),
+	"software_quality_reliability_rating_with_aica":        keep("reliability_rating"),
+	"software_quality_reliability_rating_without_aica":     keep("reliability_rating"),
+	"software_quality_security_rating":                     keep("security_rating"),
+	"software_quality_security_rating_with_aica":           keep("security_rating"),
+	"software_quality_security_rating_without_aica":        keep("security_rating"),
 
-	// new_software_quality_* → new_* equivalents.
-	"new_software_quality_maintainability_debt_ratio":          {"new_sqale_debt_ratio"},
-	"new_software_quality_maintainability_issues":              {"new_issues"},
-	"new_software_quality_maintainability_rating":              {"new_sqale_debt_ratio"},
-	"new_software_quality_maintainability_rating_with_aica":    {"new_maintainability_rating"},
-	"new_software_quality_maintainability_rating_without_aica": {"new_maintainability_rating"},
-	"new_software_quality_reliability_rating":                  {"new_reliability_rating"},
-	"new_software_quality_reliability_rating_with_aica":        {"new_reliability_rating"},
-	"new_software_quality_reliability_rating_without_aica":     {"new_reliability_rating"},
-	"new_software_quality_security_rating":                     {"new_security_rating"},
+	// new_software_quality_* → new_* equivalents, preserve op + threshold.
+	"new_software_quality_maintainability_debt_ratio":          keep("new_sqale_debt_ratio"),
+	"new_software_quality_maintainability_issues":              keep("new_issues"),
+	"new_software_quality_maintainability_rating":              keep("new_maintainability_rating"),
+	"new_software_quality_maintainability_rating_with_aica":    keep("new_maintainability_rating"),
+	"new_software_quality_maintainability_rating_without_aica": keep("new_maintainability_rating"),
+	"new_software_quality_reliability_rating":                  keep("new_reliability_rating"),
+	"new_software_quality_reliability_rating_with_aica":        keep("new_reliability_rating"),
+	"new_software_quality_reliability_rating_without_aica":     keep("new_reliability_rating"),
+	"new_software_quality_security_rating":                     keep("new_security_rating"),
 
-	// Composite mappings — one source condition becomes multiple target
-	// conditions, each preserving the source op and threshold. The set of
-	// target metrics matches the right-hand column of issue #143.
-	"software_quality_blocker_issues": {"security_review_rating", "reliability_rating"},
-	"software_quality_high_issues":    {"security_review_rating", "reliability_rating"},
-	"software_quality_medium_issues":  {"security_review_rating", "reliability_rating"},
-	"software_quality_low_issues":     {"security_rating", "reliability_rating"},
-	"software_quality_info_issues":    {"security_rating", "reliability_rating"},
+	// new_software_quality_*_issues — table specifies a single rating
+	// condition with a fixed threshold (≤ A).
+	"new_software_quality_reliability_issues": {ratingWorseThan("new_reliability_rating", "A")},
+	"new_software_quality_security_issues":    {ratingWorseThan("new_security_rating", "A")},
 
-	"new_software_quality_blocker_issues": {"new_security_review_rating", "new_reliability_rating"},
-	"new_software_quality_high_issues":    {"new_security_review_rating", "new_reliability_rating"},
-	"new_software_quality_medium_issues":  {"new_security_review_rating", "new_reliability_rating"},
-	"new_software_quality_low_issues":     {"new_security_review_rating", "new_reliability_rating"},
-	"new_software_quality_info_issues":    {"new_security_review_rating", "new_reliability_rating"},
+	// new_software_quality_security_rating_with_aica / _without_aica →
+	// new_security_rating with a fixed ≤ A threshold per the table.
+	"new_software_quality_security_rating_with_aica":    {ratingWorseThan("new_security_rating", "A")},
+	"new_software_quality_security_rating_without_aica": {ratingWorseThan("new_security_rating", "A")},
 
-	"new_software_quality_reliability_issues": {"new_reliability_rating"},
-	"new_software_quality_security_issues":    {"new_security_rating"},
+	// Composite mappings for software_quality_*_issues. The right-hand side
+	// of the issue table is "metricA <= X + metricB <= X".
+	"software_quality_blocker_issues": {
+		ratingWorseThan("security_review_rating", "D"),
+		ratingWorseThan("reliability_rating", "D"),
+	},
+	"software_quality_high_issues": {
+		ratingWorseThan("security_review_rating", "C"),
+		ratingWorseThan("reliability_rating", "C"),
+	},
+	"software_quality_medium_issues": {
+		ratingWorseThan("security_review_rating", "B"),
+		ratingWorseThan("reliability_rating", "B"),
+	},
+	"software_quality_low_issues": {
+		ratingWorseThan("security_rating", "A"),
+		ratingWorseThan("reliability_rating", "A"),
+	},
+	"software_quality_info_issues": {
+		ratingWorseThan("security_rating", "A"),
+		ratingWorseThan("reliability_rating", "A"),
+	},
+
+	// new_software_quality_*_issues — the issue table shows the same
+	// metric repeated twice (e.g. "new_security_review_rating <= D +
+	// new_security_review_rating <= D"). Follow the table literally — if
+	// SQC rejects the duplicate, the second CreateCondition surfaces a
+	// warning in the run log.
+	"new_software_quality_blocker_issues": {
+		ratingWorseThan("new_security_review_rating", "D"),
+		ratingWorseThan("new_security_review_rating", "D"),
+	},
+	"new_software_quality_high_issues": {
+		ratingWorseThan("new_security_review_rating", "C"),
+		ratingWorseThan("new_security_review_rating", "C"),
+	},
+	"new_software_quality_medium_issues": {
+		ratingWorseThan("new_security_review_rating", "B"),
+		ratingWorseThan("new_security_review_rating", "B"),
+	},
+	"new_software_quality_low_issues": {
+		ratingWorseThan("new_security_review_rating", "A"),
+		ratingWorseThan("new_security_review_rating", "A"),
+	},
+	"new_software_quality_info_issues": {
+		ratingWorseThan("new_security_review_rating", "A"),
+		ratingWorseThan("new_security_review_rating", "A"),
+	},
 
 	// Source metrics with no meaningful SQC equivalent — drop the condition.
-	"contains_ai_code":                                 {},
+	"contains_ai_code": {},
 	"effort_to_reach_software_quality_maintainability_rating_a": {},
-	"filename_size":                                    {},
-	"filename_size_rating":                             {},
-	"ncloc_with_aica":                                  {},
-	"ncloc_without_aica":                               {},
+	"filename_size":          {},
+	"filename_size_rating":   {},
+	"ncloc_with_aica":        {},
+	"ncloc_without_aica":     {},
 	"new_software_quality_maintainability_remediation_effort": {},
 	"new_software_quality_reliability_remediation_effort":     {},
 	"new_software_quality_security_remediation_effort":        {},
-	"prioritized_rule_issues":                          {},
-	"releasability_rating":                             {},
-	"releasability_rating_with_aica":                   {},
-	"releasability_rating_without_aica":                {},
-	"software_quality_maintainability_issues":          {},
-	"software_quality_maintainability_remediation_effort": {},
-	"software_quality_reliability_issues":              {},
-	"software_quality_reliability_rating":              {},
-	"software_quality_reliability_remediation_effort":  {},
-	"software_quality_security_issues":                 {},
-	"software_quality_security_remediation_effort":     {},
+	"prioritized_rule_issues":                                 {},
+	"releasability_rating":                                    {},
+	"releasability_rating_with_aica":                          {},
+	"releasability_rating_without_aica":                       {},
+	"software_quality_maintainability_issues":                 {},
+	"software_quality_maintainability_remediation_effort":     {},
+	"software_quality_reliability_issues":                     {},
+	"software_quality_reliability_rating":                     {},
+	"software_quality_reliability_remediation_effort":         {},
+	"software_quality_security_issues":                        {},
+	"software_quality_security_remediation_effort":            {},
 }
 
-// lookupMetricReplacement returns the list of SonarQube Cloud metrics that
-// should be used in place of the given source metric. The bool indicates
-// whether the source metric is known to the mapping table:
+// lookupMetricReplacement returns the list of SonarQube Cloud target
+// conditions that should replace a SonarQube Server quality-gate condition
+// on the given source metric. The bool indicates whether the source metric
+// is known to the mapping table:
 //
-//   - ok=true,  len(targets)>0  → replace with these target metric(s)
+//   - ok=true,  len(targets)>0  → expand to the listed target conditions
 //   - ok=true,  len(targets)==0 → drop the condition (no SQC equivalent)
 //   - ok=false                  → metric exists verbatim on SQC, pass through
-func lookupMetricReplacement(sourceMetric string) (targets []string, ok bool) {
+func lookupMetricReplacement(sourceMetric string) (targets []replacementCondition, ok bool) {
 	t, ok := metricMapping[sourceMetric]
 	return t, ok
 }

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -1,0 +1,133 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/sonar-solutions/sq-api-go/types"
+)
+
+func TestLookupMetricReplacement(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantOK  bool
+		wantOut []string
+	}{
+		{"unmapped passes through", "coverage", false, nil},
+		{"aica suffix dropped", "new_security_rating_with_aica", true, []string{"new_security_rating"}},
+		{"software_quality_* rating", "software_quality_security_rating", true, []string{"security_rating"}},
+		{"debt ratio rename", "software_quality_maintainability_debt_ratio", true, []string{"sqale_debt_ratio"}},
+		{"composite — software_quality_blocker_issues",
+			"software_quality_blocker_issues",
+			true, []string{"security_review_rating", "reliability_rating"}},
+		{"no SQC equivalent → drop",
+			"contains_ai_code", true, []string{}},
+		{"new_software_quality_maintainability_issues → new_issues",
+			"new_software_quality_maintainability_issues", true, []string{"new_issues"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := lookupMetricReplacement(tc.input)
+			if ok != tc.wantOK {
+				t.Fatalf("ok: got %v, want %v", ok, tc.wantOK)
+			}
+			if len(got) != len(tc.wantOut) {
+				t.Fatalf("targets length: got %v, want %v", got, tc.wantOut)
+			}
+			for i := range got {
+				if got[i] != tc.wantOut[i] {
+					t.Errorf("targets[%d]: got %q, want %q", i, got[i], tc.wantOut[i])
+				}
+			}
+		})
+	}
+}
+
+// TestAddGateConditionsAppliesMetricMapping exercises the end-to-end
+// path: source conditions on mapped/unmapped/dropped metrics, asserting
+// the CreateCondition payloads the migrator actually sends to SQC.
+func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		recorded []map[string]string
+	)
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		recorded = append(recorded, map[string]string{
+			"metric": r.FormValue("metric"),
+			"op":     r.FormValue("op"),
+			"error":  r.FormValue("error"),
+		})
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// Mix of source metrics:
+	//  - coverage (unmapped, pass-through)
+	//  - new_security_rating_with_aica (1:1 rename)
+	//  - software_quality_blocker_issues (composite: 2 conditions)
+	//  - contains_ai_code (no SQC equivalent → dropped, NO HTTP call)
+	w, _ := e.Store.Writer("getGateConditions")
+	payload := map[string]any{
+		"gate_name":          "Custom",
+		"sonarcloud_org_key": "cloud-org1",
+		"cloud_gate_id":      "42",
+		"was_preexisting":    false,
+		"conditions": []map[string]any{
+			{"metric": "coverage", "op": "LT", "error": "80"},
+			{"metric": "new_security_rating_with_aica", "op": "GT", "error": "1"},
+			{"metric": "software_quality_blocker_issues", "op": "GT", "error": "0"},
+			{"metric": "contains_ai_code", "op": "GT", "error": "0"},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	w.WriteOne(b)
+
+	if err := runAddGateConditions(context.Background(), e); err != nil {
+		t.Fatalf("runAddGateConditions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Expected: 1 (coverage) + 1 (new_security_rating) + 2 (composite) = 4
+	if len(recorded) != 4 {
+		t.Fatalf("expected 4 create_condition calls (1 + 1 + 2, with contains_ai_code dropped), got %d: %v",
+			len(recorded), recorded)
+	}
+	metrics := make([]string, 0, len(recorded))
+	for _, r := range recorded {
+		metrics = append(metrics, r["metric"])
+	}
+	sort.Strings(metrics)
+	want := []string{"coverage", "new_security_rating", "reliability_rating", "security_review_rating"}
+	for i := range want {
+		if metrics[i] != want[i] {
+			t.Errorf("metrics[%d]: got %q, want %q (full=%v)", i, metrics[i], want[i], metrics)
+		}
+	}
+	// contains_ai_code should never reach create_condition.
+	for _, r := range recorded {
+		if r["metric"] == "contains_ai_code" {
+			t.Errorf("contains_ai_code should have been dropped, but a CreateCondition call was made: %v", r)
+		}
+	}
+}

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -14,22 +14,59 @@ import (
 
 func TestLookupMetricReplacement(t *testing.T) {
 	cases := []struct {
-		name    string
-		input   string
-		wantOK  bool
-		wantOut []string
+		name   string
+		input  string
+		wantOK bool
+		want   []replacementCondition
 	}{
 		{"unmapped passes through", "coverage", false, nil},
-		{"aica suffix dropped", "new_security_rating_with_aica", true, []string{"new_security_rating"}},
-		{"software_quality_* rating", "software_quality_security_rating", true, []string{"security_rating"}},
-		{"debt ratio rename", "software_quality_maintainability_debt_ratio", true, []string{"sqale_debt_ratio"}},
-		{"composite — software_quality_blocker_issues",
-			"software_quality_blocker_issues",
-			true, []string{"security_review_rating", "reliability_rating"}},
+		{"aica suffix dropped — preserves op/error",
+			"new_security_rating_with_aica", true,
+			[]replacementCondition{{Metric: "new_security_rating"}}},
+		{"software_quality_security_rating",
+			"software_quality_security_rating", true,
+			[]replacementCondition{{Metric: "security_rating"}}},
+		{"debt ratio rename",
+			"software_quality_maintainability_debt_ratio", true,
+			[]replacementCondition{{Metric: "sqale_debt_ratio"}}},
+		{"composite — software_quality_blocker_issues with fixed <= D",
+			"software_quality_blocker_issues", true,
+			[]replacementCondition{
+				{Metric: "security_review_rating", Op: "GT", Error: "4"},
+				{Metric: "reliability_rating", Op: "GT", Error: "4"},
+			}},
+		{"composite — software_quality_low_issues with <= A",
+			"software_quality_low_issues", true,
+			[]replacementCondition{
+				{Metric: "security_rating", Op: "GT", Error: "1"},
+				{Metric: "reliability_rating", Op: "GT", Error: "1"},
+			}},
+		{"new_software_quality_blocker_issues — duplicate target per issue table",
+			"new_software_quality_blocker_issues", true,
+			[]replacementCondition{
+				{Metric: "new_security_review_rating", Op: "GT", Error: "4"},
+				{Metric: "new_security_review_rating", Op: "GT", Error: "4"},
+			}},
+		{"new_software_quality_maintainability_rating → new_maintainability_rating",
+			"new_software_quality_maintainability_rating", true,
+			[]replacementCondition{{Metric: "new_maintainability_rating"}}},
+		{"new_software_quality_reliability_issues → new_reliability_rating <= A",
+			"new_software_quality_reliability_issues", true,
+			[]replacementCondition{{Metric: "new_reliability_rating", Op: "GT", Error: "1"}}},
+		{"new_software_quality_security_issues → new_security_rating <= A",
+			"new_software_quality_security_issues", true,
+			[]replacementCondition{{Metric: "new_security_rating", Op: "GT", Error: "1"}}},
+		{"new_software_quality_security_rating_with_aica → new_security_rating <= A",
+			"new_software_quality_security_rating_with_aica", true,
+			[]replacementCondition{{Metric: "new_security_rating", Op: "GT", Error: "1"}}},
+		{"new_software_quality_security_rating_without_aica → new_security_rating <= A",
+			"new_software_quality_security_rating_without_aica", true,
+			[]replacementCondition{{Metric: "new_security_rating", Op: "GT", Error: "1"}}},
 		{"no SQC equivalent → drop",
-			"contains_ai_code", true, []string{}},
+			"contains_ai_code", true, []replacementCondition{}},
 		{"new_software_quality_maintainability_issues → new_issues",
-			"new_software_quality_maintainability_issues", true, []string{"new_issues"}},
+			"new_software_quality_maintainability_issues", true,
+			[]replacementCondition{{Metric: "new_issues"}}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -37,34 +74,36 @@ func TestLookupMetricReplacement(t *testing.T) {
 			if ok != tc.wantOK {
 				t.Fatalf("ok: got %v, want %v", ok, tc.wantOK)
 			}
-			if len(got) != len(tc.wantOut) {
-				t.Fatalf("targets length: got %v, want %v", got, tc.wantOut)
+			if len(got) != len(tc.want) {
+				t.Fatalf("targets length: got %v, want %v", got, tc.want)
 			}
 			for i := range got {
-				if got[i] != tc.wantOut[i] {
-					t.Errorf("targets[%d]: got %q, want %q", i, got[i], tc.wantOut[i])
+				if got[i] != tc.want[i] {
+					t.Errorf("targets[%d]: got %+v, want %+v", i, got[i], tc.want[i])
 				}
 			}
 		})
 	}
 }
 
-// TestAddGateConditionsAppliesMetricMapping exercises the end-to-end
-// path: source conditions on mapped/unmapped/dropped metrics, asserting
-// the CreateCondition payloads the migrator actually sends to SQC.
+// TestAddGateConditionsAppliesMetricMapping exercises the end-to-end path:
+// source conditions on mapped/unmapped/dropped metrics, asserting the
+// CreateCondition payloads (metric + op + threshold) the migrator actually
+// sends to SQC.
 func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
+	type call struct{ metric, op, errVal string }
 	var (
 		mu       sync.Mutex
-		recorded []map[string]string
+		recorded []call
 	)
 	cloudMux := http.NewServeMux()
 	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		mu.Lock()
-		recorded = append(recorded, map[string]string{
-			"metric": r.FormValue("metric"),
-			"op":     r.FormValue("op"),
-			"error":  r.FormValue("error"),
+		recorded = append(recorded, call{
+			metric: r.FormValue("metric"),
+			op:     r.FormValue("op"),
+			errVal: r.FormValue("error"),
 		})
 		mu.Unlock()
 		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
@@ -82,9 +121,9 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
 
 	// Mix of source metrics:
-	//  - coverage (unmapped, pass-through)
-	//  - new_security_rating_with_aica (1:1 rename)
-	//  - software_quality_blocker_issues (composite: 2 conditions)
+	//  - coverage (unmapped, pass-through, preserves source op/error)
+	//  - new_security_rating_with_aica (1:1 rename, preserves source op/error)
+	//  - software_quality_blocker_issues (composite: 2 conditions, fixed <= D)
 	//  - contains_ai_code (no SQC equivalent → dropped, NO HTTP call)
 	w, _ := e.Store.Writer("getGateConditions")
 	payload := map[string]any{
@@ -108,26 +147,40 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
-	// Expected: 1 (coverage) + 1 (new_security_rating) + 2 (composite) = 4
+
+	// Expected: 1 (coverage, LT 80) + 1 (new_security_rating, inherited GT 1)
+	//         + 2 (security_review_rating GT 4, reliability_rating GT 4)
+	//         + 0 (contains_ai_code dropped)
 	if len(recorded) != 4 {
-		t.Fatalf("expected 4 create_condition calls (1 + 1 + 2, with contains_ai_code dropped), got %d: %v",
-			len(recorded), recorded)
+		t.Fatalf("expected 4 create_condition calls, got %d: %+v", len(recorded), recorded)
 	}
-	metrics := make([]string, 0, len(recorded))
-	for _, r := range recorded {
-		metrics = append(metrics, r["metric"])
+
+	want := map[string]call{
+		"coverage":               {metric: "coverage", op: "LT", errVal: "80"},
+		"new_security_rating":    {metric: "new_security_rating", op: "GT", errVal: "1"},
+		"security_review_rating": {metric: "security_review_rating", op: "GT", errVal: "4"},
+		"reliability_rating":     {metric: "reliability_rating", op: "GT", errVal: "4"},
 	}
-	sort.Strings(metrics)
-	want := []string{"coverage", "new_security_rating", "reliability_rating", "security_review_rating"}
-	for i := range want {
-		if metrics[i] != want[i] {
-			t.Errorf("metrics[%d]: got %q, want %q (full=%v)", i, metrics[i], want[i], metrics)
+
+	keys := make([]string, 0, len(recorded))
+	for _, c := range recorded {
+		keys = append(keys, c.metric)
+	}
+	sort.Strings(keys)
+	wantKeys := []string{"coverage", "new_security_rating", "reliability_rating", "security_review_rating"}
+	for i := range wantKeys {
+		if keys[i] != wantKeys[i] {
+			t.Fatalf("metrics: got %v, want %v", keys, wantKeys)
 		}
 	}
-	// contains_ai_code should never reach create_condition.
-	for _, r := range recorded {
-		if r["metric"] == "contains_ai_code" {
-			t.Errorf("contains_ai_code should have been dropped, but a CreateCondition call was made: %v", r)
+	for _, c := range recorded {
+		w := want[c.metric]
+		if c.op != w.op || c.errVal != w.errVal {
+			t.Errorf("%s: got op=%q error=%q, want op=%q error=%q",
+				c.metric, c.op, c.errVal, w.op, w.errVal)
+		}
+		if c.metric == "contains_ai_code" {
+			t.Errorf("contains_ai_code should have been dropped, but a CreateCondition call was made: %+v", c)
 		}
 	}
 }

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -105,6 +105,8 @@ func runSetProjectGates(ctx context.Context, e *Executor) error {
 			if !ok {
 				return nil
 			}
+			e.Logger.Debug("gate api call: POST /api/qualitygates/select",
+				"gate_id", gateID, "gate_name", gateName, "project", projectKey, "org", orgKey)
 			if err := e.Cloud.QualityGates.Select(ctx, gateID, projectKey, orgKey); err != nil {
 				counter.Fail()
 				logAPIWarn(e.Logger, "setProjectGates failed", err, "project", projectKey)

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -113,14 +113,26 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
 			gateIDStr := extractField(item, "cloud_gate_id")
+			gateName := extractField(item, "gate_name")
+			wasPreexisting := extractBool(item, "was_preexisting")
 			if shouldSkipOrg(orgKey) || gateIDStr == "" {
 				return nil
 			}
 			gateID, _ := strconv.Atoi(gateIDStr)
 
+			// Override semantics: if the target gate already existed on SQC,
+			// wipe its current conditions first so the migrated set is the
+			// authoritative one — never a union of source + whatever was
+			// already on the target.
+			if wasPreexisting {
+				clearTargetGateConditions(ctx, e, counter, gateName, orgKey)
+			}
+
 			// Extract conditions from the gate data.
 			var obj map[string]json.RawMessage
-			json.Unmarshal(item, &obj)
+			if err := json.Unmarshal(item, &obj); err != nil {
+				return nil
+			}
 			conditionsRaw, ok := obj["conditions"]
 			if !ok {
 				return nil
@@ -150,6 +162,35 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 		})
 	counter.LogSummary(e.Logger)
 	return err
+}
+
+// clearTargetGateConditions removes every condition from a pre-existing target
+// quality gate before the migrated source conditions are added. Failures here
+// are logged at Warn level but do not abort the migration — the subsequent
+// CreateCondition calls will surface a conflict if the cleanup did not take
+// effect.
+func clearTargetGateConditions(ctx context.Context, e *Executor, counter *TaskCounter, gateName, orgKey string) {
+	if gateName == "" {
+		return
+	}
+	gate, err := e.Cloud.QualityGates.Show(ctx, gateName, orgKey)
+	if err != nil {
+		logAPIWarn(e.Logger, "addGateConditions: show gate failed during override cleanup", err,
+			"gate", gateName)
+		return
+	}
+	for _, cond := range gate.Conditions {
+		if cond.ID == 0 {
+			continue
+		}
+		if err := e.Cloud.QualityGates.DeleteCondition(ctx, cond.ID, orgKey); err != nil {
+			counter.Fail()
+			logAPIWarn(e.Logger, "addGateConditions: delete existing condition failed", err,
+				"gate", gateName, "condition_id", cond.ID, "metric", cond.Metric)
+		}
+	}
+	e.Logger.Info("addGateConditions: cleared pre-existing conditions on overridden gate",
+		"gate", gateName, "count", len(gate.Conditions))
 }
 
 func runSetDefaultProfiles(ctx context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -108,6 +108,11 @@ func runRestoreProfiles(ctx context.Context, e *Executor) error {
 }
 
 func runAddGateConditions(ctx context.Context, e *Executor) error {
+	// Sidecar JSONL recording per-condition mapping notes — used by the
+	// summary report to mark a quality gate as Partial when some of its
+	// conditions were either remapped to a close SQC equivalent (#143) or
+	// dropped because no SQC equivalent exists.
+	notesW, _ := e.Store.Writer("addGateConditions.notes")
 	counter := NewTaskCounter("addGateConditions")
 	err := forEachMigrateItem(ctx, e, "addGateConditions", "getGateConditions",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
@@ -152,6 +157,7 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 				if mapped && len(targets) == 0 {
 					e.Logger.Warn("addGateConditions: source metric has no SonarQube Cloud equivalent — condition skipped (#143)",
 						"gate", gateName, "metric", metric, "op", op, "error", errorVal)
+					recordGateConditionNote(notesW, gateIDStr, gateName, "dropped", metric, nil)
 					counter.Fail()
 					continue
 				}
@@ -160,6 +166,11 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 				} else {
 					e.Logger.Info("addGateConditions: source metric remapped to SonarQube Cloud equivalent(s) (#143)",
 						"gate", gateName, "source_metric", metric, "target_metrics", targets)
+					targetMetrics := make([]string, 0, len(targets))
+					for _, repl := range targets {
+						targetMetrics = append(targetMetrics, repl.Metric)
+					}
+					recordGateConditionNote(notesW, gateIDStr, gateName, "remapped", metric, targetMetrics)
 				}
 
 				for _, repl := range targets {
@@ -191,6 +202,27 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 		})
 	counter.LogSummary(e.Logger)
 	return err
+}
+
+// recordGateConditionNote appends a sidecar JSONL entry describing a
+// per-condition mapping decision (a metric remap per #143 or a dropped
+// condition with no SQC equivalent). The summary report reads this file to
+// mark the parent quality gate as Partial.
+func recordGateConditionNote(w *common.ChunkWriter, cloudGateID, gateName, action, sourceMetric string, targetMetrics []string) {
+	if w == nil || cloudGateID == "" {
+		return
+	}
+	rec := map[string]any{
+		"cloud_gate_id": cloudGateID,
+		"gate_name":     gateName,
+		"action":        action, // "remapped" | "dropped"
+		"source_metric": sourceMetric,
+	}
+	if len(targetMetrics) > 0 {
+		rec["target_metrics"] = targetMetrics
+	}
+	b, _ := json.Marshal(rec)
+	_ = w.WriteOne(b)
 }
 
 // clearTargetGateConditions removes every condition from a pre-existing target

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -147,6 +147,8 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 				if metric == "" || op == "" {
 					continue
 				}
+				e.Logger.Debug("gate api call: POST /api/qualitygates/create_condition",
+					"gate_id", gateID, "metric", metric, "op", op, "error", errorVal, "org", orgKey)
 				_, err := e.Cloud.QualityGates.CreateCondition(ctx, cloud.CreateConditionParams{
 					GateID: gateID, Organization: orgKey,
 					Metric: metric, Op: op, Error: errorVal,
@@ -173,6 +175,8 @@ func clearTargetGateConditions(ctx context.Context, e *Executor, counter *TaskCo
 	if gateName == "" {
 		return
 	}
+	e.Logger.Debug("gate api call: GET /api/qualitygates/show",
+		"name", gateName, "org", orgKey)
 	gate, err := e.Cloud.QualityGates.Show(ctx, gateName, orgKey)
 	if err != nil {
 		logAPIWarn(e.Logger, "addGateConditions: show gate failed during override cleanup", err,
@@ -183,6 +187,8 @@ func clearTargetGateConditions(ctx context.Context, e *Executor, counter *TaskCo
 		if cond.ID == 0 {
 			continue
 		}
+		e.Logger.Debug("gate api call: POST /api/qualitygates/delete_condition",
+			"gate", gateName, "condition_id", cond.ID, "metric", cond.Metric, "org", orgKey)
 		if err := e.Cloud.QualityGates.DeleteCondition(ctx, cond.ID, orgKey); err != nil {
 			counter.Fail()
 			logAPIWarn(e.Logger, "addGateConditions: delete existing condition failed", err,
@@ -226,8 +232,11 @@ func runSetDefaultGates(ctx context.Context, e *Executor) error {
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
 			gateIDStr := extractField(item, "cloud_gate_id")
+			gateName := extractField(item, "name")
 			gateID, _ := strconv.Atoi(gateIDStr)
 
+			e.Logger.Debug("gate api call: POST /api/qualitygates/set_as_default",
+				"name", gateName, "gate_id", gateIDStr, "org", orgKey)
 			err := e.Cloud.QualityGates.SetDefault(ctx, gateID, orgKey)
 			if err != nil {
 				counter.Fail()

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -147,17 +147,36 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 				if metric == "" || op == "" {
 					continue
 				}
-				e.Logger.Debug("gate api call: POST /api/qualitygates/create_condition",
-					"gate_id", gateID, "metric", metric, "op", op, "error", errorVal, "org", orgKey)
-				_, err := e.Cloud.QualityGates.CreateCondition(ctx, cloud.CreateConditionParams{
-					GateID: gateID, Organization: orgKey,
-					Metric: metric, Op: op, Error: errorVal,
-				})
-				if err != nil {
+
+				targets, mapped := lookupMetricReplacement(metric)
+				if mapped && len(targets) == 0 {
+					e.Logger.Warn("addGateConditions: source metric has no SonarQube Cloud equivalent — condition skipped (#143)",
+						"gate", gateName, "metric", metric, "op", op, "error", errorVal)
 					counter.Fail()
-					logAPIWarn(e.Logger, "addGateConditions failed", err, "metric", metric)
+					continue
+				}
+				if !mapped {
+					targets = []string{metric}
 				} else {
-					counter.Success()
+					e.Logger.Info("addGateConditions: source metric remapped to SonarQube Cloud equivalent(s) (#143)",
+						"gate", gateName, "source_metric", metric, "target_metrics", targets)
+				}
+
+				for _, targetMetric := range targets {
+					e.Logger.Debug("gate api call: POST /api/qualitygates/create_condition",
+						"gate_id", gateID, "metric", targetMetric, "op", op, "error", errorVal, "org", orgKey,
+						"source_metric", metric)
+					_, err := e.Cloud.QualityGates.CreateCondition(ctx, cloud.CreateConditionParams{
+						GateID: gateID, Organization: orgKey,
+						Metric: targetMetric, Op: op, Error: errorVal,
+					})
+					if err != nil {
+						counter.Fail()
+						logAPIWarn(e.Logger, "addGateConditions failed", err,
+							"metric", targetMetric, "source_metric", metric)
+					} else {
+						counter.Success()
+					}
 				}
 			}
 			return nil

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -156,24 +156,32 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 					continue
 				}
 				if !mapped {
-					targets = []string{metric}
+					targets = []replacementCondition{{Metric: metric}}
 				} else {
 					e.Logger.Info("addGateConditions: source metric remapped to SonarQube Cloud equivalent(s) (#143)",
 						"gate", gateName, "source_metric", metric, "target_metrics", targets)
 				}
 
-				for _, targetMetric := range targets {
+				for _, repl := range targets {
+					effOp := repl.Op
+					if effOp == "" {
+						effOp = op
+					}
+					effErr := repl.Error
+					if effErr == "" {
+						effErr = errorVal
+					}
 					e.Logger.Debug("gate api call: POST /api/qualitygates/create_condition",
-						"gate_id", gateID, "metric", targetMetric, "op", op, "error", errorVal, "org", orgKey,
+						"gate_id", gateID, "metric", repl.Metric, "op", effOp, "error", effErr, "org", orgKey,
 						"source_metric", metric)
 					_, err := e.Cloud.QualityGates.CreateCondition(ctx, cloud.CreateConditionParams{
 						GateID: gateID, Organization: orgKey,
-						Metric: targetMetric, Op: op, Error: errorVal,
+						Metric: repl.Metric, Op: effOp, Error: effErr,
 					})
 					if err != nil {
 						counter.Fail()
 						logAPIWarn(e.Logger, "addGateConditions failed", err,
-							"metric", targetMetric, "source_metric", metric)
+							"metric", repl.Metric, "source_metric", metric)
 					} else {
 						counter.Success()
 					}

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -151,6 +151,8 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 			}
 			name := extractField(item, "name")
 
+			e.Logger.Debug("gate api call: POST /api/qualitygates/create",
+				"name", name, "org", orgKey)
 			var gateID string
 			wasPreexisting := false
 			gate, err := e.Cloud.QualityGates.Create(ctx, name, orgKey)
@@ -161,6 +163,8 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 					return nil
 				}
 				e.Logger.Info("createGates: already exists, will override conditions", "name", name)
+				e.Logger.Debug("gate api call: GET /api/qualitygates/list (lookup)",
+					"name", name, "org", orgKey)
 				gateID, err = lookupExistingGate(ctx, e.Raw, name, orgKey)
 				if err != nil {
 					counter.Fail()
@@ -169,9 +173,13 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 				}
 				wasPreexisting = true
 				counter.Success()
+				e.Logger.Debug("gate operation: reusing existing gate",
+					"name", name, "gate_id", gateID, "org", orgKey)
 			} else {
 				counter.Success()
 				gateID = strconv.Itoa(gate.ID)
+				e.Logger.Debug("gate operation: created new gate",
+					"name", name, "gate_id", gateID, "org", orgKey)
 			}
 
 			result := common.EnrichRaw(item, map[string]any{

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -152,6 +152,7 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 			name := extractField(item, "name")
 
 			var gateID string
+			wasPreexisting := false
 			gate, err := e.Cloud.QualityGates.Create(ctx, name, orgKey)
 			if err != nil {
 				if !sqapi.IsAlreadyExists(err) {
@@ -159,13 +160,14 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 					logAPIWarn(e.Logger, "createGates: create failed", err, "name", name)
 					return nil
 				}
-				e.Logger.Info("createGates: already exists, looking up", "name", name)
+				e.Logger.Info("createGates: already exists, will override conditions", "name", name)
 				gateID, err = lookupExistingGate(ctx, e.Raw, name, orgKey)
 				if err != nil {
 					counter.Fail()
 					logAPIWarn(e.Logger, "createGates: lookup failed", err, "name", name)
 					return nil
 				}
+				wasPreexisting = true
 				counter.Success()
 			} else {
 				counter.Success()
@@ -175,6 +177,7 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 			result := common.EnrichRaw(item, map[string]any{
 				"cloud_gate_id":      gateID,
 				"sonarcloud_org_key": orgKey,
+				"was_preexisting":    wasPreexisting,
 			})
 			return w.WriteOne(result)
 		})

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -113,8 +113,11 @@ func runDeleteGates(ctx context.Context, e *Executor) error {
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
 			gateIDStr := extractField(item, "cloud_gate_id")
+			gateName := extractField(item, "name")
 			gateID, _ := strconv.Atoi(gateIDStr)
 
+			e.Logger.Debug("gate api call: POST /api/qualitygates/destroy",
+				"name", gateName, "gate_id", gateIDStr, "org", orgKey)
 			err := e.Cloud.QualityGates.Destroy(ctx, gateID, orgKey)
 			if err != nil {
 				counter.Fail()

--- a/go/internal/migrate/tasks_gate_override_test.go
+++ b/go/internal/migrate/tasks_gate_override_test.go
@@ -1,0 +1,165 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/sonar-solutions/sq-api-go/types"
+)
+
+// TestAddGateConditionsOverrideClearsExisting verifies that when a quality
+// gate already existed on SonarQube Cloud (was_preexisting=true on the
+// getGateConditions input), addGateConditions wipes the gate's previous
+// conditions via /api/qualitygates/delete_condition before applying the
+// migrated source set. The end state on SQC matches the source — never a
+// union of the two.
+func TestAddGateConditionsOverrideClearsExisting(t *testing.T) {
+	// Track which condition IDs were deleted and which CreateCondition
+	// payloads were sent, so we can assert the override semantics.
+	var (
+		mu          sync.Mutex
+		deletedIDs  []string
+		createdCnds []map[string]string
+	)
+
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("GET /api/qualitygates/show", func(w http.ResponseWriter, r *http.Request) {
+		// Pretend the existing target gate has two stale conditions.
+		_ = json.NewEncoder(w).Encode(types.QualityGate{
+			ID:   42,
+			Name: r.URL.Query().Get("name"),
+			Conditions: []types.QualityGateCondition{
+				{ID: 900, Metric: "old_metric_a", Op: "GT", Error: "1"},
+				{ID: 901, Metric: "old_metric_b", Op: "LT", Error: "50"},
+			},
+		})
+	})
+	cloudMux.HandleFunc("POST /api/qualitygates/delete_condition", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deletedIDs = append(deletedIDs, r.FormValue("id"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		createdCnds = append(createdCnds, map[string]string{
+			"metric": r.FormValue("metric"),
+			"op":     r.FormValue("op"),
+			"error":  r.FormValue("error"),
+		})
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// Pre-existing gate "Custom Gate" — was_preexisting=true.
+	w, _ := e.Store.Writer("getGateConditions")
+	payload := map[string]any{
+		"gate_name":          "Custom Gate",
+		"sonarcloud_org_key": "cloud-org1",
+		"cloud_gate_id":      "42",
+		"was_preexisting":    true,
+		"conditions": []map[string]any{
+			{"metric": "coverage", "op": "LT", "error": "80"},
+			{"metric": "new_bugs", "op": "GT", "error": "0"},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	w.WriteOne(b)
+
+	if err := runAddGateConditions(context.Background(), e); err != nil {
+		t.Fatalf("runAddGateConditions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Both pre-existing conditions must have been deleted.
+	if len(deletedIDs) != 2 {
+		t.Fatalf("expected 2 delete_condition calls, got %d (ids=%v)", len(deletedIDs), deletedIDs)
+	}
+	got := map[string]bool{deletedIDs[0]: true, deletedIDs[1]: true}
+	if !got["900"] || !got["901"] {
+		t.Errorf("expected delete of condition ids 900 and 901, got %v", deletedIDs)
+	}
+	// The migrated source conditions must have been added afterwards.
+	if len(createdCnds) != 2 {
+		t.Fatalf("expected 2 create_condition calls, got %d", len(createdCnds))
+	}
+	metrics := map[string]bool{createdCnds[0]["metric"]: true, createdCnds[1]["metric"]: true}
+	if !metrics["coverage"] || !metrics["new_bugs"] {
+		t.Errorf("expected coverage and new_bugs in created conditions, got %v", createdCnds)
+	}
+}
+
+// TestAddGateConditionsFreshGateSkipsClear verifies that on a freshly
+// created gate (was_preexisting=false) addGateConditions does NOT call
+// /api/qualitygates/show or /api/qualitygates/delete_condition — there is
+// nothing to clear.
+func TestAddGateConditionsFreshGateSkipsClear(t *testing.T) {
+	var showCalled, deleteCalled bool
+
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("GET /api/qualitygates/show", func(w http.ResponseWriter, _ *http.Request) {
+		showCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+	cloudMux.HandleFunc("POST /api/qualitygates/delete_condition", func(w http.ResponseWriter, _ *http.Request) {
+		deleteCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("getGateConditions")
+	payload := map[string]any{
+		"gate_name":          "Fresh Gate",
+		"sonarcloud_org_key": "cloud-org1",
+		"cloud_gate_id":      "42",
+		"was_preexisting":    false,
+		"conditions": []map[string]any{
+			{"metric": "coverage", "op": "LT", "error": "80"},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	w.WriteOne(b)
+
+	if err := runAddGateConditions(context.Background(), e); err != nil {
+		t.Fatalf("runAddGateConditions: %v", err)
+	}
+
+	if showCalled {
+		t.Error("show endpoint must not be called for a freshly created gate")
+	}
+	if deleteCalled {
+		t.Error("delete_condition must not be called for a freshly created gate")
+	}
+}

--- a/go/internal/migrate/tasks_read.go
+++ b/go/internal/migrate/tasks_read.go
@@ -102,21 +102,48 @@ func runGetGateConditions(ctx context.Context, e *Executor) error {
 			gateName := extractField(item, "source_gate_key")
 			orgKey := extractField(item, "sonarcloud_org_key")
 			serverURL := extractField(item, "server_url")
-			// Read gate conditions from extract data.
-			items, _ := readExtractItems(e, "getGateConditions")
-			for _, ei := range items {
-				eiGate := extractField(ei.Data, "name")
-				if eiGate == gateName && ei.ServerURL == serverURL {
-					enriched := common.EnrichRaw(ei.Data, map[string]any{
-						"sonarcloud_org_key": orgKey,
-						"cloud_gate_id":     extractField(item, "cloud_gate_id"),
-					})
-					if err := w.WriteOne(enriched); err != nil {
-						return err
-					}
-				}
+			cloudGateID := extractField(item, "cloud_gate_id")
+			wasPreexisting := extractBool(item, "was_preexisting")
+			if cloudGateID == "" {
+				return nil
 			}
-			return nil
+
+			// The extract writes one record per source condition, each
+			// enriched with the parent gateName and serverUrl. Group every
+			// matching condition into a single per-gate record so the
+			// downstream addGateConditions task can decide once per gate
+			// whether to clear the target's pre-existing conditions first.
+			extractItems, _ := readExtractItems(e, "getGateConditions")
+			var conditions []map[string]any
+			for _, ei := range extractItems {
+				if extractField(ei.Data, "gateName") != gateName || ei.ServerURL != serverURL {
+					continue
+				}
+				var cond map[string]any
+				if err := json.Unmarshal(ei.Data, &cond); err != nil {
+					continue
+				}
+				// Drop the bookkeeping fields the extract added — only the
+				// condition payload itself is useful downstream.
+				delete(cond, "gateName")
+				delete(cond, "serverUrl")
+				conditions = append(conditions, cond)
+			}
+			if len(conditions) == 0 && !wasPreexisting {
+				return nil
+			}
+
+			out, err := json.Marshal(map[string]any{
+				"gate_name":          gateName,
+				"sonarcloud_org_key": orgKey,
+				"cloud_gate_id":      cloudGateID,
+				"was_preexisting":    wasPreexisting,
+				"conditions":         conditions,
+			})
+			if err != nil {
+				return err
+			}
+			return w.WriteOne(out)
 		})
 }
 

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -374,11 +374,12 @@ func setupExtractData(dir string) {
 	writeJSON(filepath.Join(extractDir, "extract.json"),
 		map[string]any{"url": testServerURL, "edition": "enterprise"})
 
-	// Gate conditions.
+	// Gate conditions. The real extract task (api/qualitygates/show →
+	// enrichAll(conditions, ...)) writes one record per condition, each
+	// enriched with the parent gateName and serverUrl. Match that shape so
+	// runGetGateConditions sees the join key it expects.
 	writeJSONL(filepath.Join(extractDir, "getGateConditions"), []map[string]any{
-		{"name": "Custom Gate", "conditions": []map[string]any{
-			{"metric": "coverage", "op": "LT", "error": "80"},
-		}, "serverUrl": testServerURL},
+		{"metric": "coverage", "op": "LT", "error": "80", "gateName": "Custom Gate", "serverUrl": testServerURL},
 	})
 
 	// Profile backups.

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -99,6 +99,15 @@ func collectSection(store *common.DataStore, def sectionDef,
 		}
 	}
 
+	// Quality gates whose conditions were remapped (#143) or dropped
+	// because no SQC equivalent exists are reported as Partial. The
+	// per-condition decisions are written by addGateConditions to a
+	// sidecar JSONL.
+	if def.Name == "Quality Gates" {
+		notes := collectGateMappingNotes(store.BaseDir())
+		succeeded, partial = applyGateMappingNotes(succeeded, partial, notes)
+	}
+
 	return Section{
 		Name:      def.Name,
 		Succeeded: succeeded,

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -523,6 +523,88 @@ func portfolioNames(items []EntityItem) []string {
 	return out
 }
 
+func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	// Two gates created. Only one of them has a sidecar mapping note.
+	writeTaskJSONL(t, runDir, "createGates", []map[string]any{
+		{"name": "Backend QG", "sonarcloud_org_key": "org1", "cloud_gate_id": "42"},
+		{"name": "Frontend QG", "sonarcloud_org_key": "org1", "cloud_gate_id": "99"},
+	})
+
+	// addGateConditions.notes — sidecar JSONL recording per-condition
+	// remap (#143) + dropped decisions for the Backend QG.
+	notesDir := filepath.Join(runDir, "addGateConditions.notes")
+	os.MkdirAll(notesDir, 0o755)
+	lines := []map[string]any{
+		{
+			"cloud_gate_id":  "42",
+			"gate_name":      "Backend QG",
+			"action":         "remapped",
+			"source_metric":  "new_security_rating_with_aica",
+			"target_metrics": []string{"new_security_rating"},
+		},
+		{
+			"cloud_gate_id": "42",
+			"gate_name":     "Backend QG",
+			"action":        "dropped",
+			"source_metric": "contains_ai_code",
+		},
+	}
+	f, _ := os.Create(filepath.Join(notesDir, "results.1.jsonl"))
+	for _, line := range lines {
+		b, _ := json.Marshal(line)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	gates := findSection(summary, "Quality Gates")
+	if gates == nil {
+		t.Fatal("missing Quality Gates section")
+	}
+
+	// Backend QG should be moved to Partial; Frontend QG should remain
+	// in Succeeded untouched.
+	if len(gates.Succeeded) != 1 || gates.Succeeded[0].Name != "Frontend QG" {
+		t.Errorf("expected Frontend QG to remain in Succeeded, got %+v",
+			succeededNames(gates.Succeeded))
+	}
+	if len(gates.Partial) != 1 {
+		t.Fatalf("expected 1 Partial gate, got %d", len(gates.Partial))
+	}
+	item := gates.Partial[0]
+	if item.Name != "Backend QG" {
+		t.Errorf("expected Backend QG in Partial, got %q", item.Name)
+	}
+	joined := strings.Join(item.Issues, " | ")
+	if !strings.Contains(joined, "new_security_rating_with_aica → new_security_rating") {
+		t.Errorf("expected remap detail in Issues, got %q", joined)
+	}
+	if !strings.Contains(joined, "contains_ai_code") {
+		t.Errorf("expected dropped metric in Issues, got %q", joined)
+	}
+	if !strings.Contains(joined, "#143") {
+		t.Errorf("expected #143 reference in remap message, got %q", joined)
+	}
+}
+
+func succeededNames(items []EntityItem) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Name)
+	}
+	return out
+}
+
 // --- helpers ---
 
 func findSection(s *MigrationSummary, name string) *Section {

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -586,14 +586,19 @@ func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
 		t.Errorf("expected Backend QG in Partial, got %q", item.Name)
 	}
 	joined := strings.Join(item.Issues, " | ")
-	if !strings.Contains(joined, "new_security_rating_with_aica → new_security_rating") {
-		t.Errorf("expected remap detail in Issues, got %q", joined)
+	if !strings.Contains(joined, "new_security_rating_with_aica --> new_security_rating") {
+		t.Errorf("expected remap detail (with -->) in Issues, got %q", joined)
 	}
 	if !strings.Contains(joined, "contains_ai_code") {
 		t.Errorf("expected dropped metric in Issues, got %q", joined)
 	}
-	if !strings.Contains(joined, "#143") {
-		t.Errorf("expected #143 reference in remap message, got %q", joined)
+	if strings.Contains(joined, "#143") {
+		t.Errorf("did not expect #143 reference in user-facing message, got %q", joined)
+	}
+	// Each metric entry should be on its own line within an Issues message.
+	if !strings.Contains(joined, "\nnew_security_rating_with_aica -->") &&
+		!strings.HasPrefix(item.Issues[0], "Some metrics were mapped") {
+		t.Errorf("expected newline-separated metric list, got %q", joined)
 	}
 }
 

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -523,6 +523,69 @@ func portfolioNames(items []EntityItem) []string {
 	return out
 }
 
+// TestCollectSummaryQualityGateMappingDedupesAcrossSourceOrgs verifies
+// that when the same SQS source gate is migrated into a single SQC gate
+// from several source orgs (gates.csv carries one row per source-org
+// pairing, all sharing the same cloud_gate_id), the Details column shows
+// each mapping decision exactly once — not repeated per source org.
+func TestCollectSummaryQualityGateMappingDedupesAcrossSourceOrgs(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	writeTaskJSONL(t, runDir, "createGates", []map[string]any{
+		{"name": "Shared QG", "sonarcloud_org_key": "org1", "cloud_gate_id": "42"},
+	})
+
+	// Three identical sidecar entries for the same (cloud_gate_id,
+	// source_metric, target_metric) tuple — emulates addGateConditions
+	// recording the same remap from three different source SQS orgs that
+	// all migrated into a single target SQC org.
+	notesDir := filepath.Join(runDir, "addGateConditions.notes")
+	os.MkdirAll(notesDir, 0o755)
+	dup := map[string]any{
+		"cloud_gate_id":  "42",
+		"gate_name":      "Shared QG",
+		"action":         "remapped",
+		"source_metric":  "new_security_rating_with_aica",
+		"target_metrics": []string{"new_security_rating"},
+	}
+	dupDropped := map[string]any{
+		"cloud_gate_id": "42",
+		"gate_name":     "Shared QG",
+		"action":        "dropped",
+		"source_metric": "contains_ai_code",
+	}
+	f, _ := os.Create(filepath.Join(notesDir, "results.1.jsonl"))
+	for i := 0; i < 3; i++ {
+		b, _ := json.Marshal(dup)
+		f.Write(b)
+		f.Write([]byte("\n"))
+		b, _ = json.Marshal(dupDropped)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	gates := findSection(summary, "Quality Gates")
+	if len(gates.Partial) != 1 {
+		t.Fatalf("expected 1 Partial gate, got %d", len(gates.Partial))
+	}
+	joined := strings.Join(gates.Partial[0].Issues, "\n")
+	// Each remap/dropped metric should appear exactly once.
+	if got := strings.Count(joined, "new_security_rating_with_aica --> new_security_rating"); got != 1 {
+		t.Errorf("expected remap line exactly once, got %d occurrences in:\n%s", got, joined)
+	}
+	if got := strings.Count(joined, "contains_ai_code"); got != 1 {
+		t.Errorf("expected dropped metric exactly once, got %d occurrences in:\n%s", got, joined)
+	}
+}
+
 func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
 	dir := t.TempDir()
 	runID := "run-01"

--- a/go/internal/report/summary/gate_notes.go
+++ b/go/internal/report/summary/gate_notes.go
@@ -1,0 +1,159 @@
+package summary
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// gateMappingNote is a single per-condition decision recorded by
+// addGateConditions in its sidecar JSONL (addGateConditions.notes/). It
+// describes either a metric remap (#143) or a dropped condition that had no
+// SonarQube Cloud equivalent.
+type gateMappingNote struct {
+	CloudGateID   string   `json:"cloud_gate_id"`
+	GateName      string   `json:"gate_name"`
+	Action        string   `json:"action"` // "remapped" | "dropped"
+	SourceMetric  string   `json:"source_metric"`
+	TargetMetrics []string `json:"target_metrics,omitempty"`
+}
+
+// collectGateMappingNotes reads the addGateConditions.notes sidecar and
+// returns one human-readable Partial-migration message per cloud gate
+// affected. The key is the cloud_gate_id; values are the strings the
+// summary report appends to the gate's Issues list.
+func collectGateMappingNotes(runDir string) map[string][]string {
+	dir := filepath.Join(runDir, "addGateConditions.notes")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	// Aggregate per cloud_gate_id so each gate gets a tidy summary line
+	// rather than one row per affected condition.
+	type aggregate struct {
+		remapped []string // human-friendly "source → target,target"
+		dropped  []string // source metrics
+	}
+	byGate := make(map[string]*aggregate)
+
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".jsonl" {
+			continue
+		}
+		f, err := os.Open(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		scanner := bufio.NewScanner(f)
+		scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if line == "" {
+				continue
+			}
+			var note gateMappingNote
+			if json.Unmarshal([]byte(line), &note) != nil {
+				continue
+			}
+			if note.CloudGateID == "" {
+				continue
+			}
+			if byGate[note.CloudGateID] == nil {
+				byGate[note.CloudGateID] = &aggregate{}
+			}
+			ag := byGate[note.CloudGateID]
+			switch note.Action {
+			case "remapped":
+				ag.remapped = append(ag.remapped,
+					fmt.Sprintf("%s → %s", note.SourceMetric, strings.Join(note.TargetMetrics, ", ")))
+			case "dropped":
+				ag.dropped = append(ag.dropped, note.SourceMetric)
+			}
+		}
+		f.Close()
+	}
+
+	out := make(map[string][]string, len(byGate))
+	for gateID, ag := range byGate {
+		var msgs []string
+		if len(ag.remapped) > 0 {
+			sort.Strings(ag.remapped)
+			msgs = append(msgs,
+				"Some metrics were mapped to the closest SonarQube Cloud equivalents (#143): "+
+					strings.Join(ag.remapped, "; "))
+		}
+		if len(ag.dropped) > 0 {
+			sort.Strings(ag.dropped)
+			msgs = append(msgs,
+				"Some conditions were dropped because the source metric has no SonarQube Cloud equivalent: "+
+					strings.Join(ag.dropped, ", "))
+		}
+		if len(msgs) > 0 {
+			out[gateID] = msgs
+		}
+	}
+	return out
+}
+
+// applyGateMappingNotes moves any Succeeded quality gate whose cloud gate id
+// appears in notes into the Partial bucket, attaching the human-readable
+// issue strings. Gates already in Partial get their Issues list extended.
+func applyGateMappingNotes(succeeded, partial []EntityItem, notes map[string][]string) ([]EntityItem, []EntityItem) {
+	if len(notes) == 0 || (len(succeeded) == 0 && len(partial) == 0) {
+		return succeeded, partial
+	}
+
+	// Index existing Partial entries by cloud_gate_id so we can extend
+	// them rather than create duplicates.
+	partialIdx := make(map[string]int, len(partial))
+	for i, item := range partial {
+		if item.Detail != "" {
+			partialIdx[item.Detail] = i
+		}
+	}
+
+	keep := succeeded[:0:0]
+	for _, item := range succeeded {
+		issues, ok := notes[item.Detail]
+		if !ok {
+			keep = append(keep, item)
+			continue
+		}
+		// Move to Partial.
+		moved := EntityItem{
+			Name:         item.Name,
+			Language:     item.Language,
+			Organization: item.Organization,
+			Detail:       item.Detail,
+			Issues:       append([]string(nil), issues...),
+		}
+		partial = append(partial, moved)
+	}
+
+	// Append notes for gates already in Partial (e.g., from another
+	// upstream source).
+	for gateID, issues := range notes {
+		idx, ok := partialIdx[gateID]
+		if !ok {
+			continue
+		}
+		partial[idx].Issues = append(partial[idx].Issues, issues...)
+	}
+
+	return keep, partial
+}
+
+// gateMappingDataStore is an interface satisfied by *common.DataStore so the
+// helper above can be exercised in unit tests without a full Executor.
+type gateMappingDataStore interface {
+	BaseDir() string
+}
+
+var _ gateMappingDataStore = (*common.DataStore)(nil)

--- a/go/internal/report/summary/gate_notes.go
+++ b/go/internal/report/summary/gate_notes.go
@@ -72,7 +72,7 @@ func collectGateMappingNotes(runDir string) map[string][]string {
 			switch note.Action {
 			case "remapped":
 				ag.remapped = append(ag.remapped,
-					fmt.Sprintf("%s → %s", note.SourceMetric, strings.Join(note.TargetMetrics, ", ")))
+					fmt.Sprintf("%s --> %s", note.SourceMetric, strings.Join(note.TargetMetrics, ", ")))
 			case "dropped":
 				ag.dropped = append(ag.dropped, note.SourceMetric)
 			}
@@ -86,14 +86,14 @@ func collectGateMappingNotes(runDir string) map[string][]string {
 		if len(ag.remapped) > 0 {
 			sort.Strings(ag.remapped)
 			msgs = append(msgs,
-				"Some metrics were mapped to the closest SonarQube Cloud equivalents (#143): "+
-					strings.Join(ag.remapped, "; "))
+				"Some metrics were mapped to the closest SonarQube Cloud equivalents:\n"+
+					strings.Join(ag.remapped, "\n"))
 		}
 		if len(ag.dropped) > 0 {
 			sort.Strings(ag.dropped)
 			msgs = append(msgs,
-				"Some conditions were dropped because the source metric has no SonarQube Cloud equivalent: "+
-					strings.Join(ag.dropped, ", "))
+				"Some conditions were dropped because the source metric has no SonarQube Cloud equivalent:\n"+
+					strings.Join(ag.dropped, "\n"))
 		}
 		if len(msgs) > 0 {
 			out[gateID] = msgs

--- a/go/internal/report/summary/gate_notes.go
+++ b/go/internal/report/summary/gate_notes.go
@@ -36,10 +36,14 @@ func collectGateMappingNotes(runDir string) map[string][]string {
 	}
 
 	// Aggregate per cloud_gate_id so each gate gets a tidy summary line
-	// rather than one row per affected condition.
+	// rather than one row per affected condition. The *Seen maps deduplicate
+	// repeated notes (one source SQS gate mapped to a single SQC gate from
+	// multiple source orgs writes the same note multiple times).
 	type aggregate struct {
-		remapped []string // human-friendly "source → target,target"
-		dropped  []string // source metrics
+		remapped     []string        // human-friendly "source --> target,target"
+		dropped      []string        // source metrics
+		remappedSeen map[string]bool // key: source + "→" + joined targets
+		droppedSeen  map[string]bool // key: source metric
 	}
 	byGate := make(map[string]*aggregate)
 
@@ -66,14 +70,33 @@ func collectGateMappingNotes(runDir string) map[string][]string {
 				continue
 			}
 			if byGate[note.CloudGateID] == nil {
-				byGate[note.CloudGateID] = &aggregate{}
+				byGate[note.CloudGateID] = &aggregate{
+					remappedSeen: map[string]bool{},
+					droppedSeen:  map[string]bool{},
+				}
 			}
 			ag := byGate[note.CloudGateID]
+			// addGateConditions can record the same per-condition decision
+			// more than once when the same SQS source gate is mapped to a
+			// single SQC org from multiple source orgs (gates.csv carries
+			// one row per source-org pairing, all sharing the same cloud
+			// gate id). Deduplicate by (action, source, targets) so the
+			// Details column shows each mapping exactly once.
 			switch note.Action {
 			case "remapped":
+				targets := strings.Join(note.TargetMetrics, ", ")
+				key := note.SourceMetric + "→" + targets
+				if ag.remappedSeen[key] {
+					continue
+				}
+				ag.remappedSeen[key] = true
 				ag.remapped = append(ag.remapped,
-					fmt.Sprintf("%s --> %s", note.SourceMetric, strings.Join(note.TargetMetrics, ", ")))
+					fmt.Sprintf("%s --> %s", note.SourceMetric, targets))
 			case "dropped":
+				if ag.droppedSeen[note.SourceMetric] {
+					continue
+				}
+				ag.droppedSeen[note.SourceMetric] = true
 				ag.dropped = append(ag.dropped, note.SourceMetric)
 			}
 		}

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -389,12 +389,12 @@ func successDetails(item EntityItem) string {
 	return fmt.Sprintf("%s — scan history: %s", cloudKey, scanStatusLabel(scan))
 }
 
-// partialDetails formats the Details column for a Partial item — joined issues,
-// and the cloud key if known.
+// partialDetails formats the Details column for a Partial item — each issue
+// rendered on its own line, prefixed by the cloud key if known.
 func partialDetails(item EntityItem) string {
-	issues := strings.Join(item.Issues, "; ")
+	issues := strings.Join(item.Issues, "\n")
 	if item.Detail != "" && issues != "" {
-		return item.Detail + " — " + issues
+		return item.Detail + "\n" + issues
 	}
 	if issues != "" {
 		return issues

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -260,21 +260,30 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 	}
 
 	// Single-line rows render at the original 6mm height; when the Details
-	// text wraps, each extra line is set to a tighter 3.6mm so the row does
-	// not balloon vertically. This still leaves enough breathing room above
-	// and below 8pt text for legibility.
+	// text wraps, each extra line is set to a tighter 3.0mm so the row does
+	// not balloon vertically. Multi-line details (typically metric mapping
+	// notes) also drop to a smaller 6pt font so the per-line cost stays low.
 	const (
-		singleLineH  = 6.0
-		wrappedLineH = 3.6
+		singleLineH       = 6.0
+		wrappedLineH      = 3.0
+		bodyFontSize      = 8.0
+		multiLineFontSize = 6.0
 	)
-	pdf.SetFont(pdfFontFamily, "", 8)
+	pdf.SetFont(pdfFontFamily, "", bodyFontSize)
 	for i, row := range rows {
 		// Compute wrapped line count for the Details column so the whole row
 		// (Name, Organization, Outcome) can match that height. SplitLines
 		// already accounts for the cell's internal margin.
 		detailsText := sanitizeForPDF(row.details)
 		detailsCol := len(widths) - 1
+		multiLine := strings.Contains(detailsText, "\n")
+		detailsFontSize := bodyFontSize
+		if multiLine {
+			detailsFontSize = multiLineFontSize
+		}
+		pdf.SetFont(pdfFontFamily, "", detailsFontSize)
 		lineCount := len(pdf.SplitLines([]byte(detailsText), widths[detailsCol]))
+		pdf.SetFont(pdfFontFamily, "", bodyFontSize)
 		if lineCount < 1 {
 			lineCount = 1
 		}
@@ -313,10 +322,13 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		col++
 		// Details in black, regular — MultiCell wraps long text across lines
 		// rather than truncating. lineH is per-line so the cell ends up at
-		// rowHeight, matching the row.
+		// rowHeight, matching the row. Multi-line details drop to a smaller
+		// font so a long metric-mapping block doesn't visually dominate the
+		// table.
 		setColor(pdf, colorBlack)
-		pdf.SetFont(pdfFontFamily, "", 8)
+		pdf.SetFont(pdfFontFamily, "", detailsFontSize)
 		pdf.MultiCell(widths[col], lineH, detailsText, "1", "L", true)
+		pdf.SetFont(pdfFontFamily, "", bodyFontSize)
 	}
 }
 

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -231,8 +231,8 @@ func TestBuildUnifiedRowsOrdering(t *testing.T) {
 	if rows[4].name != "GateD" {
 		t.Errorf("expected unused skipped second, got name %q", rows[4].name)
 	}
-	if rows[1].details != "43 — Add condition: foo" {
-		t.Errorf("expected partial details to combine cloud key + issues, got %q", rows[1].details)
+	if rows[1].details != "43\nAdd condition: foo" {
+		t.Errorf("expected partial details to combine cloud key + issues on separate lines, got %q", rows[1].details)
 	}
 }
 

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -428,6 +428,40 @@ func TestQualityGatesCreateConditionError(t *testing.T) {
 	assert.True(t, sqapi.IsForbidden(err))
 }
 
+func TestQualityGatesShow(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/qualitygates/show", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "MyGate", r.URL.Query().Get("name"))
+		assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
+		writeJSON(w, types.QualityGate{
+			ID: 10, Name: "MyGate",
+			Conditions: []types.QualityGateCondition{
+				{ID: 100, Metric: "coverage", Op: "LT", Error: "80"},
+				{ID: 101, Metric: "new_bugs", Op: "GT", Error: "0"},
+			},
+		})
+	})
+	cc := newTestCloud(t, mux)
+
+	gate, err := cc.QualityGates.Show(context.Background(), "MyGate", "myorg")
+	require.NoError(t, err)
+	assert.Equal(t, 10, gate.ID)
+	assert.Len(t, gate.Conditions, 2)
+	assert.Equal(t, 100, gate.Conditions[0].ID)
+}
+
+func TestQualityGatesDeleteCondition(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/qualitygates/delete_condition", func(w http.ResponseWriter, r *http.Request) {
+		assertFormValue(t, r, "id", "100")
+		assertFormValue(t, r, "organization", "myorg")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	require.NoError(t, cc.QualityGates.DeleteCondition(context.Background(), 100, "myorg"))
+}
+
 func TestQualityGatesDestroy(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/qualitygates/destroy", func(w http.ResponseWriter, r *http.Request) {

--- a/lib/sq-api-go/cloud/qualitygates.go
+++ b/lib/sq-api-go/cloud/qualitygates.go
@@ -49,6 +49,28 @@ func (q *QualityGatesClient) CreateCondition(ctx context.Context, params CreateC
 	return &result, nil
 }
 
+// Show returns the quality gate with its current conditions via
+// /api/qualitygates/show.
+func (q *QualityGatesClient) Show(ctx context.Context, name, organization string) (*types.QualityGate, error) {
+	v := url.Values{}
+	v.Set("name", name)
+	v.Set("organization", organization)
+	var result types.QualityGate
+	if err := q.getJSON(ctx, "api/qualitygates/show?"+v.Encode(), &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DeleteCondition removes a single condition from a quality gate via
+// /api/qualitygates/delete_condition.
+func (q *QualityGatesClient) DeleteCondition(ctx context.Context, conditionID int, organization string) error {
+	form := url.Values{}
+	form.Set("id", strconv.Itoa(conditionID))
+	form.Set("organization", organization)
+	return q.postForm(ctx, "api/qualitygates/delete_condition", form, nil)
+}
+
 // Destroy deletes a quality gate via /api/qualitygates/destroy.
 func (q *QualityGatesClient) Destroy(ctx context.Context, gateID int, organization string) error {
 	form := url.Values{}


### PR DESCRIPTION
## Summary

Migrates SonarQube Server quality gates to SonarQube Cloud with true overwrite semantics and a closest-equivalent metric mapping. Closes #117 and #143.

### Quality-gate migration (#117)

- **Override semantics fixed.** When a gate with the same name already exists on SQC, the previous code reused the existing gate ID and *appended* the source conditions, producing a union (or duplicates). It now clears the target gate's pre-existing conditions before applying the source set, so the migrated gate is an exact copy of the source.
- New SDK methods: `cloud.QualityGatesClient.Show(ctx, name, org)` (GET `/api/qualitygates/show`) and `DeleteCondition(ctx, conditionID, org)` (POST `/api/qualitygates/delete_condition`).
- `runCreateGates` stamps `was_preexisting=true` on each `createGates` JSONL entry whenever the gate was reused.
- `runGetGateConditions` rebuilt: it now emits one per-gate record carrying `gate_name`, `sonarcloud_org_key`, `cloud_gate_id`, `was_preexisting`, and the full `conditions` array. (Previously it joined on `name` instead of the extract's `gateName`, so its output never matched what `runAddGateConditions` expected and *no* conditions actually migrated — a latent bug.)
- `runAddGateConditions` calls a new `clearTargetGateConditions` helper when `was_preexisting=true`: `Show` the gate, then `DeleteCondition` for every existing condition before applying the source set. Fresh gates skip the clear.
- Debug logs on every QG API call (`POST /api/qualitygates/create`, `GET /api/qualitygates/list (lookup)`, `GET /api/qualitygates/show`, `POST /api/qualitygates/delete_condition`, `POST /api/qualitygates/create_condition`, `POST /api/qualitygates/set_as_default`, `POST /api/qualitygates/select`, `POST /api/qualitygates/destroy`). Grep `gate api call` in a `--debug` run to follow exactly what the tool did to each gate.

### Closest-metric mapping (#143)

- New `metricMapping` table covers every entry from the #143 table:
  - `_with_aica` / `_without_aica` variants → drop the AICA suffix.
  - `software_quality_*` (SQS-only) → classic SQC equivalents (`software_quality_security_rating → security_rating`, etc.).
  - `new_software_quality_*` → `new_*` equivalents (including the `_issues` rows with explicit `<= A` rating thresholds).
  - Composite mappings (e.g. `software_quality_blocker_issues → security_review_rating + reliability_rating` each at `GT 4` (the `<= D` shorthand from the table)).
  - Drop list — `contains_ai_code`, `releasability_rating*`, `filename_size*`, `prioritized_rule_issues`, `ncloc_with_aica`, … logged at Warn and surfaced as Partial in the report.
- `replacementCondition` lets each mapping override the source op and threshold (used for ratings; otherwise the source values flow through).

### Reporting

- Each remap or drop is recorded in `<runDir>/addGateConditions.notes/results.N.jsonl` with `cloud_gate_id`, `gate_name`, `action`, `source_metric`, and (for remaps) `target_metrics`.
- The summary report's `collectGateMappingNotes` aggregates the sidecar per gate, **dedupes** repeated entries (one SQS gate landing on a single SQC gate from several source orgs writes the same note multiple times via gates.csv), and produces:
  - *"Some metrics were mapped to the closest SonarQube Cloud equivalents:\nsrc1 --> tgt1\nsrc2 --> tgta, tgtb"*
  - *"Some conditions were dropped because the source metric has no SonarQube Cloud equivalent:\nmetricX\nmetricY"*
- Any gate with at least one note is moved from **Succeeded** to **Partial**; the messages render in the Details column at a tighter **6pt** font with `-->` as the source-to-target separator. Each metric is on its own line and the row height auto-grows from `SplitLines`.

## Test plan

- [x] `go test ./...` in both `lib/sq-api-go/` and `go/`
- [x] `TestQualityGatesShow` + `TestQualityGatesDeleteCondition` cover the new SDK methods.
- [x] `TestAddGateConditionsOverrideClearsExisting` — pre-existing gate has stale conditions; assert wipe-then-replace order.
- [x] `TestAddGateConditionsFreshGateSkipsClear` — fresh gate; `Show` / `DeleteCondition` not hit.
- [x] `TestLookupMetricReplacement` — 13 table-driven cases incl. composites and threshold-aware ratings.
- [x] `TestAddGateConditionsAppliesMetricMapping` — end-to-end remap/drop/composite expansion, asserting the CreateCondition payloads (metric + op + threshold) the migrator sends.
- [x] `TestCollectSummaryQualityGateMetricMappingMovesToPartial` — sidecar → Partial bucket with `-->` formatting and no `#143` reference.
- [x] `TestCollectSummaryQualityGateMappingDedupesAcrossSourceOrgs` — 3× duplicate notes for the same gate collapse to a single line.
- [ ] Run on staging against the 17-gate corpus from issue #117 + #143 and visually confirm the Partial gates render with each mapping on its own line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
