### PR TITLE
Issue #186 Migrate customized SQS global settings to every SQC org

### DIFF
--- a/go/internal/extract/extract_test.go
+++ b/go/internal/extract/extract_test.go
@@ -174,6 +174,15 @@ func newMockServer() *httptest.Server {
 		})
 	})
 
+	mux.HandleFunc("GET /api/settings/list_definitions", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"definitions": []map[string]any{
+				{"key": "sonar.custom", "type": "STRING", "multiValues": false, "defaultValue": ""},
+				{"key": "sonar.core.id", "type": "STRING", "multiValues": false, "defaultValue": "xxx"},
+			},
+		})
+	})
+
 	mux.HandleFunc("GET /api/plugins/installed", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"plugins": []map[string]any{{"key": "findbugs", "name": "FindBugs"}},
@@ -378,7 +387,7 @@ func TestRunExtractFull(t *testing.T) {
 	expectedTasks := []string{
 		"getProjects", "getUsers", "getGroups", "getProfiles", "getGates",
 		"getTemplates", "getDefaultTemplates", "getRules", "getRepos",
-		"getPlugins", "getServerInfo", "getServerSettings", "getUsage",
+		"getPlugins", "getServerInfo", "getServerSettings", "getServerSettingsDefinitions", "getUsage",
 		"getBindings", "getWebhooks", "getServerWebhooks", "getUserPermissions",
 		"getProfileRules", "getTasks",
 		// Per-project tasks

--- a/go/internal/extract/tasks_system.go
+++ b/go/internal/extract/tasks_system.go
@@ -22,6 +22,17 @@ func systemTasks() []TaskDef {
 			},
 		},
 		{
+			// Companion to getServerSettings: extracts the SQS-side
+			// setting definitions (key, type, multiValues, defaultValue)
+			// so the migrate phase can decide which global settings have
+			// been customized (value != defaultValue — issue #186).
+			Name:     "getServerSettingsDefinitions",
+			Editions: AllEditions,
+			Run: func(ctx context.Context, e *Executor) error {
+				return fetchAndWriteArray(ctx, e, "getServerSettingsDefinitions", "api/settings/list_definitions", "definitions", nil, map[string]any{"serverUrl": e.ServerURL})
+			},
+		},
+		{
 			Name:     "getPlugins",
 			Editions: AllEditions,
 			Run: func(ctx context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -46,6 +46,16 @@ func associateTasks() []TaskDef {
 			Dependencies: []string{"createProjects"},
 			Run:          runSetNewCodePeriods,
 		},
+		{
+			// Migrates non-default SQS global settings to every SQC org
+			// in scope. Depends on the org mapping plus both halves of
+			// the SQS settings extract (values + definitions, the latter
+			// supplies the defaultValue used to detect customization).
+			// Issue #186.
+			Name:         "setGlobalSettings",
+			Dependencies: []string{"generateOrganizationMappings"},
+			Run:          runSetGlobalSettings,
+		},
 	}
 }
 
@@ -218,7 +228,7 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	// example: SQS exposes it as values=[.java,.jav] but SQC defines it as
 	// STRING + multiValues=false, so POSTing values= just no-ops with 204).
 	// Reading list_definitions lets us pick the right form per setting key.
-	defsByOrg := loadSettingDefinitions(ctx, e, orgs)
+	defsByOrg := loadSettingDefinitionsForOrgs(ctx, e, orgs, "setProjectSettings")
 
 	counter := NewTaskCounter("setProjectSettings")
 	err := forEachExtractItem(ctx, e, "setProjectSettings", "getProjectSettings",
@@ -266,128 +276,10 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	return err
 }
 
-// loadSettingDefinitions fetches /api/settings/list_definitions for each
-// SonarQube Cloud organization that will receive project settings, and
-// returns a per-org lookup keyed by setting key. A failed fetch for one org
-// is logged at Warn level and yields an empty (not nil) inner map — callers
-// then transparently fall back to extract-shape dispatch for that org.
-func loadSettingDefinitions(ctx context.Context, e *Executor, orgs map[string]struct{}) map[string]map[string]types.SettingDefinition {
-	out := make(map[string]map[string]types.SettingDefinition, len(orgs))
-	for org := range orgs {
-		defs, err := e.Cloud.Settings.ListDefinitions(ctx, org)
-		if err != nil {
-			logAPIWarn(e.Logger, "setProjectSettings: list_definitions failed, falling back to extract-shape dispatch", err, "org", org)
-			out[org] = map[string]types.SettingDefinition{}
-			continue
-		}
-		byKey := make(map[string]types.SettingDefinition, len(defs))
-		for _, d := range defs {
-			byKey[d.Key] = d
-		}
-		out[org] = byKey
-		e.Logger.Debug("setProjectSettings: loaded definitions", "org", org, "count", len(defs))
-	}
-	return out
-}
-
-// errSettingEmpty is the sentinel returned by applyProjectSetting when the
-// extract record had no value / values / fieldValues to send. It is not a
-// real error — the caller silently skips the record.
-var errSettingEmpty = errors.New("setting has no value")
-
-// applyProjectSetting dispatches a single getProjectSettings record to the
-// appropriate SDK call. When a SQC definition is available for the setting
-// key, the post shape is chosen from the target's definition (PROPERTY_SET
-// → fieldValues, multiValues=true → values, otherwise → single CSV-joined
-// value). Without a definition we fall back to the extract record's shape.
-//
-// The definition path matters because SQS and SQC disagree on a handful of
-// settings — notably sonar.java.file.suffixes — where SQS returns
-// values=[...] but SQC's definition is a single STRING with
-// multiValues=false. POSTing values= to such a setting on SQC returns 204
-// but silently fails to persist; joining with comma and POSTing as value=
-// is what actually lands.
+// applyProjectSetting dispatches a single getProjectSettings record via
+// the shared definition-aware dispatcher. See applySettingByDef.
 func applyProjectSetting(ctx context.Context, e *Executor, pm projectMapping, raw json.RawMessage, settingKey string, def types.SettingDefinition, hasDef bool) error {
-	if hasDef {
-		switch {
-		case def.Type == "PROPERTY_SET":
-			fvs := extractObjectArray(raw, "fieldValues")
-			if len(fvs) == 0 {
-				return errSettingEmpty
-			}
-			e.Logger.Debug("project api call: POST /api/settings/set (property-set)",
-				"project", pm.CloudKey, "key", settingKey, "field_values_count", len(fvs), "org", pm.OrgKey)
-			return e.Cloud.Settings.SetFieldValues(ctx, pm.CloudKey, settingKey, fvs, pm.OrgKey)
-		case def.MultiValues:
-			vals := extractStringArray(raw, "values")
-			if len(vals) == 0 {
-				if v := extractField(raw, "value"); v != "" {
-					vals = strings.Split(v, ",")
-				}
-			}
-			if len(vals) == 0 {
-				return errSettingEmpty
-			}
-			e.Logger.Debug("project api call: POST /api/settings/set (multi-value)",
-				"project", pm.CloudKey, "key", settingKey, "values", vals, "org", pm.OrgKey)
-			return e.Cloud.Settings.SetValues(ctx, pm.CloudKey, settingKey, vals, pm.OrgKey)
-		default:
-			// Single-value (STRING/BOOLEAN/INTEGER/FLOAT/SINGLE_SELECT_LIST,
-			// etc.). If SQS returned a list (values=), CSV-join it so SQC
-			// stores it as one string.
-			value := extractField(raw, "value")
-			if value == "" {
-				if vals := extractStringArray(raw, "values"); len(vals) > 0 {
-					value = strings.Join(vals, ",")
-				}
-			}
-			if value == "" {
-				return errSettingEmpty
-			}
-			e.Logger.Debug("project api call: POST /api/settings/set",
-				"project", pm.CloudKey, "key", settingKey, "value", value, "org", pm.OrgKey)
-			return e.Cloud.Settings.Set(ctx, pm.CloudKey, settingKey, value, pm.OrgKey)
-		}
-	}
-
-	// No SQC definition for this key — fall back to dispatching by the
-	// shape of the extract record. This preserves behaviour for custom or
-	// plugin-defined settings that aren't in list_definitions.
-	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
-		e.Logger.Debug("project api call: POST /api/settings/set (multi-value, no SQC def)",
-			"project", pm.CloudKey, "key", settingKey, "values", vals, "org", pm.OrgKey)
-		return e.Cloud.Settings.SetValues(ctx, pm.CloudKey, settingKey, vals, pm.OrgKey)
-	}
-	if fvs := extractObjectArray(raw, "fieldValues"); len(fvs) > 0 {
-		e.Logger.Debug("project api call: POST /api/settings/set (property-set, no SQC def)",
-			"project", pm.CloudKey, "key", settingKey, "field_values_count", len(fvs), "org", pm.OrgKey)
-		return e.Cloud.Settings.SetFieldValues(ctx, pm.CloudKey, settingKey, fvs, pm.OrgKey)
-	}
-	value := extractField(raw, "value")
-	if value == "" {
-		return errSettingEmpty
-	}
-	e.Logger.Debug("project api call: POST /api/settings/set (no SQC def)",
-		"project", pm.CloudKey, "key", settingKey, "value", value, "org", pm.OrgKey)
-	return e.Cloud.Settings.Set(ctx, pm.CloudKey, settingKey, value, pm.OrgKey)
-}
-
-// extractObjectArray reads a []map[string]any from a JSON field. Returns
-// nil for missing fields, non-array shapes, or empty arrays.
-func extractObjectArray(raw json.RawMessage, key string) []map[string]any {
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return nil
-	}
-	arrRaw, ok := obj[key]
-	if !ok {
-		return nil
-	}
-	var arr []map[string]any
-	if err := json.Unmarshal(arrRaw, &arr); err != nil {
-		return nil
-	}
-	return arr
+	return applySettingByDef(ctx, e, pm.CloudKey, pm.OrgKey, raw, settingKey, def, hasDef)
 }
 
 // runSetNewCodePeriods migrates per-branch new-code policy. It iterates the

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -1,0 +1,241 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/sonar-solutions/sq-api-go/types"
+	"golang.org/x/sync/errgroup"
+)
+
+// runSetGlobalSettings migrates customized SQS-side global settings to
+// every SonarQube Cloud organization in scope (issue #186).
+//
+// Pipeline:
+//
+//  1. Read getServerSettingsDefinitions to learn each SQS setting's
+//     defaultValue (and shape) — that's how we detect "customized".
+//  2. Read getServerSettings (raw values) and filter out any setting
+//     whose value equals the SQS default — uncustomized settings are
+//     skipped entirely.
+//  3. Read generateOrganizationMappings and collect every target
+//     sonarcloud_org_key that isn't empty / SKIPPED.
+//  4. For each org, fetch SQC's list_definitions once (cached) so we know
+//     which keys actually exist on the target and what shape (single /
+//     multi / property-set) they expect.
+//  5. For each (customized SQS setting × target SQC org):
+//     – not in SQC's defs → log Warn, record skipped(reason=not-on-sqc).
+//     – in SQC's defs → dispatch via applySettingByDef (the same helper
+//     that drives setProjectSettings, but with empty projectKey so the
+//     SDK scopes the request to the organization).
+//  6. Emit one JSONL record per setting key, with applied / failed /
+//     skipped org lists plus a pre-built "detail" string that the
+//     summary report renders verbatim.
+func runSetGlobalSettings(ctx context.Context, e *Executor) error {
+	// SQS-side definitions — keyed by setting key. Drives the
+	// "customized?" check below.
+	sqsDefRecords, _ := e.Store.ReadAll("getServerSettingsDefinitions")
+	sqsDefaultByKey := make(map[string]string, len(sqsDefRecords))
+	for _, d := range sqsDefRecords {
+		k := extractField(d, "key")
+		if k == "" {
+			continue
+		}
+		sqsDefaultByKey[k] = extractField(d, "defaultValue")
+	}
+
+	// Raw SQS global settings — kept only when customized.
+	sqsValues, _ := e.Store.ReadAll("getServerSettings")
+	customized := make([]json.RawMessage, 0, len(sqsValues))
+	for _, raw := range sqsValues {
+		key := extractField(raw, "key")
+		if key == "" {
+			continue
+		}
+		if !isSettingCustomized(raw, sqsDefaultByKey[key]) {
+			continue
+		}
+		customized = append(customized, raw)
+	}
+
+	// Target SQC orgs.
+	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")
+	orgs := make(map[string]struct{})
+	orgList := make([]string, 0, len(orgItems))
+	for _, o := range orgItems {
+		orgKey := extractField(o, "sonarcloud_org_key")
+		if shouldSkipOrg(orgKey) {
+			continue
+		}
+		if _, dup := orgs[orgKey]; dup {
+			continue
+		}
+		orgs[orgKey] = struct{}{}
+		orgList = append(orgList, orgKey)
+	}
+	sort.Strings(orgList)
+
+	e.Logger.Info("starting task", "task", "setGlobalSettings",
+		"customized_settings", len(customized), "target_orgs", len(orgList))
+
+	// One list_definitions fetch per target org.
+	defsByOrg := loadSettingDefinitionsForOrgs(ctx, e, orgs, "setGlobalSettings")
+
+	counter := NewTaskCounter("setGlobalSettings")
+	w, err := e.Store.Writer("setGlobalSettings")
+	if err != nil {
+		return err
+	}
+
+	var mu sync.Mutex
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(cap(e.Sem))
+	for _, raw := range customized {
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+			rec := applyOneGlobalSetting(gctx, e, raw, orgList, defsByOrg, counter)
+			b, _ := json.Marshal(rec)
+			mu.Lock()
+			defer mu.Unlock()
+			return w.WriteOne(b)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	counter.LogSummary(e.Logger)
+	return nil
+}
+
+// applyOneGlobalSetting applies a single customized SQS global setting to
+// every target SQC org and returns a result record describing the per-org
+// outcomes plus a pre-built detail string for the report.
+func applyOneGlobalSetting(ctx context.Context, e *Executor, raw json.RawMessage, orgs []string,
+	defsByOrg map[string]map[string]types.SettingDefinition, counter *TaskCounter) globalSettingResult {
+
+	key := extractField(raw, "key")
+	rec := globalSettingResult{Key: key}
+	rec.Value, rec.Values, rec.FieldValues = readSettingPayload(raw)
+
+	for _, org := range orgs {
+		def, hasDef := defsByOrg[org][key]
+		if !hasDef {
+			e.Logger.Warn("setGlobalSettings: setting key not available on SQC, skipping",
+				"key", key, "org", org)
+			rec.SkippedOrgs = append(rec.SkippedOrgs, skippedOrg{Org: org, Reason: "not-on-sqc"})
+			continue
+		}
+		err := applySettingByDef(ctx, e, "", org, raw, key, def, true)
+		switch {
+		case errors.Is(err, errSettingEmpty):
+			rec.SkippedOrgs = append(rec.SkippedOrgs, skippedOrg{Org: org, Reason: "empty"})
+		case err != nil:
+			counter.Fail()
+			logAPIWarn(e.Logger, "setGlobalSettings failed", err, "key", key, "org", org)
+			rec.FailedOrgs = append(rec.FailedOrgs, failedOrg{Org: org, Reason: err.Error()})
+		default:
+			counter.Success()
+			rec.AppliedOrgs = append(rec.AppliedOrgs, org)
+		}
+	}
+	rec.Detail = renderGlobalSettingDetail(rec)
+	return rec
+}
+
+// isSettingCustomized reports whether the SQS-side value for a setting
+// differs from its declared defaultValue. SQS exposes values in three
+// shapes (value / values / fieldValues); for the comparison we collapse
+// each into a comparable scalar string — fieldValues collapses to its
+// JSON encoding, values to a sorted CSV.
+func isSettingCustomized(raw json.RawMessage, defaultValue string) bool {
+	if fvs := extractObjectArray(raw, "fieldValues"); len(fvs) > 0 {
+		// PROPERTY_SET — defaultValue is unlikely to match a complex
+		// JSON payload, so treat any populated fieldValues as
+		// customized.
+		return true
+	}
+	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
+		sorted := append([]string(nil), vals...)
+		sort.Strings(sorted)
+		joined := strings.Join(sorted, ",")
+		defSorted := strings.Split(defaultValue, ",")
+		sort.Strings(defSorted)
+		return joined != strings.Join(defSorted, ",")
+	}
+	return extractField(raw, "value") != defaultValue
+}
+
+// readSettingPayload extracts the three possible value shapes from a
+// settings record so the result can be serialized back into the output
+// JSONL record exactly as it came from SQS.
+func readSettingPayload(raw json.RawMessage) (value string, values []string, fieldValues []map[string]any) {
+	return extractField(raw, "value"),
+		extractStringArray(raw, "values"),
+		extractObjectArray(raw, "fieldValues")
+}
+
+// renderGlobalSettingDetail produces the string the summary report shows
+// in the Detail column for one global-setting row. Matches the format
+// requested in issue #186: "value=… — applied to: org1, org2".
+func renderGlobalSettingDetail(r globalSettingResult) string {
+	var parts []string
+	switch {
+	case len(r.FieldValues) > 0:
+		b, _ := json.Marshal(r.FieldValues)
+		parts = append(parts, fmt.Sprintf("fieldValues=%s", string(b)))
+	case len(r.Values) > 0:
+		parts = append(parts, fmt.Sprintf("values=[%s]", strings.Join(r.Values, ",")))
+	default:
+		parts = append(parts, fmt.Sprintf("value=%s", r.Value))
+	}
+	if len(r.AppliedOrgs) > 0 {
+		parts = append(parts, "applied to: "+strings.Join(r.AppliedOrgs, ", "))
+	}
+	if len(r.SkippedOrgs) > 0 {
+		skipped := make([]string, 0, len(r.SkippedOrgs))
+		for _, s := range r.SkippedOrgs {
+			skipped = append(skipped, fmt.Sprintf("%s (%s)", s.Org, s.Reason))
+		}
+		parts = append(parts, "skipped: "+strings.Join(skipped, ", "))
+	}
+	if len(r.FailedOrgs) > 0 {
+		failed := make([]string, 0, len(r.FailedOrgs))
+		for _, f := range r.FailedOrgs {
+			failed = append(failed, f.Org)
+		}
+		parts = append(parts, "failed: "+strings.Join(failed, ", "))
+	}
+	return strings.Join(parts, " — ")
+}
+
+// globalSettingResult is the per-setting record written to the
+// setGlobalSettings task output (one JSONL line per setting key) and
+// read back by the summary report to populate the Global Settings
+// section.
+type globalSettingResult struct {
+	Key         string           `json:"key"`
+	Value       string           `json:"value,omitempty"`
+	Values      []string         `json:"values,omitempty"`
+	FieldValues []map[string]any `json:"fieldValues,omitempty"`
+	AppliedOrgs []string         `json:"applied_orgs,omitempty"`
+	SkippedOrgs []skippedOrg     `json:"skipped_orgs,omitempty"`
+	FailedOrgs  []failedOrg      `json:"failed_orgs,omitempty"`
+	Detail      string           `json:"detail"`
+}
+
+type skippedOrg struct {
+	Org    string `json:"org"`
+	Reason string `json:"reason"`
+}
+
+type failedOrg struct {
+	Org    string `json:"org"`
+	Reason string `json:"reason"`
+}

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -47,20 +47,33 @@ const (
 //     skipped org lists plus a pre-built "detail" string that the
 //     summary report renders verbatim.
 func runSetGlobalSettings(ctx context.Context, e *Executor) error {
-	// SQS-side definitions — keyed by setting key. Drives the
-	// "customized?" check below.
-	sqsDefRecords, _ := e.Store.ReadAll("getServerSettingsDefinitions")
-	sqsDefaultByKey := make(map[string]string, len(sqsDefRecords))
-	for _, d := range sqsDefRecords {
-		k := extractField(d, "key")
+	// getServerSettings and getServerSettingsDefinitions are EXTRACT
+	// tasks — their output lives in the per-server extract directories
+	// (one level above the migrate run dir) and is reached via
+	// readExtractItems / e.Mapping. Using e.Store.ReadAll here would
+	// silently return zero records and the task would no-op.
+	sqsDefItems, err := readExtractItems(e, "getServerSettingsDefinitions")
+	if err != nil {
+		return fmt.Errorf("setGlobalSettings: reading getServerSettingsDefinitions: %w", err)
+	}
+	sqsDefaultByKey := make(map[string]string, len(sqsDefItems))
+	for _, d := range sqsDefItems {
+		k := extractField(d.Data, "key")
 		if k == "" {
 			continue
 		}
-		sqsDefaultByKey[k] = extractField(d, "defaultValue")
+		sqsDefaultByKey[k] = extractField(d.Data, "defaultValue")
 	}
 
 	// Raw SQS global settings — kept only when customized.
-	sqsValues, _ := e.Store.ReadAll("getServerSettings")
+	sqsItems, err := readExtractItems(e, "getServerSettings")
+	if err != nil {
+		return fmt.Errorf("setGlobalSettings: reading getServerSettings: %w", err)
+	}
+	sqsValues := make([]json.RawMessage, 0, len(sqsItems))
+	for _, it := range sqsItems {
+		sqsValues = append(sqsValues, it.Data)
+	}
 	customized := make([]json.RawMessage, 0, len(sqsValues))
 	for _, raw := range sqsValues {
 		key := extractField(raw, "key")

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -5,12 +5,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"sync"
 
 	"github.com/sonar-solutions/sq-api-go/types"
 	"golang.org/x/sync/errgroup"
+)
+
+// SQS-only key with no direct SQC equivalent: its patterns are
+// platform-enforced "always-exclude" globs. On SQC the closest match is
+// sonar.exclusions, so the migrate task folds sonar.global.exclusions's
+// patterns into sonar.exclusions before posting (issue #186 follow-up).
+const (
+	sqsGlobalExclusionsKey = "sonar.global.exclusions"
+	sqsExclusionsKey       = "sonar.exclusions"
 )
 
 // runSetGlobalSettings migrates customized SQS-side global settings to
@@ -62,6 +72,13 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 		}
 		customized = append(customized, raw)
 	}
+
+	// SQS exposes platform-enforced exclusion patterns via
+	// sonar.global.exclusions; SQC has no equivalent key. Fold its
+	// patterns into sonar.exclusions so the platform-level enforcement
+	// is preserved on SQC; drop sonar.global.exclusions from the
+	// migration list so it doesn't trigger a "not-on-sqc" Warn.
+	customized = mergeGlobalExclusionsIntoExclusions(sqsValues, customized, e.Logger)
 
 	// Target SQC orgs.
 	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")
@@ -123,6 +140,10 @@ func applyOneGlobalSetting(ctx context.Context, e *Executor, raw json.RawMessage
 	key := extractField(raw, "key")
 	rec := globalSettingResult{Key: key}
 	rec.Value, rec.Values, rec.FieldValues = readSettingPayload(raw)
+	// Carry the merge marker through to the output record so the report
+	// can call out that sonar.exclusions was sourced from SQS's
+	// sonar.global.exclusions in addition to sonar.exclusions.
+	rec.MergedFromGlobal = extractBool(raw, "_merged_from_global")
 
 	for _, org := range orgs {
 		def, hasDef := defsByOrg[org][key]
@@ -147,6 +168,119 @@ func applyOneGlobalSetting(ctx context.Context, e *Executor, raw json.RawMessage
 	}
 	rec.Detail = renderGlobalSettingDetail(rec)
 	return rec
+}
+
+// mergeGlobalExclusionsIntoExclusions folds SQS's
+// sonar.global.exclusions patterns into the sonar.exclusions record so
+// the merged set lands on SQC's sonar.exclusions setting (SQC has no
+// global-exclusions counterpart). The synthesized record carries a
+// _merged_from_global marker that renderGlobalSettingDetail picks up so
+// the report calls out the merge.
+//
+// Behaviour rules:
+//   - If sonar.global.exclusions has no values (or value=) on SQS, this
+//     is a no-op — the original customized list passes through.
+//   - If sonar.global.exclusions IS set, the synthesized sonar.exclusions
+//     record carries the union (order-preserving, deduped) of the global
+//     patterns and the project-default patterns.
+//   - sonar.global.exclusions is removed from the customized list — its
+//     patterns have moved to sonar.exclusions, so there's nothing to
+//     migrate under the original key.
+//   - If sonar.exclusions wasn't customized on its own (only the global
+//     side was) we still emit the synthesized record so the global
+//     patterns make it to SQC.
+func mergeGlobalExclusionsIntoExclusions(sqsValues []json.RawMessage, customized []json.RawMessage, logger *slog.Logger) []json.RawMessage {
+	// Look up both sides in the full extract — we need the global patterns
+	// even if sonar.exclusions itself wasn't filtered into `customized`.
+	var globalRec, exclusionsRec json.RawMessage
+	for _, raw := range sqsValues {
+		switch extractField(raw, "key") {
+		case sqsGlobalExclusionsKey:
+			globalRec = raw
+		case sqsExclusionsKey:
+			exclusionsRec = raw
+		}
+	}
+	globalVals := readPatterns(globalRec)
+	if len(globalVals) == 0 {
+		return customized
+	}
+	exclusionsVals := readPatterns(exclusionsRec)
+	merged := unionPreservingOrder(globalVals, exclusionsVals)
+
+	synth := map[string]any{
+		"key":                 sqsExclusionsKey,
+		"values":              merged,
+		"_merged_from_global": true,
+	}
+	synthRaw, _ := json.Marshal(synth)
+
+	out := make([]json.RawMessage, 0, len(customized)+1)
+	replaced := false
+	for _, raw := range customized {
+		switch extractField(raw, "key") {
+		case sqsGlobalExclusionsKey:
+			// Drop — its patterns have moved into sonar.exclusions.
+			continue
+		case sqsExclusionsKey:
+			out = append(out, synthRaw)
+			replaced = true
+		default:
+			out = append(out, raw)
+		}
+	}
+	if !replaced {
+		// sonar.exclusions wasn't in the customized list (it was at
+		// SQS default), but the global side was set — synthesize a
+		// record so the global patterns make it across.
+		out = append(out, synthRaw)
+	}
+	logger.Info("setGlobalSettings: merged sonar.global.exclusions into sonar.exclusions",
+		"global_patterns", len(globalVals),
+		"exclusions_patterns", len(exclusionsVals),
+		"merged_patterns", len(merged))
+	return out
+}
+
+// readPatterns reads exclusion-style patterns from a setting record,
+// handling both shapes that /api/settings/values may return (values=[...]
+// for a multi-value field, value="csv,joined" for a single field).
+func readPatterns(raw json.RawMessage) []string {
+	if raw == nil {
+		return nil
+	}
+	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
+		return vals
+	}
+	if v := extractField(raw, "value"); v != "" {
+		return strings.Split(v, ",")
+	}
+	return nil
+}
+
+// unionPreservingOrder returns the deduplicated concatenation a ++ b,
+// preserving first-seen order. Used to merge two exclusion lists into a
+// stable, predictable single list.
+func unionPreservingOrder(a, b []string) []string {
+	seen := make(map[string]bool, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range a {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	for _, s := range b {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
 }
 
 // isSettingCustomized reports whether the SQS-side value for a setting
@@ -195,6 +329,15 @@ func renderGlobalSettingDetail(r globalSettingResult) string {
 	default:
 		parts = append(parts, fmt.Sprintf("value=%s", r.Value))
 	}
+	if r.MergedFromGlobal {
+		// Surface the cross-key merge so an operator inspecting the
+		// report can see where the patterns actually came from. This
+		// satisfies the issue requirement that the report "detail that
+		// SQC org sonar.exclusions is set from the combination of the
+		// SQS global sonar.global.exclusions and sonar.exclusions
+		// setting".
+		parts = append(parts, "merged from sonar.global.exclusions + sonar.exclusions")
+	}
 	if len(r.AppliedOrgs) > 0 {
 		parts = append(parts, "applied to: "+strings.Join(r.AppliedOrgs, ", "))
 	}
@@ -220,14 +363,15 @@ func renderGlobalSettingDetail(r globalSettingResult) string {
 // read back by the summary report to populate the Global Settings
 // section.
 type globalSettingResult struct {
-	Key         string           `json:"key"`
-	Value       string           `json:"value,omitempty"`
-	Values      []string         `json:"values,omitempty"`
-	FieldValues []map[string]any `json:"fieldValues,omitempty"`
-	AppliedOrgs []string         `json:"applied_orgs,omitempty"`
-	SkippedOrgs []skippedOrg     `json:"skipped_orgs,omitempty"`
-	FailedOrgs  []failedOrg      `json:"failed_orgs,omitempty"`
-	Detail      string           `json:"detail"`
+	Key              string           `json:"key"`
+	Value            string           `json:"value,omitempty"`
+	Values           []string         `json:"values,omitempty"`
+	FieldValues      []map[string]any `json:"fieldValues,omitempty"`
+	AppliedOrgs      []string         `json:"applied_orgs,omitempty"`
+	SkippedOrgs      []skippedOrg     `json:"skipped_orgs,omitempty"`
+	FailedOrgs       []failedOrg      `json:"failed_orgs,omitempty"`
+	Detail           string           `json:"detail"`
+	MergedFromGlobal bool             `json:"merged_from_global,omitempty"`
 }
 
 type skippedOrg struct {

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1,0 +1,236 @@
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// runGlobalSettingsTest wires up the cloud / api mocks and the executor
+// for setGlobalSettings tests. Each test case provides:
+//
+//   - sqsSettings: the records that getServerSettings would have produced
+//     (one map per setting; the test serializes them to JSONL).
+//   - sqsDefs:     the records that getServerSettingsDefinitions produced
+//     (used to detect customization via defaultValue).
+//   - orgs:        the records that generateOrganizationMappings produced.
+//   - sqcDefs:     the response body for SQC's list_definitions endpoint.
+//
+// It returns the captured /api/settings/set requests and the captured
+// Warn-log buffer so each test can assert independently.
+func runGlobalSettingsTest(t *testing.T,
+	sqsSettings []map[string]any,
+	sqsDefs []map[string]any,
+	orgs []map[string]any,
+	sqcDefs []map[string]any,
+) (hits []settingsHit, logs string) {
+
+	t.Helper()
+	cloudMux := http.NewServeMux()
+	muHits, hitsPtr := mountSettingsSetCapture(cloudMux)
+	mountSettingsDefinitions(cloudMux, sqcDefs...)
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	t.Cleanup(cloudSrv.Close)
+
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	var logBuf bytes.Buffer
+	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	writeTaskJSONL(t, e, "getServerSettings", sqsSettings)
+	writeTaskJSONL(t, e, "getServerSettingsDefinitions", sqsDefs)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", orgs)
+
+	if err := runSetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetGlobalSettings: %v", err)
+	}
+
+	muHits.Lock()
+	defer muHits.Unlock()
+	hits = append(hits, *hitsPtr...)
+	return hits, logBuf.String()
+}
+
+// writeTaskJSONL writes a slice of maps as JSONL into the named task's output
+// in the migrate store — mirrors what an earlier task would have done.
+func writeTaskJSONL(t *testing.T, e *Executor, task string, records []map[string]any) {
+	t.Helper()
+	w, err := e.Store.Writer(task)
+	if err != nil {
+		t.Fatalf("writer(%s): %v", task, err)
+	}
+	for _, r := range records {
+		b, _ := json.Marshal(r)
+		if err := w.WriteOne(b); err != nil {
+			t.Fatalf("write(%s): %v", task, err)
+		}
+	}
+}
+
+// Settings whose value matches the SQS defaultValue must not produce any
+// /api/settings/set request — they're not customized.
+func TestRunSetGlobalSettingsSkipsWhenValueEqualsDefault(t *testing.T) {
+	hits, _ := runGlobalSettingsTest(t,
+		// SQS extract values
+		[]map[string]any{
+			{"key": "sonar.foo", "value": "default-foo"}, // matches default → skip
+			{"key": "sonar.bar", "value": "custom-bar"},  // differs → migrate
+		},
+		// SQS list_definitions
+		[]map[string]any{
+			{"key": "sonar.foo", "type": "STRING", "multiValues": false, "defaultValue": "default-foo"},
+			{"key": "sonar.bar", "type": "STRING", "multiValues": false, "defaultValue": "default-bar"},
+		},
+		// Org mapping
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+		},
+		// SQC list_definitions — keys present
+		[]map[string]any{
+			{"key": "sonar.foo", "type": "STRING", "multiValues": false},
+			{"key": "sonar.bar", "type": "STRING", "multiValues": false},
+		},
+	)
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 settings.set call (only customized setting), got %d", len(hits))
+	}
+	if hits[0].key != "sonar.bar" {
+		t.Errorf("expected the customized setting to be migrated, got %q", hits[0].key)
+	}
+}
+
+// Customized setting + key on SQC with multiValues=true → send via
+// values=. The test also confirms the request is org-scoped, not
+// component-scoped.
+func TestRunSetGlobalSettingsMultiValueOnSQC(t *testing.T) {
+	hits, _ := runGlobalSettingsTest(t,
+		[]map[string]any{
+			{"key": "sonar.exclusions", "values": []string{"**/*.gen", "build/**"}},
+		},
+		[]map[string]any{
+			{"key": "sonar.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
+		},
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+			{"sonarcloud_org_key": "org2"},
+		},
+		[]map[string]any{
+			{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
+		},
+	)
+	if len(hits) != 2 {
+		t.Fatalf("expected 2 calls (one per org), got %d", len(hits))
+	}
+	for _, h := range hits {
+		if h.key != "sonar.exclusions" {
+			t.Errorf("wrong key: %q", h.key)
+		}
+		if len(h.values) != 2 {
+			t.Errorf("expected values= shape (multiValues=true), got %+v", h)
+		}
+		if h.value != "" {
+			t.Errorf("must NOT collapse multi-value to single value=, got %q", h.value)
+		}
+	}
+}
+
+// Customized setting + key on SQC with multiValues=false → SQS array
+// must be CSV-joined into a single value= param (same trick as the
+// sonar.java.file.suffixes fix from #120).
+func TestRunSetGlobalSettingsSingleValueOnSQCJoinsCSV(t *testing.T) {
+	hits, _ := runGlobalSettingsTest(t,
+		[]map[string]any{
+			{"key": "sonar.java.file.suffixes", "values": []string{".java", ".jav"}},
+		},
+		[]map[string]any{
+			{"key": "sonar.java.file.suffixes", "type": "STRING", "multiValues": true, "defaultValue": ".java"},
+		},
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+		},
+		[]map[string]any{
+			{"key": "sonar.java.file.suffixes", "type": "STRING", "multiValues": false},
+		},
+	)
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(hits))
+	}
+	h := hits[0]
+	if len(h.values) != 0 {
+		t.Errorf("must NOT send values= for a single-value SQC setting, got %v", h.values)
+	}
+	if h.value != ".java,.jav" {
+		t.Errorf("expected CSV-joined value, got %q", h.value)
+	}
+}
+
+// Customized setting whose key is NOT in SQC's list_definitions → no
+// /api/settings/set request, and a Warn must be logged naming both the
+// setting key and the org.
+func TestRunSetGlobalSettingsWarnsWhenKeyNotOnSQC(t *testing.T) {
+	hits, logs := runGlobalSettingsTest(t,
+		[]map[string]any{
+			{"key": "sonar.sqs.only", "value": "custom"},
+		},
+		[]map[string]any{
+			{"key": "sonar.sqs.only", "type": "STRING", "multiValues": false, "defaultValue": "default"},
+		},
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+		},
+		// SQC doesn't define sonar.sqs.only at all.
+		[]map[string]any{},
+	)
+	if len(hits) != 0 {
+		t.Fatalf("expected zero API calls for SQS-only setting, got %d", len(hits))
+	}
+	if !strings.Contains(logs, "setting key not available on SQC") {
+		t.Errorf("expected Warn about SQC-missing key, got:\n%s", logs)
+	}
+	if !strings.Contains(logs, "sonar.sqs.only") || !strings.Contains(logs, "org1") {
+		t.Errorf("expected Warn to name the setting key and org, got:\n%s", logs)
+	}
+}
+
+// Customized PROPERTY_SET setting → sent via fieldValues= shape.
+func TestRunSetGlobalSettingsPropertySet(t *testing.T) {
+	hits, _ := runGlobalSettingsTest(t,
+		[]map[string]any{
+			{"key": "sonar.issue.ignore.allfile",
+				"fieldValues": []map[string]any{{"fileRegexp": "Generated test"}}},
+		},
+		[]map[string]any{
+			// defaultValue irrelevant for property-set: isSettingCustomized
+			// treats any non-empty fieldValues as customized.
+			{"key": "sonar.issue.ignore.allfile", "type": "PROPERTY_SET", "multiValues": false},
+		},
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+		},
+		[]map[string]any{
+			{"key": "sonar.issue.ignore.allfile", "type": "PROPERTY_SET", "multiValues": false},
+		},
+	)
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(hits))
+	}
+	if len(hits[0].fields) != 1 {
+		t.Errorf("expected fieldValues= shape, got %+v", hits[0])
+	}
+}
+
+// Compile-time guard: catch accidental removal of the helper that drives
+// most tests above.
+var _ = sync.Mutex{}

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -228,6 +229,100 @@ func TestRunSetGlobalSettingsPropertySet(t *testing.T) {
 	}
 	if len(hits[0].fields) != 1 {
 		t.Errorf("expected fieldValues= shape, got %+v", hits[0])
+	}
+}
+
+// SQS exposes sonar.global.exclusions (platform-enforced patterns) and
+// sonar.exclusions (per-project default) separately, but SQC has only
+// sonar.exclusions. The migrate task must:
+//
+//   - send a single sonar.exclusions PATCH whose values= is the union of
+//     both SQS keys (deduped, order preserved),
+//   - NOT emit a "not-on-sqc" Warn for sonar.global.exclusions (SQC has no
+//     such key, but its patterns are still being migrated — just under a
+//     different name), and
+//   - mark the result so the report can call out the merge.
+func TestRunSetGlobalSettingsMergesGlobalExclusionsIntoExclusions(t *testing.T) {
+	hits, logs := runGlobalSettingsTest(t,
+		// SQS extract values — both keys customized.
+		[]map[string]any{
+			{"key": "sonar.global.exclusions", "values": []string{"**/*.gen", "vendor/**"}},
+			{"key": "sonar.exclusions", "values": []string{"build/**", "**/*.gen"}}, // **/*.gen also in global → dedupe
+		},
+		[]map[string]any{
+			{"key": "sonar.global.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
+			{"key": "sonar.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
+		},
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+		},
+		[]map[string]any{
+			// SQC only has sonar.exclusions.
+			{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
+		},
+	)
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 settings.set call (merged exclusions), got %d (%+v)", len(hits), hits)
+	}
+	if hits[0].key != "sonar.exclusions" {
+		t.Fatalf("expected the call to land on sonar.exclusions, got %q", hits[0].key)
+	}
+	want := []string{"**/*.gen", "vendor/**", "build/**"}
+	if !reflect.DeepEqual(hits[0].values, want) {
+		t.Errorf("merged patterns: want %v (global-first, exclusions-second, deduped), got %v",
+			want, hits[0].values)
+	}
+	if strings.Contains(logs, "sonar.global.exclusions") && strings.Contains(logs, "not available on SQC") {
+		t.Errorf("must NOT Warn about sonar.global.exclusions being SQC-missing — its patterns were migrated:\n%s", logs)
+	}
+}
+
+// When only sonar.global.exclusions is customized (sonar.exclusions is
+// at its SQS default of empty), the global patterns must still land on
+// SQC's sonar.exclusions — otherwise the platform-enforced exclusions
+// are silently lost during migration.
+func TestRunSetGlobalSettingsAppliesGlobalExclusionsWhenExclusionsAtDefault(t *testing.T) {
+	hits, _ := runGlobalSettingsTest(t,
+		[]map[string]any{
+			{"key": "sonar.global.exclusions", "values": []string{"vendor/**"}},
+			// sonar.exclusions is at default — must NOT need to be in the
+			// extract for the merge to fire (it would normally be filtered
+			// out by isSettingCustomized).
+		},
+		[]map[string]any{
+			{"key": "sonar.global.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
+			{"key": "sonar.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
+		},
+		[]map[string]any{
+			{"sonarcloud_org_key": "org1"},
+		},
+		[]map[string]any{
+			{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
+		},
+	)
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 call (global patterns onto sonar.exclusions), got %d", len(hits))
+	}
+	if hits[0].key != "sonar.exclusions" {
+		t.Fatalf("expected sonar.exclusions to be the target, got %q", hits[0].key)
+	}
+	if !reflect.DeepEqual(hits[0].values, []string{"vendor/**"}) {
+		t.Errorf("want values=[vendor/**] from global-only side, got %v", hits[0].values)
+	}
+}
+
+// renderGlobalSettingDetail must annotate the merged record so the
+// summary report displays the cross-key provenance — this is the report
+// requirement called out in the issue.
+func TestRenderGlobalSettingDetailMentionsMerge(t *testing.T) {
+	got := renderGlobalSettingDetail(globalSettingResult{
+		Key:              "sonar.exclusions",
+		Values:           []string{"a", "b"},
+		AppliedOrgs:      []string{"org1"},
+		MergedFromGlobal: true,
+	})
+	if !strings.Contains(got, "merged from sonar.global.exclusions + sonar.exclusions") {
+		t.Errorf("expected detail to call out the merge, got: %s", got)
 	}
 }
 

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -7,6 +7,8 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -50,8 +52,20 @@ func runGlobalSettingsTest(t *testing.T,
 	var logBuf bytes.Buffer
 	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	writeTaskJSONL(t, e, "getServerSettings", sqsSettings)
-	writeTaskJSONL(t, e, "getServerSettingsDefinitions", sqsDefs)
+	// getServerSettings / getServerSettingsDefinitions are EXTRACT tasks
+	// — runSetGlobalSettings reaches them via readExtractItems and
+	// e.Mapping, NOT via the migrate store. Writing to the migrate store
+	// would silently leave the production read path empty and the test
+	// would be exercising a different code path than reality. Drop the
+	// records into the configured extract directory instead.
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", sqsSettings)
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", sqsDefs)
+	// extract.json is what GetUniqueExtracts inspects to assemble the
+	// ExtractMapping; without it readExtractItems can't resolve the
+	// extract dir for a server URL.
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	// generateOrganizationMappings IS produced by the migrate phase, so
+	// it correctly lives in the migrate store.
 	writeTaskJSONL(t, e, "generateOrganizationMappings", orgs)
 
 	if err := runSetGlobalSettings(context.Background(), e); err != nil {
@@ -62,6 +76,40 @@ func runGlobalSettingsTest(t *testing.T,
 	defer muHits.Unlock()
 	hits = append(hits, *hitsPtr...)
 	return hits, logBuf.String()
+}
+
+// writeExtractTaskJSONL writes records as JSONL into an extract run
+// directory (NOT the migrate store). setGlobalSettings reads from here
+// via readExtractItems / e.Mapping.
+func writeExtractTaskJSONL(t *testing.T, exportDir, extractRun, task string, records []map[string]any) {
+	t.Helper()
+	taskDir := filepath.Join(exportDir, extractRun, task)
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", taskDir, err)
+	}
+	f, err := os.Create(filepath.Join(taskDir, "results.1.jsonl"))
+	if err != nil {
+		t.Fatalf("create extract jsonl: %v", err)
+	}
+	defer f.Close()
+	for _, r := range records {
+		b, _ := json.Marshal(r)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+}
+
+// writeExtractMetaJSON writes the extract.json file the structure
+// package reads to learn which server URL produced this extract.
+func writeExtractMetaJSON(t *testing.T, exportDir, extractRun, serverURL string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(exportDir, extractRun), 0o755); err != nil {
+		t.Fatalf("mkdir extract: %v", err)
+	}
+	b, _ := json.Marshal(map[string]any{"url": serverURL})
+	if err := os.WriteFile(filepath.Join(exportDir, extractRun, "extract.json"), b, 0o644); err != nil {
+		t.Fatalf("write extract.json: %v", err)
+	}
 }
 
 // writeTaskJSONL writes a slice of maps as JSONL into the named task's output

--- a/go/internal/migrate/tasks_settings_helpers.go
+++ b/go/internal/migrate/tasks_settings_helpers.go
@@ -1,0 +1,148 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/sonar-solutions/sq-api-go/types"
+)
+
+// errSettingEmpty is the sentinel returned by applySettingByDef when the
+// extract record had no value / values / fieldValues to send. Callers
+// silently skip the record — it is not a real error.
+var errSettingEmpty = errors.New("setting has no value")
+
+// loadSettingDefinitionsForOrgs fetches /api/settings/list_definitions
+// once for each SonarQube Cloud organization in the supplied set and
+// returns a per-org lookup keyed by setting key. A failed fetch for one
+// org is logged at Warn level and yields an empty (not nil) inner map —
+// callers then transparently fall back to extract-shape dispatch for
+// that org.
+//
+// taskName is included in the log message so the source of the warning is
+// obvious (setProjectSettings vs setGlobalSettings).
+func loadSettingDefinitionsForOrgs(ctx context.Context, e *Executor, orgs map[string]struct{}, taskName string) map[string]map[string]types.SettingDefinition {
+	out := make(map[string]map[string]types.SettingDefinition, len(orgs))
+	for org := range orgs {
+		defs, err := e.Cloud.Settings.ListDefinitions(ctx, org)
+		if err != nil {
+			logAPIWarn(e.Logger, taskName+": list_definitions failed, falling back to extract-shape dispatch", err, "org", org)
+			out[org] = map[string]types.SettingDefinition{}
+			continue
+		}
+		byKey := make(map[string]types.SettingDefinition, len(defs))
+		for _, d := range defs {
+			byKey[d.Key] = d
+		}
+		out[org] = byKey
+		e.Logger.Debug(taskName+": loaded definitions", "org", org, "count", len(defs))
+	}
+	return out
+}
+
+// applySettingByDef is the shared definition-aware dispatcher used by both
+// setProjectSettings (projectKey non-empty) and setGlobalSettings
+// (projectKey empty, orgKey non-empty). When a SQC definition is supplied
+// for the setting key, the post shape is chosen from the target's
+// definition (PROPERTY_SET → fieldValues, multiValues=true → values,
+// otherwise → single CSV-joined value). Without a definition we fall back
+// to the extract record's shape.
+//
+// The definition path matters because SQS and SQC disagree on a handful of
+// settings — notably sonar.java.file.suffixes — where SQS returns
+// values=[...] but SQC's definition is a single STRING with
+// multiValues=false. POSTing values= to such a setting on SQC returns 204
+// but silently fails to persist; joining with comma and POSTing as value=
+// is what actually lands. See issue #120 for the regression that motivated
+// this dispatcher and issue #186 for the global-scope reuse.
+func applySettingByDef(ctx context.Context, e *Executor, projectKey, orgKey string,
+	raw json.RawMessage, settingKey string, def types.SettingDefinition, hasDef bool) error {
+
+	scope := "project"
+	if projectKey == "" {
+		scope = "global"
+	}
+
+	if hasDef {
+		switch {
+		case def.Type == "PROPERTY_SET":
+			fvs := extractObjectArray(raw, "fieldValues")
+			if len(fvs) == 0 {
+				return errSettingEmpty
+			}
+			e.Logger.Debug(scope+" api call: POST /api/settings/set (property-set)",
+				"project", projectKey, "key", settingKey, "field_values_count", len(fvs), "org", orgKey)
+			return e.Cloud.Settings.SetFieldValues(ctx, projectKey, settingKey, fvs, orgKey)
+		case def.MultiValues:
+			vals := extractStringArray(raw, "values")
+			if len(vals) == 0 {
+				if v := extractField(raw, "value"); v != "" {
+					vals = strings.Split(v, ",")
+				}
+			}
+			if len(vals) == 0 {
+				return errSettingEmpty
+			}
+			e.Logger.Debug(scope+" api call: POST /api/settings/set (multi-value)",
+				"project", projectKey, "key", settingKey, "values", vals, "org", orgKey)
+			return e.Cloud.Settings.SetValues(ctx, projectKey, settingKey, vals, orgKey)
+		default:
+			// Single-value (STRING/BOOLEAN/INTEGER/FLOAT/SINGLE_SELECT_LIST,
+			// etc.). If SQS returned a list (values=), CSV-join it so SQC
+			// stores it as one string.
+			value := extractField(raw, "value")
+			if value == "" {
+				if vals := extractStringArray(raw, "values"); len(vals) > 0 {
+					value = strings.Join(vals, ",")
+				}
+			}
+			if value == "" {
+				return errSettingEmpty
+			}
+			e.Logger.Debug(scope+" api call: POST /api/settings/set",
+				"project", projectKey, "key", settingKey, "value", value, "org", orgKey)
+			return e.Cloud.Settings.Set(ctx, projectKey, settingKey, value, orgKey)
+		}
+	}
+
+	// No SQC definition for this key — fall back to dispatching by the
+	// shape of the extract record. This preserves behaviour for custom or
+	// plugin-defined settings that aren't in list_definitions.
+	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
+		e.Logger.Debug(scope+" api call: POST /api/settings/set (multi-value, no SQC def)",
+			"project", projectKey, "key", settingKey, "values", vals, "org", orgKey)
+		return e.Cloud.Settings.SetValues(ctx, projectKey, settingKey, vals, orgKey)
+	}
+	if fvs := extractObjectArray(raw, "fieldValues"); len(fvs) > 0 {
+		e.Logger.Debug(scope+" api call: POST /api/settings/set (property-set, no SQC def)",
+			"project", projectKey, "key", settingKey, "field_values_count", len(fvs), "org", orgKey)
+		return e.Cloud.Settings.SetFieldValues(ctx, projectKey, settingKey, fvs, orgKey)
+	}
+	value := extractField(raw, "value")
+	if value == "" {
+		return errSettingEmpty
+	}
+	e.Logger.Debug(scope+" api call: POST /api/settings/set (no SQC def)",
+		"project", projectKey, "key", settingKey, "value", value, "org", orgKey)
+	return e.Cloud.Settings.Set(ctx, projectKey, settingKey, value, orgKey)
+}
+
+// extractObjectArray reads a []map[string]any from a JSON field. Returns
+// nil for missing fields, non-array shapes, or empty arrays.
+func extractObjectArray(raw json.RawMessage, key string) []map[string]any {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	arrRaw, ok := obj[key]
+	if !ok {
+		return nil
+	}
+	var arr []map[string]any
+	if err := json.Unmarshal(arrRaw, &arr); err != nil {
+		return nil
+	}
+	return arr
+}

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -71,6 +71,15 @@ func collectSection(store *common.DataStore, def sectionDef,
 	configFailures []configFailure,
 	exportDir string, extractMapping structure.ExtractMapping) Section {
 
+	// Global settings (issue #186) don't match the generic create*/
+	// generate*Mappings pattern — each output record carries its own
+	// per-org outcome buckets. Render that section through a dedicated
+	// fan-out helper instead of the standard succeeded/skipped/failed
+	// path.
+	if def.Name == "Global Settings" {
+		return collectGlobalSettings(store, def)
+	}
+
 	succeeded := collectSucceeded(store, def)
 	skipped := collectSkipped(store, def)
 	failed := collectFailed(failuresByType, def)
@@ -308,4 +317,100 @@ func extractRunID(runDir string) string {
 // jsonStr extracts a string field from a json.RawMessage.
 func jsonStr(raw json.RawMessage, key string) string {
 	return common.ExtractField(raw, key)
+}
+
+// collectGlobalSettings renders the Global Settings section (issue #186).
+// Each setGlobalSettings JSONL record represents one SQS setting whose
+// value differs from its declared default; it carries three per-org
+// outcome lists (applied / skipped / failed). The section emits one
+// EntityItem per (setting key × org) pair so the report can show exactly
+// which orgs the setting reached, was missing from, or failed on.
+//
+// The Detail column reuses the pre-built "detail" string from the migrate
+// task so the rendered row is identical across buckets — only the
+// Organization and SkipReason / ErrorMessage differ.
+func collectGlobalSettings(store *common.DataStore, def sectionDef) Section {
+	items, err := store.ReadAll(def.OutputTask)
+	if err != nil {
+		return Section{Name: def.Name}
+	}
+	var succeeded, skipped, failed []EntityItem
+	for _, raw := range items {
+		key := jsonStr(raw, def.NameField)
+		detail := jsonStr(raw, def.DetailField)
+
+		for _, org := range parseStringArray(raw, "applied_orgs") {
+			succeeded = append(succeeded, EntityItem{
+				Name:         key,
+				Organization: org,
+				Detail:       detail,
+			})
+		}
+		for _, e := range parseOrgReasonArray(raw, "skipped_orgs") {
+			reason := SkipReasonUnused // default bucket label
+			if e.Reason == "not-on-sqc" {
+				reason = "not-on-sqc"
+			}
+			skipped = append(skipped, EntityItem{
+				Name:         key,
+				Organization: e.Org,
+				Detail:       detail,
+				SkipReason:   reason,
+			})
+		}
+		for _, e := range parseOrgReasonArray(raw, "failed_orgs") {
+			failed = append(failed, EntityItem{
+				Name:         key,
+				Organization: e.Org,
+				Detail:       detail,
+				ErrorMessage: e.Reason,
+			})
+		}
+	}
+	return Section{
+		Name:      def.Name,
+		Succeeded: succeeded,
+		Skipped:   skipped,
+		Failed:    failed,
+	}
+}
+
+// orgReason is the {org, reason} shape used inside setGlobalSettings's
+// skipped_orgs / failed_orgs JSON arrays.
+type orgReason struct {
+	Org    string `json:"org"`
+	Reason string `json:"reason"`
+}
+
+// parseStringArray decodes a JSON array of strings from a top-level
+// field of the record. Returns nil when the field is missing or the
+// shape doesn't match — collectGlobalSettings just skips that bucket.
+func parseStringArray(raw json.RawMessage, field string) []string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	arr, ok := obj[field]
+	if !ok {
+		return nil
+	}
+	var out []string
+	_ = json.Unmarshal(arr, &out)
+	return out
+}
+
+// parseOrgReasonArray decodes a JSON array of {org, reason} objects
+// from a top-level field of the record.
+func parseOrgReasonArray(raw json.RawMessage, field string) []orgReason {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	arr, ok := obj[field]
+	if !ok {
+		return nil
+	}
+	var out []orgReason
+	_ = json.Unmarshal(arr, &out)
+	return out
 }

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -673,6 +673,54 @@ func succeededNames(items []EntityItem) []string {
 	return out
 }
 
+// TestCollectGlobalSettingsFansOutByBucket ensures one setGlobalSettings
+// JSONL record produces one EntityItem per (org, outcome) — applied →
+// Succeeded, skipped_orgs[i] → Skipped, failed_orgs[i] → Failed — and
+// that the Detail string from the migrate task is forwarded verbatim.
+// Issue #186.
+func TestCollectGlobalSettingsFansOutByBucket(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskJSONL(t, dir, "setGlobalSettings", []map[string]any{
+		{
+			"key":          "sonar.cleanasyoucode.enabled",
+			"value":        "true",
+			"applied_orgs": []string{"orgA", "orgB"},
+			"skipped_orgs": []map[string]any{{"org": "orgC", "reason": "not-on-sqc"}},
+			"failed_orgs":  []map[string]any{{"org": "orgD", "reason": "boom"}},
+			"detail":       "value=true — applied to: orgA, orgB — skipped: orgC (not-on-sqc) — failed: orgD",
+		},
+	})
+
+	summary, err := CollectSummary(dir, "")
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	sec := findSection(summary, "Global Settings")
+	if sec == nil {
+		t.Fatal("missing Global Settings section")
+	}
+	if len(sec.Succeeded) != 2 {
+		t.Errorf("Succeeded: want 2 (orgA + orgB), got %d", len(sec.Succeeded))
+	}
+	if len(sec.Skipped) != 1 || sec.Skipped[0].Organization != "orgC" {
+		t.Errorf("Skipped: want one entry for orgC, got %+v", sec.Skipped)
+	}
+	if sec.Skipped[0].SkipReason != "not-on-sqc" {
+		t.Errorf("Skipped[0].SkipReason: want 'not-on-sqc', got %q", sec.Skipped[0].SkipReason)
+	}
+	if len(sec.Failed) != 1 || sec.Failed[0].Organization != "orgD" {
+		t.Errorf("Failed: want one entry for orgD, got %+v", sec.Failed)
+	}
+	if sec.Failed[0].ErrorMessage != "boom" {
+		t.Errorf("Failed[0].ErrorMessage: want 'boom', got %q", sec.Failed[0].ErrorMessage)
+	}
+	// Detail string from migrate task is forwarded verbatim — that's how
+	// the report renders value + per-org info without re-deriving it.
+	if !strings.Contains(sec.Succeeded[0].Detail, "applied to: orgA, orgB") {
+		t.Errorf("Detail not forwarded: %q", sec.Succeeded[0].Detail)
+	}
+}
+
 // --- helpers ---
 
 func findSection(s *MigrationSummary, name string) *Section {

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -100,6 +100,19 @@ var sectionDefs = []sectionDef{
 		NameField:      "name",
 		DetailField:    "cloud_project_key",
 	},
+	{
+		// Global settings (issue #186) — one row per non-default SQS
+		// setting, fanned out across orgs by collectGlobalSettings.
+		// InputTask is left empty: the "skip when value=default"
+		// filter is applied inside the migrate task, so the report
+		// just reflects what was written. NameField is the setting
+		// key; DetailField is the pre-rendered value + per-org
+		// summary string set by renderGlobalSettingDetail.
+		Name:        "Global Settings",
+		OutputTask:  "setGlobalSettings",
+		NameField:   "key",
+		DetailField: "detail",
+	},
 }
 
 // skippedOrgSentinel matches the value used by the wizard when an org is skipped.

--- a/lib/sq-api-go/server/phase3_test.go
+++ b/lib/sq-api-go/server/phase3_test.go
@@ -363,6 +363,38 @@ func TestSettingsValuesError(t *testing.T) {
 	assert.True(t, sqapi.IsForbidden(err))
 }
 
+// Global-settings migration (issue #186) needs each definition's
+// defaultValue to decide whether the SQS-side value is customized. This
+// test pins the JSON unmarshalling: the SDK must decode defaultValue,
+// multiValues, and type into the typed struct.
+func TestSettingsListDefinitions(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/settings/list_definitions", func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.URL.Query().Get("component"), "global call must not send a component")
+		writeJSON(w, types.SettingsListDefinitionsResponse{
+			Definitions: []types.SettingDefinition{
+				{Key: "sonar.exclusions", Type: "STRING", MultiValues: true, DefaultValue: ""},
+				{Key: "sonar.java.file.suffixes", Type: "STRING", MultiValues: false, DefaultValue: ".java,.jav"},
+				{Key: "sonar.cleanasyoucode.enabled", Type: "BOOLEAN", MultiValues: false, DefaultValue: "true"},
+			},
+		})
+	})
+	sc := newTestServer(t, mux)
+
+	defs, err := sc.Settings.ListDefinitions(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, defs, 3)
+
+	byKey := make(map[string]types.SettingDefinition, len(defs))
+	for _, d := range defs {
+		byKey[d.Key] = d
+	}
+	assert.Equal(t, ".java,.jav", byKey["sonar.java.file.suffixes"].DefaultValue,
+		"defaultValue must round-trip — this is how migrate detects customization")
+	assert.True(t, byKey["sonar.exclusions"].MultiValues)
+	assert.Equal(t, "BOOLEAN", byKey["sonar.cleanasyoucode.enabled"].Type)
+}
+
 // --- Plugins ---
 
 func TestPluginsInstalled(t *testing.T) {

--- a/lib/sq-api-go/server/settings.go
+++ b/lib/sq-api-go/server/settings.go
@@ -28,3 +28,20 @@ func (s *SettingsClient) Values(ctx context.Context, component string, keys stri
 	}
 	return result.Settings, nil
 }
+
+// ListDefinitions returns the setting definitions registered on the
+// SonarQube Server, used by global-settings migration (issue #186) to
+// detect which keys have been customized (value != defaultValue) and
+// therefore deserve forwarding to SQC. component is optional — leave it
+// empty to fetch global definitions.
+func (s *SettingsClient) ListDefinitions(ctx context.Context, component string) ([]types.SettingDefinition, error) {
+	params := url.Values{}
+	if component != "" {
+		params.Set("component", component)
+	}
+	var result types.SettingsListDefinitionsResponse
+	if err := s.get(ctx, "api/settings/list_definitions", params, &result); err != nil {
+		return nil, err
+	}
+	return result.Definitions, nil
+}

--- a/lib/sq-api-go/types/settings.go
+++ b/lib/sq-api-go/types/settings.go
@@ -15,15 +15,17 @@ type SettingsValuesResponse struct {
 	Settings []Setting `json:"settings"`
 }
 
-// SettingDefinition describes a setting's property type and whether it
-// accepts multiple values, as returned by /api/settings/list_definitions.
-// Only the fields actually consumed during migration are decoded — the
-// API also returns name, description, category, defaultValue, options, and
-// fields, all of which we don't need.
+// SettingDefinition describes a setting's property type, whether it accepts
+// multiple values, and its default value, as returned by
+// /api/settings/list_definitions. The defaultValue is the source-of-truth
+// for "is this setting customized?" — global-settings migration (issue
+// #186) compares it against the value returned by /api/settings/values to
+// decide whether to forward the setting to SQC.
 type SettingDefinition struct {
-	Key         string `json:"key"`
-	Type        string `json:"type"`
-	MultiValues bool   `json:"multiValues"`
+	Key          string `json:"key"`
+	Type         string `json:"type"`
+	MultiValues  bool   `json:"multiValues"`
+	DefaultValue string `json:"defaultValue"`
 }
 
 // SettingsListDefinitionsResponse is the response envelope for


### PR DESCRIPTION
## Summary

Closes #186. Migrates non-default SQS global settings (e.g. `sonar.javascript.environments`, `sonar.dbcleaner.branchesToKeepWhenInactive`) to every SQC organization in scope, logs a Warn for any SQS-only key, and adds a "Global Settings" section to the migration summary PDF.

Three commits, each a discrete layer:

- **SDK + extract foundation (`2867327`)** — `types.SettingDefinition` gains `DefaultValue`; `server.SettingsClient.ListDefinitions` mirrors the cloud-side method added in #120; new `getServerSettingsDefinitions` extract task hits SQS's `/api/settings/list_definitions` so the migrate phase can detect customization without guessing.
- **`setGlobalSettings` migrate task (`8a0a063`)** — joins `getServerSettings` + `getServerSettingsDefinitions` to filter out uncustomized settings, iterates the target SQC orgs from `generateOrganizationMappings`, fetches each org's `list_definitions` once, and routes via the shared `applySettingByDef` helper (lifted out of `tasks_associate.go` so both `setProjectSettings` and `setGlobalSettings` share one definition-driven dispatcher). Keys absent from SQC produce a Warn and a `skipped(reason=not-on-sqc)` outcome.
- **Report section (`150cd51`)** — new "Global Settings" entry in `sectionDefs` plus a `collectGlobalSettings` fan-out helper. Each setting JSONL record produces one EntityItem per (org × outcome) so the summary shows exactly which orgs received the setting, were missing it, or failed.

## Test plan

- [x] `cd lib/sq-api-go && go test ./...` — SDK suite green; new `TestSettingsListDefinitions` pins JSON round-trip of `defaultValue`/`multiValues`/`type`.
- [x] `cd go && go test ./...` — full suite green; 5 new migrate tests for `setGlobalSettings` (default-skip, multi-value, single-value CSV-join, key-not-on-SQC Warn, property-set) and 1 new report test for the fan-out.
- [x] `go vet` clean on all modified packages (`server`, `types`, `cloud`, `internal/extract`, `internal/migrate`, `internal/report/summary`).
- [ ] Live re-run against the user's staging env: set a non-default global setting on SQS (e.g. `sonar.javascript.environments`), run extract + migrate, and confirm:
  - The setting is set on every non-skipped SQC org.
  - `migrate.log` has a Warn line for any SQS-only key.
  - `migration_summary.pdf` shows a Global Settings section with rows per (setting × org), value and applied-orgs in Detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
