### PR TITLE
Issue #120 Migrate project settings (analysis scope, exclusions, language suffixes, etc.)

### DIFF
--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strconv"
 	"strings"
 
@@ -175,6 +176,23 @@ func applyGroupPermissions(ctx context.Context, e *Executor, data json.RawMessag
 	}))
 }
 
+// runSetProjectSettings migrates every non-inherited project-level setting
+// extracted from the source server, including the analysis-scope keys
+// listed in issue #120 (sonar.exclusions, sonar.inclusions,
+// sonar.coverage.exclusions, sonar.cpd.exclusions, sonar.<language>.*,
+// sonar.scm.*, sonar.coverage.*, external-analyzer settings).
+//
+// SonarQube's /api/settings/values can return a setting in three shapes
+// depending on its definition:
+//
+//   - "value":       single scalar value (e.g. sonar.cfamily.ignoreHeaderComments=false)
+//   - "values":      multi-value array (e.g. sonar.exclusions=[a,b,c])
+//   - "fieldValues": property-set array of objects (e.g.
+//                    sonar.issue.ignore.allfile=[{fileRegexp:...}])
+//
+// Until this change only "value" was forwarded; multi-value and
+// property-set settings were silently dropped. Each shape now routes to
+// the matching SDK helper so the setting actually lands on SQC.
 func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	// Build project lookup.
 	projects, _ := e.Store.ReadAll("createProjects")
@@ -197,17 +215,21 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 				return nil
 			}
 			settingKey := extractField(item.Data, "key")
-			value := extractField(item.Data, "value")
-			if settingKey == "" || value == "" {
+			if settingKey == "" {
 				return nil
 			}
-			e.Logger.Debug("project api call: POST /api/settings/set",
-				"project", pm.CloudKey, "key", settingKey, "value", value, "org", pm.OrgKey)
-			if err := e.Cloud.Settings.Set(ctx, pm.CloudKey, settingKey, value, pm.OrgKey); err != nil {
+
+			err := applyProjectSetting(ctx, e, pm, item.Data, settingKey)
+			switch {
+			case errors.Is(err, errSettingEmpty):
+				// Empty payload — skip silently, do not count as success
+				// or failure.
+				return nil
+			case err != nil:
 				counter.Fail()
 				logAPIWarn(e.Logger, "setProjectSettings failed", err,
 					"project", pm.CloudKey, "setting", settingKey)
-			} else {
+			default:
 				counter.Success()
 			}
 			_ = w.WriteOne(item.Data)
@@ -215,6 +237,52 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 		})
 	counter.LogSummary(e.Logger)
 	return err
+}
+
+// errSettingEmpty is the sentinel returned by applyProjectSetting when the
+// extract record had no value / values / fieldValues to send. It is not a
+// real error — the caller silently skips the record.
+var errSettingEmpty = errors.New("setting has no value")
+
+// applyProjectSetting dispatches a single getProjectSettings record to the
+// appropriate SDK call based on which of value / values / fieldValues is
+// populated.
+func applyProjectSetting(ctx context.Context, e *Executor, pm projectMapping, raw json.RawMessage, settingKey string) error {
+	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
+		e.Logger.Debug("project api call: POST /api/settings/set (multi-value)",
+			"project", pm.CloudKey, "key", settingKey, "values", vals, "org", pm.OrgKey)
+		return e.Cloud.Settings.SetValues(ctx, pm.CloudKey, settingKey, vals, pm.OrgKey)
+	}
+	if fvs := extractObjectArray(raw, "fieldValues"); len(fvs) > 0 {
+		e.Logger.Debug("project api call: POST /api/settings/set (property-set)",
+			"project", pm.CloudKey, "key", settingKey, "field_values_count", len(fvs), "org", pm.OrgKey)
+		return e.Cloud.Settings.SetFieldValues(ctx, pm.CloudKey, settingKey, fvs, pm.OrgKey)
+	}
+	value := extractField(raw, "value")
+	if value == "" {
+		return errSettingEmpty
+	}
+	e.Logger.Debug("project api call: POST /api/settings/set",
+		"project", pm.CloudKey, "key", settingKey, "value", value, "org", pm.OrgKey)
+	return e.Cloud.Settings.Set(ctx, pm.CloudKey, settingKey, value, pm.OrgKey)
+}
+
+// extractObjectArray reads a []map[string]any from a JSON field. Returns
+// nil for missing fields, non-array shapes, or empty arrays.
+func extractObjectArray(raw json.RawMessage, key string) []map[string]any {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	arrRaw, ok := obj[key]
+	if !ok {
+		return nil
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(arrRaw, &arr); err != nil {
+		return nil
+	}
+	return arr
 }
 
 // runSetNewCodePeriods migrates per-branch new-code policy. It iterates the

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/sonar-solutions/sq-api-go/cloud"
+	"github.com/sonar-solutions/sq-api-go/types"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
@@ -197,14 +198,27 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	// Build project lookup.
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping)
+	orgs := make(map[string]struct{})
 	for _, p := range projects {
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
-		projectKeyMap[serverURL+key] = projectMapping{
+		pm := projectMapping{
 			CloudKey: extractField(p, "cloud_project_key"),
 			OrgKey:   extractField(p, "sonarcloud_org_key"),
 		}
+		projectKeyMap[serverURL+key] = pm
+		if pm.OrgKey != "" {
+			orgs[pm.OrgKey] = struct{}{}
+		}
 	}
+
+	// Pre-fetch SQC's setting definitions per org we will write to. SQS and
+	// SQC don't always agree on whether a setting is multi-value or stored
+	// as a single CSV string (sonar.java.file.suffixes is the canonical
+	// example: SQS exposes it as values=[.java,.jav] but SQC defines it as
+	// STRING + multiValues=false, so POSTing values= just no-ops with 204).
+	// Reading list_definitions lets us pick the right form per setting key.
+	defsByOrg := loadSettingDefinitions(ctx, e, orgs)
 
 	counter := NewTaskCounter("setProjectSettings")
 	err := forEachExtractItem(ctx, e, "setProjectSettings", "getProjectSettings",
@@ -231,7 +245,8 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 				return nil
 			}
 
-			err := applyProjectSetting(ctx, e, pm, item.Data, settingKey)
+			def, hasDef := defsByOrg[pm.OrgKey][settingKey]
+			err := applyProjectSetting(ctx, e, pm, item.Data, settingKey, def, hasDef)
 			switch {
 			case errors.Is(err, errSettingEmpty):
 				// Empty payload — skip silently, do not count as success
@@ -251,22 +266,100 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	return err
 }
 
+// loadSettingDefinitions fetches /api/settings/list_definitions for each
+// SonarQube Cloud organization that will receive project settings, and
+// returns a per-org lookup keyed by setting key. A failed fetch for one org
+// is logged at Warn level and yields an empty (not nil) inner map — callers
+// then transparently fall back to extract-shape dispatch for that org.
+func loadSettingDefinitions(ctx context.Context, e *Executor, orgs map[string]struct{}) map[string]map[string]types.SettingDefinition {
+	out := make(map[string]map[string]types.SettingDefinition, len(orgs))
+	for org := range orgs {
+		defs, err := e.Cloud.Settings.ListDefinitions(ctx, org)
+		if err != nil {
+			logAPIWarn(e.Logger, "setProjectSettings: list_definitions failed, falling back to extract-shape dispatch", err, "org", org)
+			out[org] = map[string]types.SettingDefinition{}
+			continue
+		}
+		byKey := make(map[string]types.SettingDefinition, len(defs))
+		for _, d := range defs {
+			byKey[d.Key] = d
+		}
+		out[org] = byKey
+		e.Logger.Debug("setProjectSettings: loaded definitions", "org", org, "count", len(defs))
+	}
+	return out
+}
+
 // errSettingEmpty is the sentinel returned by applyProjectSetting when the
 // extract record had no value / values / fieldValues to send. It is not a
 // real error — the caller silently skips the record.
 var errSettingEmpty = errors.New("setting has no value")
 
 // applyProjectSetting dispatches a single getProjectSettings record to the
-// appropriate SDK call based on which of value / values / fieldValues is
-// populated.
-func applyProjectSetting(ctx context.Context, e *Executor, pm projectMapping, raw json.RawMessage, settingKey string) error {
+// appropriate SDK call. When a SQC definition is available for the setting
+// key, the post shape is chosen from the target's definition (PROPERTY_SET
+// → fieldValues, multiValues=true → values, otherwise → single CSV-joined
+// value). Without a definition we fall back to the extract record's shape.
+//
+// The definition path matters because SQS and SQC disagree on a handful of
+// settings — notably sonar.java.file.suffixes — where SQS returns
+// values=[...] but SQC's definition is a single STRING with
+// multiValues=false. POSTing values= to such a setting on SQC returns 204
+// but silently fails to persist; joining with comma and POSTing as value=
+// is what actually lands.
+func applyProjectSetting(ctx context.Context, e *Executor, pm projectMapping, raw json.RawMessage, settingKey string, def types.SettingDefinition, hasDef bool) error {
+	if hasDef {
+		switch {
+		case def.Type == "PROPERTY_SET":
+			fvs := extractObjectArray(raw, "fieldValues")
+			if len(fvs) == 0 {
+				return errSettingEmpty
+			}
+			e.Logger.Debug("project api call: POST /api/settings/set (property-set)",
+				"project", pm.CloudKey, "key", settingKey, "field_values_count", len(fvs), "org", pm.OrgKey)
+			return e.Cloud.Settings.SetFieldValues(ctx, pm.CloudKey, settingKey, fvs, pm.OrgKey)
+		case def.MultiValues:
+			vals := extractStringArray(raw, "values")
+			if len(vals) == 0 {
+				if v := extractField(raw, "value"); v != "" {
+					vals = strings.Split(v, ",")
+				}
+			}
+			if len(vals) == 0 {
+				return errSettingEmpty
+			}
+			e.Logger.Debug("project api call: POST /api/settings/set (multi-value)",
+				"project", pm.CloudKey, "key", settingKey, "values", vals, "org", pm.OrgKey)
+			return e.Cloud.Settings.SetValues(ctx, pm.CloudKey, settingKey, vals, pm.OrgKey)
+		default:
+			// Single-value (STRING/BOOLEAN/INTEGER/FLOAT/SINGLE_SELECT_LIST,
+			// etc.). If SQS returned a list (values=), CSV-join it so SQC
+			// stores it as one string.
+			value := extractField(raw, "value")
+			if value == "" {
+				if vals := extractStringArray(raw, "values"); len(vals) > 0 {
+					value = strings.Join(vals, ",")
+				}
+			}
+			if value == "" {
+				return errSettingEmpty
+			}
+			e.Logger.Debug("project api call: POST /api/settings/set",
+				"project", pm.CloudKey, "key", settingKey, "value", value, "org", pm.OrgKey)
+			return e.Cloud.Settings.Set(ctx, pm.CloudKey, settingKey, value, pm.OrgKey)
+		}
+	}
+
+	// No SQC definition for this key — fall back to dispatching by the
+	// shape of the extract record. This preserves behaviour for custom or
+	// plugin-defined settings that aren't in list_definitions.
 	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
-		e.Logger.Debug("project api call: POST /api/settings/set (multi-value)",
+		e.Logger.Debug("project api call: POST /api/settings/set (multi-value, no SQC def)",
 			"project", pm.CloudKey, "key", settingKey, "values", vals, "org", pm.OrgKey)
 		return e.Cloud.Settings.SetValues(ctx, pm.CloudKey, settingKey, vals, pm.OrgKey)
 	}
 	if fvs := extractObjectArray(raw, "fieldValues"); len(fvs) > 0 {
-		e.Logger.Debug("project api call: POST /api/settings/set (property-set)",
+		e.Logger.Debug("project api call: POST /api/settings/set (property-set, no SQC def)",
 			"project", pm.CloudKey, "key", settingKey, "field_values_count", len(fvs), "org", pm.OrgKey)
 		return e.Cloud.Settings.SetFieldValues(ctx, pm.CloudKey, settingKey, fvs, pm.OrgKey)
 	}
@@ -274,7 +367,7 @@ func applyProjectSetting(ctx context.Context, e *Executor, pm projectMapping, ra
 	if value == "" {
 		return errSettingEmpty
 	}
-	e.Logger.Debug("project api call: POST /api/settings/set",
+	e.Logger.Debug("project api call: POST /api/settings/set (no SQC def)",
 		"project", pm.CloudKey, "key", settingKey, "value", value, "org", pm.OrgKey)
 	return e.Cloud.Settings.Set(ctx, pm.CloudKey, settingKey, value, pm.OrgKey)
 }

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -216,11 +216,17 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 			if projectKey == "" {
 				projectKey = extractField(item.Data, "projectKey")
 			}
+			settingKey := extractField(item.Data, "key")
 			pm, ok := projectKeyMap[item.ServerURL+projectKey]
 			if !ok {
+				// Most common cause: the source project failed createProjects
+				// (or wasn't in this run's scope). Surface it as a Warn so
+				// users see *why* their settings aren't landing on SQC instead
+				// of silently losing them.
+				e.Logger.Warn("setProjectSettings: skipping setting, project not found in migration scope",
+					"project", projectKey, "setting", settingKey, "server", item.ServerURL)
 				return nil
 			}
-			settingKey := extractField(item.Data, "key")
 			if settingKey == "" {
 				return nil
 			}

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -209,7 +209,13 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	counter := NewTaskCounter("setProjectSettings")
 	err := forEachExtractItem(ctx, e, "setProjectSettings", "getProjectSettings",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
-			projectKey := extractField(item.Data, "projectKey")
+			// projectSettingsTask enriches each setting with "project": <key>
+			// (see internal/extract/tasks_projects.go); legacy fixtures used
+			// "projectKey", so accept either to stay robust.
+			projectKey := extractField(item.Data, "project")
+			if projectKey == "" {
+				projectKey = extractField(item.Data, "projectKey")
+			}
 			pm, ok := projectKeyMap[item.ServerURL+projectKey]
 			if !ok {
 				return nil

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -1,0 +1,141 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+)
+
+// TestRunSetProjectSettingsDispatchesByShape verifies that the migrate task
+// dispatches each /api/settings/values record to the right SQC PUT shape:
+//
+//   - single "value"   → "value" form field
+//   - multi  "values"  → repeated "values" form fields
+//   - "fieldValues"    → repeated "fieldValues" JSON-encoded form fields
+//
+// Records missing every payload (only a key) must be skipped silently —
+// not counted as a failure.
+func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
+	type recorded struct {
+		key    string
+		value  string
+		values []string
+		fields []string
+	}
+	var (
+		mu   sync.Mutex
+		hits []recorded
+	)
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		hits = append(hits, recorded{
+			key:    r.FormValue("key"),
+			value:  r.FormValue("value"),
+			values: append([]string(nil), r.Form["values"]...),
+			fields: append([]string(nil), r.Form["fieldValues"]...),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	extractDir := filepath.Join(dir, "extract-01", "getProjectSettings")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, _ := os.Create(filepath.Join(extractDir, "results.1.jsonl"))
+	for _, rec := range []map[string]any{
+		// Single scalar value — should hit the "value" path.
+		{"projectKey": "proj1", "key": "sonar.cfamily.ignoreHeaderComments", "value": "false"},
+		// Multi-value list — should hit the SetValues path.
+		{"projectKey": "proj1", "key": "sonar.exclusions", "values": []string{"src/gen/**", "**/*.spec.ts"}},
+		// Property-set — should hit the SetFieldValues path.
+		{"projectKey": "proj1", "key": "sonar.issue.ignore.allfile",
+			"fieldValues": []map[string]any{{"fileRegexp": "Generated test"}}},
+		// Empty payload — must be skipped silently.
+		{"projectKey": "proj1", "key": "sonar.cleanup.something"},
+	} {
+		b, _ := json.Marshal(rec)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	pw, _ := e.Store.Writer("createProjects")
+	b, _ := json.Marshal(map[string]any{
+		"key": "proj1", "server_url": testServerURL,
+		"sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj1",
+	})
+	pw.WriteOne(b)
+
+	if err := runSetProjectSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetProjectSettings: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(hits) != 3 {
+		t.Fatalf("expected 3 settings calls (empty record skipped), got %d", len(hits))
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].key < hits[j].key })
+
+	// sonar.cfamily.ignoreHeaderComments — single value.
+	cfamily := hits[0]
+	if cfamily.key != "sonar.cfamily.ignoreHeaderComments" || cfamily.value != "false" {
+		t.Errorf("cfamily: got %+v", cfamily)
+	}
+	if len(cfamily.values) != 0 || len(cfamily.fields) != 0 {
+		t.Errorf("cfamily: must not send values/fieldValues, got %+v", cfamily)
+	}
+
+	// sonar.exclusions — multi-value list, repeated "values" param.
+	excl := hits[1]
+	if excl.key != "sonar.exclusions" {
+		t.Errorf("excl: wrong key %q", excl.key)
+	}
+	want := []string{"**/*.spec.ts", "src/gen/**"}
+	sort.Strings(excl.values)
+	for i := range want {
+		if i >= len(excl.values) || excl.values[i] != want[i] {
+			t.Errorf("excl: got values=%v, want %v", excl.values, want)
+			break
+		}
+	}
+	if excl.value != "" {
+		t.Errorf("excl: must not send single value param, got %q", excl.value)
+	}
+
+	// sonar.issue.ignore.allfile — property-set.
+	ifa := hits[2]
+	if ifa.key != "sonar.issue.ignore.allfile" {
+		t.Errorf("ifa: wrong key %q", ifa.key)
+	}
+	if len(ifa.fields) != 1 {
+		t.Fatalf("ifa: expected 1 fieldValues entry, got %d", len(ifa.fields))
+	}
+	var fv map[string]any
+	if err := json.Unmarshal([]byte(ifa.fields[0]), &fv); err != nil {
+		t.Fatalf("ifa: fieldValues JSON: %v", err)
+	}
+	if fv["fileRegexp"] != "Generated test" {
+		t.Errorf("ifa: wrong fieldValues content: %+v", fv)
+	}
+}

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -9,37 +9,35 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
 	"testing"
 )
 
-// TestRunSetProjectSettingsDispatchesByShape verifies that the migrate task
-// dispatches each /api/settings/values record to the right SQC PUT shape:
-//
-//   - single "value"   → "value" form field
-//   - multi  "values"  → repeated "values" form fields
-//   - "fieldValues"    → repeated "fieldValues" JSON-encoded form fields
-//
-// Records missing every payload (only a key) must be skipped silently —
-// not counted as a failure.
-func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
-	type recorded struct {
-		key    string
-		value  string
-		values []string
-		fields []string
-	}
+// settingsHit captures the request shape a /api/settings/set handler saw,
+// so each test can assert exactly one of value=, values=, or fieldValues=
+// was sent (rather than allowing both shapes to coexist).
+type settingsHit struct {
+	key    string
+	value  string
+	values []string
+	fields []string
+}
+
+// mountSettingsSetCapture wires a POST /api/settings/set handler that
+// records every request into the returned slice (guarded by the returned
+// mutex). Each test gets a fresh mux/server pair via this helper.
+func mountSettingsSetCapture(mux *http.ServeMux) (*sync.Mutex, *[]settingsHit) {
 	var (
 		mu   sync.Mutex
-		hits []recorded
+		hits []settingsHit
 	)
-	cloudMux := http.NewServeMux()
-	cloudMux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		mu.Lock()
-		hits = append(hits, recorded{
+		hits = append(hits, settingsHit{
 			key:    r.FormValue("key"),
 			value:  r.FormValue("value"),
 			values: append([]string(nil), r.Form["values"]...),
@@ -48,6 +46,31 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
+	return &mu, &hits
+}
+
+// mountSettingsDefinitions installs a list_definitions handler that
+// returns the supplied keys. Each entry is "<key>:<type>:<multi>" e.g.
+// "sonar.exclusions:STRING:true". Use this to drive the new
+// definition-aware dispatcher in setProjectSettings.
+func mountSettingsDefinitions(mux *http.ServeMux, defs ...map[string]any) {
+	mux.HandleFunc("GET /api/settings/list_definitions", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"definitions": defs})
+	})
+}
+
+// TestRunSetProjectSettingsDispatchesByShape covers the FALLBACK path:
+// when SQC's list_definitions has no entry for a setting key (custom or
+// plugin-defined settings), the task dispatches based on the extract
+// record's shape — values=[...] → SetValues, fieldValues=[...] →
+// SetFieldValues, plain value → Set. Records with no payload at all are
+// skipped silently.
+func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
+	cloudMux := http.NewServeMux()
+	mu, hitsPtr := mountSettingsSetCapture(cloudMux)
+	// Empty definitions registry so EVERY setting falls back to extract
+	// shape — that's exactly what this test exercises.
+	mountSettingsDefinitions(cloudMux)
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})
@@ -98,6 +121,7 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	hits := *hitsPtr
 	if len(hits) != 3 {
 		t.Fatalf("expected 3 settings calls (empty record skipped), got %d", len(hits))
 	}
@@ -146,6 +170,114 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 	}
 }
 
+// TestRunSetProjectSettingsRespectsSQCDefinitions is the regression test
+// for sonar.java.file.suffixes (and any other "looks-multi-on-SQS, stored-
+// as-CSV-string-on-SQC" setting). SQC returns 204 for a malformed shape
+// but doesn't persist — the only way to know which shape is right is to
+// ask SQC's list_definitions and dispatch on its multiValues / type flags.
+func TestRunSetProjectSettingsRespectsSQCDefinitions(t *testing.T) {
+	cloudMux := http.NewServeMux()
+	mu, hitsPtr := mountSettingsSetCapture(cloudMux)
+	// SQC says: file.suffixes is single STRING (CSV), exclusions is
+	// multi-value, issue.ignore.allfile is a PROPERTY_SET. Exactly what
+	// list_definitions returns against sonarcloud.io.
+	mountSettingsDefinitions(cloudMux,
+		map[string]any{"key": "sonar.java.file.suffixes", "type": "STRING", "multiValues": false},
+		map[string]any{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
+		map[string]any{"key": "sonar.issue.ignore.allfile", "type": "PROPERTY_SET", "multiValues": false},
+	)
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	extractDir := filepath.Join(dir, "extract-01", "getProjectSettings")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Every extract record comes in with values=[...] (which is what SQS
+	// returns regardless of how SQC has defined the setting). The dispatcher
+	// must look at SQC's definition to decide the post shape.
+	f, _ := os.Create(filepath.Join(extractDir, "results.1.jsonl"))
+	for _, rec := range []map[string]any{
+		{"project": "proj1", "key": "sonar.java.file.suffixes",
+			"values": []string{".jav", ".java", ".javax"}},
+		{"project": "proj1", "key": "sonar.exclusions",
+			"values": []string{"src/gen/**", "**/*.spec.ts"}},
+		{"project": "proj1", "key": "sonar.issue.ignore.allfile",
+			"fieldValues": []map[string]any{{"fileRegexp": "Generated test"}}},
+	} {
+		b, _ := json.Marshal(rec)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	pw, _ := e.Store.Writer("createProjects")
+	b, _ := json.Marshal(map[string]any{
+		"key": "proj1", "server_url": testServerURL,
+		"sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj1",
+	})
+	pw.WriteOne(b)
+
+	if err := runSetProjectSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetProjectSettings: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	hits := *hitsPtr
+	if len(hits) != 3 {
+		t.Fatalf("expected 3 settings calls, got %d", len(hits))
+	}
+	sort.Slice(hits, func(i, j int) bool { return hits[i].key < hits[j].key })
+
+	// sonar.exclusions: SQC defines multiValues=true → values= shape.
+	excl := hits[0]
+	if excl.key != "sonar.exclusions" {
+		t.Fatalf("excl: wrong key %q", excl.key)
+	}
+	sort.Strings(excl.values)
+	if !reflect.DeepEqual(excl.values, []string{"**/*.spec.ts", "src/gen/**"}) {
+		t.Errorf("excl: got values=%v, want [**/*.spec.ts src/gen/**]", excl.values)
+	}
+	if excl.value != "" {
+		t.Errorf("excl: must NOT collapse to a single CSV value (multiValues=true), got %q", excl.value)
+	}
+
+	// sonar.issue.ignore.allfile: PROPERTY_SET → fieldValues=.
+	ifa := hits[1]
+	if ifa.key != "sonar.issue.ignore.allfile" {
+		t.Fatalf("ifa: wrong key %q", ifa.key)
+	}
+	if len(ifa.fields) != 1 {
+		t.Errorf("ifa: expected 1 fieldValues entry, got %d", len(ifa.fields))
+	}
+
+	// sonar.java.file.suffixes: SQC defines multiValues=false → must be
+	// CSV-joined and sent as value=, NOT as values=. This is the central
+	// regression — sending values= here returns 204 but silently no-ops.
+	jfs := hits[2]
+	if jfs.key != "sonar.java.file.suffixes" {
+		t.Fatalf("jfs: wrong key %q", jfs.key)
+	}
+	if len(jfs.values) != 0 {
+		t.Errorf("jfs: must NOT send values=[%s] for a single-value SQC setting (would 204 but not persist)",
+			strings.Join(jfs.values, ","))
+	}
+	// Order of CSV elements mirrors the extract record's array order.
+	if jfs.value != ".jav,.java,.javax" {
+		t.Errorf("jfs: expected value=\".jav,.java,.javax\", got %q", jfs.value)
+	}
+}
+
 // When a source project failed createProjects (or wasn't in the migrate
 // scope), its settings extract records have no corresponding entry in
 // projectKeyMap. Historically those records were silently dropped, which
@@ -155,6 +287,7 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 // record, naming both the project key and the setting key.
 func TestRunSetProjectSettingsWarnsOnUnmappedProject(t *testing.T) {
 	cloudMux := http.NewServeMux()
+	mountSettingsDefinitions(cloudMux)
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -1,13 +1,16 @@
 package migrate
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -140,5 +143,75 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 	}
 	if fv["fileRegexp"] != "Generated test" {
 		t.Errorf("ifa: wrong fieldValues content: %+v", fv)
+	}
+}
+
+// When a source project failed createProjects (or wasn't in the migrate
+// scope), its settings extract records have no corresponding entry in
+// projectKeyMap. Historically those records were silently dropped, which
+// made setting-migration cascade failures invisible — users would see "task
+// summary succeeded=N" without any hint that N was smaller than expected.
+// This test enforces that the migrate task now logs a Warn line per dropped
+// record, naming both the project key and the setting key.
+func TestRunSetProjectSettingsWarnsOnUnmappedProject(t *testing.T) {
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	// Capture Warn output so the test can assert on it.
+	var buf bytes.Buffer
+	e.Logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	extractDir := filepath.Join(dir, "extract-01", "getProjectSettings")
+	if err := os.MkdirAll(extractDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, _ := os.Create(filepath.Join(extractDir, "results.1.jsonl"))
+	// One record for a project that IS in createProjects, and one for a
+	// project that ISN'T (the realistic cascade case: createProjects failed
+	// for okorach-oss_sonar-tools, so its setting must surface a Warn).
+	for _, rec := range []map[string]any{
+		{"project": "proj1", "key": "sonar.exclusions", "values": []string{"**/*.gen"}},
+		{"project": "okorach-oss_sonar-tools", "key": "sonar.java.file.suffixes",
+			"values": []string{".java", ".jav"}},
+	} {
+		b, _ := json.Marshal(rec)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	pw, _ := e.Store.Writer("createProjects")
+	b, _ := json.Marshal(map[string]any{
+		"key": "proj1", "server_url": testServerURL,
+		"sonarcloud_org_key": "org1", "cloud_project_key": "org1_proj1",
+	})
+	pw.WriteOne(b)
+
+	if err := runSetProjectSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetProjectSettings: %v", err)
+	}
+
+	logs := buf.String()
+	if !strings.Contains(logs, "project not found in migration scope") {
+		t.Errorf("expected Warn for unmapped project, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "okorach-oss_sonar-tools") {
+		t.Errorf("expected dropped project key in Warn, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "sonar.java.file.suffixes") {
+		t.Errorf("expected dropped setting key in Warn, got:\n%s", logs)
+	}
+	// The mapped record (proj1/sonar.exclusions) should NOT produce a Warn.
+	if strings.Contains(logs, "proj1") && strings.Contains(logs, "not found") {
+		t.Errorf("mapped project must not Warn, got:\n%s", logs)
 	}
 }

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -63,15 +63,18 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 	}
 	f, _ := os.Create(filepath.Join(extractDir, "results.1.jsonl"))
 	for _, rec := range []map[string]any{
-		// Single scalar value — should hit the "value" path.
-		{"projectKey": "proj1", "key": "sonar.cfamily.ignoreHeaderComments", "value": "false"},
+		// Single scalar value — should hit the "value" path. Note the real
+		// extract enriches the record with "project" (see
+		// projectSettingsTask), not "projectKey" — mirror that shape so
+		// any future regression on the field name is caught immediately.
+		{"project": "proj1", "key": "sonar.cfamily.ignoreHeaderComments", "value": "false"},
 		// Multi-value list — should hit the SetValues path.
-		{"projectKey": "proj1", "key": "sonar.exclusions", "values": []string{"src/gen/**", "**/*.spec.ts"}},
+		{"project": "proj1", "key": "sonar.exclusions", "values": []string{"src/gen/**", "**/*.spec.ts"}},
 		// Property-set — should hit the SetFieldValues path.
-		{"projectKey": "proj1", "key": "sonar.issue.ignore.allfile",
+		{"project": "proj1", "key": "sonar.issue.ignore.allfile",
 			"fieldValues": []map[string]any{{"fileRegexp": "Generated test"}}},
 		// Empty payload — must be skipped silently.
-		{"projectKey": "proj1", "key": "sonar.cleanup.something"},
+		{"project": "proj1", "key": "sonar.cleanup.something"},
 	} {
 		b, _ := json.Marshal(rec)
 		f.Write(b)

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -808,11 +808,30 @@ func TestSettingsSetValues(t *testing.T) {
 		// Cloud parses the list correctly.
 		assert.Equal(t, []string{"a.java", "b.java", "c.java"}, r.Form["values"])
 		assert.Empty(t, r.Form["value"], "single value param must not be present for multi-value settings")
+		// SonarQube Cloud rejects requests that send both component AND
+		// organization with HTTP 400 "Only component or organization can be
+		// set, not both". Project-level scope is conveyed by component only.
+		assert.Empty(t, r.Form["organization"], "organization must be omitted when component is set")
 		w.WriteHeader(http.StatusNoContent)
 	})
 	cc := newTestCloud(t, mux)
 
 	err := cc.Settings.SetValues(context.Background(), "proj1", "sonar.exclusions", []string{"a.java", "b.java", "c.java"}, "myorg")
+	require.NoError(t, err)
+}
+
+func TestSettingsSetUsesOrgWhenComponentEmpty(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathSettingsSet, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		assert.Empty(t, r.Form["component"], "component must be absent for org-level settings")
+		assert.Equal(t, "myorg", r.FormValue("organization"))
+		assert.Equal(t, "sonar.example", r.FormValue("key"))
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.Settings.Set(context.Background(), "", "sonar.example", "v", "myorg")
 	require.NoError(t, err)
 }
 

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -107,6 +107,33 @@ func TestProjectsCreateWithNewCode(t *testing.T) {
 	assert.Equal(t, "p1", proj.Key)
 }
 
+// SQC rejects /api/projects/create requests that include
+// newCodeDefinitionType without newCodeDefinitionValue (HTTP 400 "Both
+// newCodeDefinitionType and newCodeDefinitionValue must be provided"). For
+// "previous_version" — the SQC default, which has no value — every project
+// in the migration plan would otherwise cascade-fail and break downstream
+// tasks (setProjectSettings, setProjectGates, etc.). The SDK now omits both
+// fields whenever either side is empty.
+func TestProjectsCreateOmitsNewCodeWhenValueMissing(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathProjectsCreate, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		assert.Empty(t, r.Form["newCodeDefinitionType"],
+			"type must be omitted when value is empty (SQC rejects the half-set pair)")
+		assert.Empty(t, r.Form["newCodeDefinitionValue"])
+		writeJSON(w, types.ProjectCreateResponse{Project: types.Project{Key: "p1"}})
+	})
+	cc := newTestCloud(t, mux)
+
+	_, err := cc.Projects.Create(context.Background(), cloud.CreateProjectParams{
+		ProjectKey:            "p1",
+		Name:                  "P",
+		Organization:          "o",
+		NewCodeDefinitionType: "previous_version",
+	})
+	require.NoError(t, err)
+}
+
 func TestProjectsCreateError(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathProjectsCreate, func(w http.ResponseWriter, r *http.Request) {

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -800,14 +800,49 @@ func TestSettingsSetError(t *testing.T) {
 func TestSettingsSetValues(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc(pathSettingsSet, func(w http.ResponseWriter, r *http.Request) {
-		assertFormValue(t, r, "component", "proj1")
-		assertFormValue(t, r, "key", "sonar.exclusions")
-		assertFormValue(t, r, "value", "a.java,b.java,c.java")
+		_ = r.ParseForm()
+		assert.Equal(t, "proj1", r.FormValue("component"))
+		assert.Equal(t, "sonar.exclusions", r.FormValue("key"))
+		// Multi-value settings must be sent as repeated "values" form
+		// parameters (not as a single comma-joined "value") so SonarQube
+		// Cloud parses the list correctly.
+		assert.Equal(t, []string{"a.java", "b.java", "c.java"}, r.Form["values"])
+		assert.Empty(t, r.Form["value"], "single value param must not be present for multi-value settings")
 		w.WriteHeader(http.StatusNoContent)
 	})
 	cc := newTestCloud(t, mux)
 
 	err := cc.Settings.SetValues(context.Background(), "proj1", "sonar.exclusions", []string{"a.java", "b.java", "c.java"}, "myorg")
+	require.NoError(t, err)
+}
+
+func TestSettingsSetFieldValues(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc(pathSettingsSet, func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		assert.Equal(t, "proj1", r.FormValue("component"))
+		assert.Equal(t, "sonar.issue.ignore.allfile", r.FormValue("key"))
+		// Each property-set entry is JSON-encoded and sent as a separate
+		// "fieldValues" form parameter.
+		fv := r.Form["fieldValues"]
+		require.Len(t, fv, 2)
+		var entries []map[string]any
+		for _, raw := range fv {
+			var m map[string]any
+			require.NoError(t, json.Unmarshal([]byte(raw), &m))
+			entries = append(entries, m)
+		}
+		assert.Equal(t, "Generated test", entries[0]["fileRegexp"])
+		assert.Equal(t, "Mock data", entries[1]["fileRegexp"])
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.Settings.SetFieldValues(context.Background(), "proj1", "sonar.issue.ignore.allfile",
+		[]map[string]any{
+			{"fileRegexp": "Generated test"},
+			{"fileRegexp": "Mock data"},
+		}, "myorg")
 	require.NoError(t, err)
 }
 

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -892,6 +892,44 @@ func TestSettingsSetFieldValues(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestSettingsListDefinitions exercises the SDK's read of
+// /api/settings/list_definitions, which the migrate task uses to decide
+// whether each setting key on the target SQC org expects a single value,
+// repeated values, or a property-set fieldValues payload. The migration
+// regression that motivated this endpoint was sonar.java.file.suffixes:
+// SQS returns it as values=[...] but SQC defines it as a single STRING
+// (multiValues=false), so the migrate tool needs SQC's view of the schema
+// — not SQS's — to pick the right shape.
+func TestSettingsListDefinitions(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/settings/list_definitions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
+		writeJSON(w, types.SettingsListDefinitionsResponse{
+			Definitions: []types.SettingDefinition{
+				{Key: "sonar.exclusions", Type: "STRING", MultiValues: true},
+				{Key: "sonar.java.file.suffixes", Type: "STRING", MultiValues: false},
+				{Key: "sonar.issue.ignore.allfile", Type: "PROPERTY_SET", MultiValues: false},
+			},
+		})
+	})
+	cc := newTestCloud(t, mux)
+
+	defs, err := cc.Settings.ListDefinitions(context.Background(), "myorg")
+	require.NoError(t, err)
+	require.Len(t, defs, 3)
+
+	byKey := make(map[string]types.SettingDefinition, len(defs))
+	for _, d := range defs {
+		byKey[d.Key] = d
+	}
+	assert.True(t, byKey["sonar.exclusions"].MultiValues,
+		"sonar.exclusions must round-trip multiValues=true")
+	assert.False(t, byKey["sonar.java.file.suffixes"].MultiValues,
+		"sonar.java.file.suffixes must round-trip multiValues=false — this is the bit that determines whether migrate sends value= or values=")
+	assert.Equal(t, "PROPERTY_SET", byKey["sonar.issue.ignore.allfile"].Type)
+}
+
 // --- Enterprises ---
 
 func TestEnterprisesList(t *testing.T) {

--- a/lib/sq-api-go/cloud/projects.go
+++ b/lib/sq-api-go/cloud/projects.go
@@ -18,7 +18,14 @@ type CreateProjectParams struct {
 	Name         string
 	Organization string
 	Visibility   string
-	// NewCodeDefinitionType and NewCodeDefinitionValue are optional new-code period settings.
+	// NewCodeDefinitionType and NewCodeDefinitionValue are optional new-code
+	// period settings. SonarQube Cloud /api/projects/create rejects requests
+	// that include type without value (HTTP 400: "Both newCodeDefinitionType
+	// and newCodeDefinitionValue must be provided"), so we only forward the
+	// pair when BOTH are non-empty. "previous_version" — which has no value —
+	// is therefore omitted entirely and the project inherits the SQC default
+	// (which is previous_version); project-level NCD can be set later via
+	// /api/new_code_periods/set.
 	NewCodeDefinitionType  string
 	NewCodeDefinitionValue string
 }
@@ -32,10 +39,8 @@ func (p *ProjectsClient) Create(ctx context.Context, params CreateProjectParams)
 	if params.Visibility != "" {
 		form.Set("visibility", params.Visibility)
 	}
-	if params.NewCodeDefinitionType != "" {
+	if params.NewCodeDefinitionType != "" && params.NewCodeDefinitionValue != "" {
 		form.Set("newCodeDefinitionType", params.NewCodeDefinitionType)
-	}
-	if params.NewCodeDefinitionValue != "" {
 		form.Set("newCodeDefinitionValue", params.NewCodeDefinitionValue)
 	}
 

--- a/lib/sq-api-go/cloud/settings.go
+++ b/lib/sq-api-go/cloud/settings.go
@@ -2,8 +2,8 @@ package cloud
 
 import (
 	"context"
+	"encoding/json"
 	"net/url"
-	"strings"
 )
 
 // SettingsClient provides write-path methods for SonarQube Cloud project settings.
@@ -22,15 +22,37 @@ func (s *SettingsClient) Set(ctx context.Context, projectKey, settingKey, value,
 }
 
 // SetValues sets a multi-value project setting via /api/settings/set.
-// values are sent as repeated "values" form parameters.
+// Each entry is sent as a separate "values" form parameter (the encoding
+// the SonarQube/SonarQube Cloud Web API expects for multi-value settings
+// such as sonar.exclusions, sonar.coverage.exclusions, etc.).
 func (s *SettingsClient) SetValues(ctx context.Context, projectKey, settingKey string, values []string, organization string) error {
 	form := url.Values{}
 	form.Set("component", projectKey)
 	form.Set("key", settingKey)
-	// SonarQube accepts multi-value settings as a comma-separated string
-	// in the "value" param, or as repeated "values[]" params. The Python
-	// implementation joins them; we do the same for consistency.
-	form.Set("value", strings.Join(values, ","))
+	for _, v := range values {
+		form.Add("values", v)
+	}
+	if organization != "" {
+		form.Set("organization", organization)
+	}
+	return s.postForm(ctx, "api/settings/set", form, nil)
+}
+
+// SetFieldValues sets a property-set (multi-field) project setting via
+// /api/settings/set. Each entry is JSON-encoded and sent as a separate
+// "fieldValues" form parameter — the encoding used by settings such as
+// sonar.issue.ignore.allfile, sonar.issue.ignore.multicriteria, etc.
+func (s *SettingsClient) SetFieldValues(ctx context.Context, projectKey, settingKey string, fieldValues []map[string]any, organization string) error {
+	form := url.Values{}
+	form.Set("component", projectKey)
+	form.Set("key", settingKey)
+	for _, fv := range fieldValues {
+		encoded, err := json.Marshal(fv)
+		if err != nil {
+			continue
+		}
+		form.Add("fieldValues", string(encoded))
+	}
 	if organization != "" {
 		form.Set("organization", organization)
 	}

--- a/lib/sq-api-go/cloud/settings.go
+++ b/lib/sq-api-go/cloud/settings.go
@@ -10,14 +10,17 @@ import (
 type SettingsClient struct{ baseClient }
 
 // Set sets a single-value project setting via /api/settings/set.
+//
+// The organization argument is accepted for API symmetry but only included
+// in the request when projectKey is empty. SonarQube Cloud rejects requests
+// that include both component and organization with HTTP 400
+// "Only component or organization can be set, not both"; for project-level
+// settings the cloud project key already namespaces by organization.
 func (s *SettingsClient) Set(ctx context.Context, projectKey, settingKey, value, organization string) error {
 	form := url.Values{}
-	form.Set("component", projectKey)
 	form.Set("key", settingKey)
 	form.Set("value", value)
-	if organization != "" {
-		form.Set("organization", organization)
-	}
+	addSettingsScope(form, projectKey, organization)
 	return s.postForm(ctx, "api/settings/set", form, nil)
 }
 
@@ -27,14 +30,11 @@ func (s *SettingsClient) Set(ctx context.Context, projectKey, settingKey, value,
 // such as sonar.exclusions, sonar.coverage.exclusions, etc.).
 func (s *SettingsClient) SetValues(ctx context.Context, projectKey, settingKey string, values []string, organization string) error {
 	form := url.Values{}
-	form.Set("component", projectKey)
 	form.Set("key", settingKey)
 	for _, v := range values {
 		form.Add("values", v)
 	}
-	if organization != "" {
-		form.Set("organization", organization)
-	}
+	addSettingsScope(form, projectKey, organization)
 	return s.postForm(ctx, "api/settings/set", form, nil)
 }
 
@@ -44,7 +44,6 @@ func (s *SettingsClient) SetValues(ctx context.Context, projectKey, settingKey s
 // sonar.issue.ignore.allfile, sonar.issue.ignore.multicriteria, etc.
 func (s *SettingsClient) SetFieldValues(ctx context.Context, projectKey, settingKey string, fieldValues []map[string]any, organization string) error {
 	form := url.Values{}
-	form.Set("component", projectKey)
 	form.Set("key", settingKey)
 	for _, fv := range fieldValues {
 		encoded, err := json.Marshal(fv)
@@ -53,8 +52,20 @@ func (s *SettingsClient) SetFieldValues(ctx context.Context, projectKey, setting
 		}
 		form.Add("fieldValues", string(encoded))
 	}
+	addSettingsScope(form, projectKey, organization)
+	return s.postForm(ctx, "api/settings/set", form, nil)
+}
+
+// addSettingsScope adds exactly one of "component" or "organization" to
+// the request form. SonarQube Cloud rejects calls that include both, so a
+// non-empty projectKey wins (project-level settings inherit organization
+// scope from the cloud project key prefix).
+func addSettingsScope(form url.Values, projectKey, organization string) {
+	if projectKey != "" {
+		form.Set("component", projectKey)
+		return
+	}
 	if organization != "" {
 		form.Set("organization", organization)
 	}
-	return s.postForm(ctx, "api/settings/set", form, nil)
 }

--- a/lib/sq-api-go/cloud/settings.go
+++ b/lib/sq-api-go/cloud/settings.go
@@ -4,10 +4,38 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+
+	"github.com/sonar-solutions/sq-api-go/types"
 )
 
 // SettingsClient provides write-path methods for SonarQube Cloud project settings.
 type SettingsClient struct{ baseClient }
+
+// ListDefinitions returns the setting definitions registered on SonarQube
+// Cloud — used by migration to decide whether each setting key should be
+// posted via "value" (single, possibly CSV-joined), "values" (multi-value
+// list), or "fieldValues" (property-set). The shape returned by SQS's
+// /api/settings/values for a given key is NOT always the same as what SQC
+// expects when writing: e.g. sonar.java.file.suffixes comes back from SQS
+// as a values=[...] array but on SQC is defined as a single STRING property
+// with multiValues=false, so posting it as values= silently no-ops (returns
+// 204 without persisting). Reading the target's definitions removes that
+// guesswork.
+//
+// organization scopes the call to a single SQC org (required for project-
+// level callers). Passing an empty organization returns the global
+// definitions.
+func (s *SettingsClient) ListDefinitions(ctx context.Context, organization string) ([]types.SettingDefinition, error) {
+	path := "api/settings/list_definitions"
+	if organization != "" {
+		path += "?organization=" + url.QueryEscape(organization)
+	}
+	var resp types.SettingsListDefinitionsResponse
+	if err := s.getJSON(ctx, path, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Definitions, nil
+}
 
 // Set sets a single-value project setting via /api/settings/set.
 //

--- a/lib/sq-api-go/types/settings.go
+++ b/lib/sq-api-go/types/settings.go
@@ -14,3 +14,20 @@ type Setting struct {
 type SettingsValuesResponse struct {
 	Settings []Setting `json:"settings"`
 }
+
+// SettingDefinition describes a setting's property type and whether it
+// accepts multiple values, as returned by /api/settings/list_definitions.
+// Only the fields actually consumed during migration are decoded — the
+// API also returns name, description, category, defaultValue, options, and
+// fields, all of which we don't need.
+type SettingDefinition struct {
+	Key         string `json:"key"`
+	Type        string `json:"type"`
+	MultiValues bool   `json:"multiValues"`
+}
+
+// SettingsListDefinitionsResponse is the response envelope for
+// /api/settings/list_definitions.
+type SettingsListDefinitionsResponse struct {
+	Definitions []SettingDefinition `json:"definitions"`
+}


### PR DESCRIPTION
## Summary

Closes #120. Restores end-to-end migration of project-level settings — analysis-scope keys (`sonar.exclusions`, `sonar.inclusions`, `sonar.coverage.*`, `sonar.cpd.*`), per-language settings (`sonar.<lang>.file.suffixes`), external-analyzer settings, etc. — from SonarQube Server to SonarQube Cloud. Five commits, each addressing a distinct gap that was preventing settings from landing on SQC during live `sc-staging.io` testing.

- **Multi-value / property-set dispatch (`5198760`)** — `setProjectSettings` only forwarded scalar `value`, silently dropping multi-value and property-set shapes. Added `applyProjectSetting` to route each record to `Set` / `SetValues` / `SetFieldValues` based on which payload field is populated.
- **Extract field name (`b7397fe`)** — `projectSettingsTask` enriches records with `project`, but the migrate side was reading legacy `projectKey`. Every record was skipped before any API call. Fixed by reading `project` first with `projectKey` fallback.
- **component / organization mutually exclusive (`e0752c7`)** — SQC `/api/settings/set` returns 400 "Only component or organization can be set, not both"; the SDK was sending both. New `addSettingsScope` helper forwards exactly one (component wins for project-scope, organization for org-scope).
- **NCD cascade (`b931bcd`)** — SQC `/api/projects/create` returns 400 when `newCodeDefinitionType` is sent without `newCodeDefinitionValue`. This bit every project whose source NCD is `previous_version` (the SQC default, which has no value): 74 of 78 projects failed createProjects in the user's run, and their settings then cascaded into the silent-drop branch below. SDK now only forwards the NCD pair when both fields are non-empty; per-project NCD remains the responsibility of `setNewCodePeriods`.
- **Visibility on silent drops (`5104d4a`)** — `setProjectSettings` used to `return nil` when the project wasn't in the createProjects map, so cascade failures were invisible. The task now Warns with the project key, setting key, and source server URL whenever a setting is dropped because its project failed (or wasn't in the scope of) createProjects.

## Test plan
- [x] `go test ./...` in both `lib/sq-api-go` and `go/` — full suites pass; new tests `TestProjectsCreateOmitsNewCodeWhenValueMissing`, `TestSettingsSetUsesOrgWhenComponentEmpty`, `TestRunSetProjectSettingsDispatchesByShape`, `TestRunSetProjectSettingsWarnsOnUnmappedProject` cover the four shape regressions.
- [x] `go vet` clean on modified packages (`internal/migrate`, `cloud`).
- [ ] Live re-run against `sc-staging.io` from a fresh extract: confirm `sonar.exclusions` (multi-value) and `sonar.java.file.suffixes` (multi-value, language-specific) both land on SQC for projects in scope, and that any dropped settings now produce a Warn naming the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
