### PR TITLE
Issue #119 Migrate new-code period definitions for every branch

### DIFF
--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/sonar-solutions/sq-api-go/cloud"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
@@ -37,6 +38,11 @@ func associateTasks() []TaskDef {
 			Name:         "setProjectTags",
 			Dependencies: []string{"createProjects"},
 			Run:          runSetProjectTags,
+		},
+		{
+			Name:         "setNewCodePeriods",
+			Dependencies: []string{"createProjects"},
+			Run:          runSetNewCodePeriods,
 		},
 	}
 }
@@ -209,6 +215,82 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 		})
 	counter.LogSummary(e.Logger)
 	return err
+}
+
+// runSetNewCodePeriods migrates per-branch new-code policy. It iterates the
+// extract getNewCodePeriods records (one per source project+branch), maps
+// each to its target SonarQube Cloud project, translates the SQS
+// type/value to SQC equivalents, and calls
+// POST /api/new_code_periods/set on SQC. This handles both newly-created
+// projects and pre-existing ones (createProjects only sets the main-branch
+// NCD at creation time and skips that work entirely when the project
+// already exists).
+func runSetNewCodePeriods(ctx context.Context, e *Executor) error {
+	projects, _ := e.Store.ReadAll("createProjects")
+	projectKeyMap := make(map[string]projectMapping)
+	for _, p := range projects {
+		serverURL := extractField(p, "server_url")
+		key := extractField(p, "key")
+		projectKeyMap[serverURL+key] = projectMapping{
+			CloudKey: extractField(p, "cloud_project_key"),
+			OrgKey:   extractField(p, "sonarcloud_org_key"),
+		}
+	}
+
+	counter := NewTaskCounter("setNewCodePeriods")
+	err := forEachExtractItem(ctx, e, "setNewCodePeriods", "getNewCodePeriods",
+		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
+			projectKey := extractField(item.Data, "projectKey")
+			pm, ok := projectKeyMap[item.ServerURL+projectKey]
+			if !ok || pm.CloudKey == "" {
+				return nil
+			}
+			sqsType := extractField(item.Data, "type")
+			sqcType, mapped := sqcNewCodeType[sqsType]
+			if !mapped {
+				e.Logger.Warn("setNewCodePeriods: unmapped source NCD type, skipping",
+					"project", pm.CloudKey, "source_type", sqsType)
+				return nil
+			}
+			branch := extractField(item.Data, "branchKey")
+			value := extractAnyStr(item.Data, "value")
+			// previous_version must travel with an empty value; SQC rejects
+			// the call otherwise.
+			if sqcType == "previous_version" {
+				value = ""
+			}
+
+			e.Logger.Debug("project api call: POST /api/new_code_periods/set",
+				"project", pm.CloudKey, "branch", branch, "type", sqcType,
+				"value", value, "org", pm.OrgKey, "source_type", sqsType)
+			err := e.Cloud.NewCodePeriods.Set(ctx, cloud.SetNewCodePeriodParams{
+				Project:      pm.CloudKey,
+				Branch:       branch,
+				Type:         sqcType,
+				Value:        value,
+				Organization: pm.OrgKey,
+			})
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setNewCodePeriods failed", err,
+					"project", pm.CloudKey, "branch", branch, "type", sqcType)
+			} else {
+				counter.Success()
+			}
+			_ = w.WriteOne(item.Data)
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
+}
+
+// sqcNewCodeType maps the SonarQube Server NCD type enum to the equivalent
+// SonarQube Cloud "type" value accepted by /api/new_code_periods/set.
+var sqcNewCodeType = map[string]string{
+	"NUMBER_OF_DAYS":    "days",
+	"PREVIOUS_VERSION":  "previous_version",
+	"REFERENCE_BRANCH":  "reference_branch",
+	"SPECIFIC_ANALYSIS": "specific_analysis",
 }
 
 func runSetProjectTags(ctx context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_newcode_test.go
+++ b/go/internal/migrate/tasks_newcode_test.go
@@ -1,0 +1,105 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// TestRunSetNewCodePeriodsTranslatesAndSets verifies that runSetNewCodePeriods
+// translates SQS NCD types to their SQC equivalents, omits the value for
+// previous_version, and resolves projectKey + branch to the right cloud
+// project + organization.
+func TestRunSetNewCodePeriodsTranslatesAndSets(t *testing.T) {
+	type call struct {
+		project, branch, ncdType, value, org string
+	}
+	var (
+		mu       sync.Mutex
+		recorded []call
+	)
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/new_code_periods/set", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		recorded = append(recorded, call{
+			project: r.FormValue("project"),
+			branch:  r.FormValue("branch"),
+			ncdType: r.FormValue("type"),
+			value:   r.FormValue("value"),
+			org:     r.FormValue("organization"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// Three extract records covering each translated NCD type plus an
+	// unmapped one (UNKNOWN) which the task should skip with a warning.
+	extractDir := filepath.Join(dir, "extract-01", "getNewCodePeriods")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, _ := os.Create(filepath.Join(extractDir, "results.1.jsonl"))
+	for _, rec := range []map[string]any{
+		{"projectKey": "proj-days", "branchKey": "main", "type": "NUMBER_OF_DAYS", "value": "14"},
+		{"projectKey": "proj-prev", "branchKey": "main", "type": "PREVIOUS_VERSION", "value": nil},
+		{"projectKey": "proj-ref", "branchKey": "main", "type": "REFERENCE_BRANCH", "value": "develop"},
+		{"projectKey": "proj-unknown", "branchKey": "main", "type": "UNKNOWN_MODE"},
+	} {
+		b, _ := json.Marshal(rec)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	pw, _ := e.Store.Writer("createProjects")
+	for _, src := range []map[string]any{
+		{"key": "proj-days", "server_url": testServerURL, "sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj-days"},
+		{"key": "proj-prev", "server_url": testServerURL, "sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj-prev"},
+		{"key": "proj-ref", "server_url": testServerURL, "sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj-ref"},
+		{"key": "proj-unknown", "server_url": testServerURL, "sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj-unknown"},
+	} {
+		b, _ := json.Marshal(src)
+		pw.WriteOne(b)
+	}
+
+	if err := runSetNewCodePeriods(context.Background(), e); err != nil {
+		t.Fatalf("runSetNewCodePeriods: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Expect 3 calls — the UNKNOWN_MODE record should be skipped.
+	if len(recorded) != 3 {
+		t.Fatalf("expected 3 calls, got %d: %+v", len(recorded), recorded)
+	}
+	sort.Slice(recorded, func(i, j int) bool { return recorded[i].project < recorded[j].project })
+
+	want := []call{
+		{project: "org1_proj-days", branch: "main", ncdType: "days", value: "14", org: "org1"},
+		{project: "org1_proj-prev", branch: "main", ncdType: "previous_version", value: "", org: "org1"},
+		{project: "org1_proj-ref", branch: "main", ncdType: "reference_branch", value: "develop", org: "org1"},
+	}
+	for i, w := range want {
+		if recorded[i] != w {
+			t.Errorf("call %d: got %+v, want %+v", i, recorded[i], w)
+		}
+	}
+}

--- a/go/internal/structure/projects.go
+++ b/go/internal/structure/projects.go
@@ -14,6 +14,7 @@ var cloudEndpoints = []string{"dev.azure.com", "gitlab.com", "api.github.com", "
 var newCodeMappings = map[string]string{
 	"NUMBER_OF_DAYS":   "days",
 	"PREVIOUS_VERSION": "previous_version",
+	"REFERENCE_BRANCH": "reference_branch",
 }
 
 // IsCloudBinding checks whether a binding URL matches a known cloud endpoint.
@@ -90,9 +91,15 @@ func MapNewCodeDefinitions(directory string, mapping ExtractMapping) map[string]
 		projectKey := common.ExtractField(item.Data, "projectKey")
 		branchKey := common.ExtractField(item.Data, "branchKey")
 
+		// SonarQube Cloud expects no value for the "previous_version" mode —
+		// the type alone fully describes the policy. Previous releases of
+		// this tool serialised the literal string "previous_version" as the
+		// value, which leaked into projects.csv and then into the SQC
+		// create payload as newCodeDefinitionValue=previous_version. Leave
+		// the value empty here so the migrate-side check skips that param.
 		value := ncdValue
 		if ncdType == "PREVIOUS_VERSION" {
-			value = "previous_version"
+			value = nil
 		}
 
 		if result[item.ServerURL] == nil {

--- a/lib/sq-api-go/cloud/client.go
+++ b/lib/sq-api-go/cloud/client.go
@@ -46,6 +46,7 @@ type Client struct {
 	Settings        *SettingsClient
 	Enterprises     *EnterprisesClient
 	Organizations   *OrganizationsClient
+	NewCodePeriods  *NewCodePeriodsClient
 	DOP             *DOPClient
 }
 
@@ -63,6 +64,7 @@ func New(c *sqapi.Client) *Client {
 		Settings:        &SettingsClient{b},
 		Enterprises:     &EnterprisesClient{b},
 		Organizations:   &OrganizationsClient{b},
+		NewCodePeriods:  &NewCodePeriodsClient{b},
 		DOP:             &DOPClient{b},
 	}
 }

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -685,6 +685,40 @@ func TestBranchesMainBranchIDMissing(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestNewCodePeriodsSetDays(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/new_code_periods/set", func(w http.ResponseWriter, r *http.Request) {
+		assertFormValue(t, r, "project", "p1")
+		assertFormValue(t, r, "branch", "main")
+		assertFormValue(t, r, "type", "days")
+		assertFormValue(t, r, "value", "30")
+		assertFormValue(t, r, "organization", "org1")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.NewCodePeriods.Set(context.Background(), cloud.SetNewCodePeriodParams{
+		Project: "p1", Branch: "main", Type: "days", Value: "30", Organization: "org1",
+	})
+	require.NoError(t, err)
+}
+
+func TestNewCodePeriodsSetPreviousVersionOmitsValue(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/new_code_periods/set", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		assert.Equal(t, "previous_version", r.FormValue("type"))
+		assert.Equal(t, "", r.FormValue("value"), "value must be omitted for previous_version mode")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.NewCodePeriods.Set(context.Background(), cloud.SetNewCodePeriodParams{
+		Project: "p1", Type: "previous_version", Organization: "org1",
+	})
+	require.NoError(t, err)
+}
+
 // --- Rules ---
 
 func TestRulesUpdate(t *testing.T) {

--- a/lib/sq-api-go/cloud/newcode.go
+++ b/lib/sq-api-go/cloud/newcode.go
@@ -1,0 +1,53 @@
+// Package cloud — newcode.go covers the /api/new_code_periods endpoints used
+// by the sonar-migration-tool to migrate per-branch new-code policy.
+package cloud
+
+import (
+	"context"
+	"net/url"
+)
+
+// NewCodePeriodsClient provides write-path methods for SonarQube Cloud's
+// /api/new_code_periods endpoints.
+type NewCodePeriodsClient struct{ baseClient }
+
+// SetNewCodePeriodParams describes the per-branch new-code policy a caller
+// wants to apply on SonarQube Cloud.
+//
+//   - Project is required.
+//   - Branch is optional; when empty the call sets the project-level
+//     default that branches inherit from.
+//   - Type must be one of "previous_version", "days",
+//     "specific_analysis", or "reference_branch".
+//   - Value is required for every type EXCEPT "previous_version", where it
+//     must be empty (the type alone fully describes the policy).
+//   - Organization is the SonarQube Cloud organization key.
+type SetNewCodePeriodParams struct {
+	Project      string
+	Branch       string
+	Type         string
+	Value        string
+	Organization string
+}
+
+// Set applies a new-code period policy via
+// POST /api/new_code_periods/set.
+func (n *NewCodePeriodsClient) Set(ctx context.Context, params SetNewCodePeriodParams) error {
+	form := url.Values{}
+	if params.Project != "" {
+		form.Set("project", params.Project)
+	}
+	if params.Branch != "" {
+		form.Set("branch", params.Branch)
+	}
+	if params.Type != "" {
+		form.Set("type", params.Type)
+	}
+	if params.Value != "" {
+		form.Set("value", params.Value)
+	}
+	if params.Organization != "" {
+		form.Set("organization", params.Organization)
+	}
+	return n.postForm(ctx, "api/new_code_periods/set", form, nil)
+}


### PR DESCRIPTION
## Summary

Migrates new-code period definitions to SonarQube Cloud for every branch, not just the main branch at project-creation time. Closes #119.

**Before this change** the tool already extracted `getNewCodePeriods` and passed `new_code_definition_type/value` to `createProjects`, so a freshly-created project got its main-branch policy. But:
- `createProjects` is skipped entirely when the project already exists on SQC → existing projects kept whatever NCD they had.
- Non-main branches with their own NCD were never migrated.
- `REFERENCE_BRANCH` source records were dropped because `newCodeMappings` only knew `NUMBER_OF_DAYS` and `PREVIOUS_VERSION`.
- `PREVIOUS_VERSION` serialised a buggy `"previous_version"` value into `projects.csv` that surfaced in the SQC create payload as `newCodeDefinitionValue=previous_version` (SQC expects no value for that mode).

## Changes

1. **`structure/projects.go`** — add `REFERENCE_BRANCH → reference_branch` to `newCodeMappings`, and stop emitting the bogus `"previous_version"` value (use `nil` so the migrate-side `if value != ""` check skips the param).

2. **SDK `cloud/newcode.go`** — new `NewCodePeriodsClient.Set(ctx, SetNewCodePeriodParams)` → `POST /api/new_code_periods/set`. Honours the SQC requirement that `value` is omitted for `previous_version` mode and required for every other mode.

3. **Migrate `setNewCodePeriods` task** (`tasks_associate.go`) — depends on `createProjects`, iterates extract `getNewCodePeriods`, resolves each `(serverURL, projectKey)` → cloud project + organization via the createProjects JSONL, translates the SQS type enum (`NUMBER_OF_DAYS / PREVIOUS_VERSION / REFERENCE_BRANCH / SPECIFIC_ANALYSIS`) to its SQC equivalent, and applies the policy per-branch. Unmapped types are logged at Warn and skipped. Per-call Debug logs follow the `project api call: POST /api/new_code_periods/set` convention so they grep next to the existing project-touching trace.

## Test plan

- [x] `go test ./...` in both `lib/sq-api-go/` and `go/`
- [x] `TestNewCodePeriodsSetDays` — full request shape (project, branch, type=days, value=30, organization).
- [x] `TestNewCodePeriodsSetPreviousVersionOmitsValue` — asserts the `value` param is absent.
- [x] `TestRunSetNewCodePeriodsTranslatesAndSets` — 4 source records (days, previous_version, reference_branch, an unmapped type), asserts exactly the 3 expected PATCH calls with the right type translations and that the unknown type is skipped.
- [ ] Manual: run extract + migrate against a SQS instance with mixed NCD modes across multiple branches and confirm the SQC projects pick them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
