### PR TITLE
Issue #193 Verify already-existing project is in target org before adopting

### DIFF
--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -79,6 +79,27 @@ func runCreateProjects(ctx context.Context, e *Executor) error {
 					logAPIWarn(e.Logger, "createProjects: create failed", err, "key", key)
 					return nil
 				}
+				// SonarQube Cloud project keys are GLOBALLY unique, not
+				// org-scoped, so "key already exists" doesn't guarantee
+				// the existing project is in OUR target org. If it
+				// isn't, downstream tasks (setProjectSettings,
+				// setGlobalSettings fan-out, etc.) will issue PATCHes
+				// against a phantom project and get 404s. Verify the
+				// project is actually accessible in orgKey before
+				// recording it (issue #193).
+				exists, verifyErr := e.Cloud.Projects.ExistsInOrg(ctx, cloudKey, orgKey)
+				if verifyErr != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "createProjects: could not verify already-existing project belongs to target org",
+						verifyErr, "source_key", key, "cloud_key", cloudKey, "org", orgKey)
+					return nil
+				}
+				if !exists {
+					counter.Fail()
+					e.Logger.Warn("createProjects: key already exists but project is not in target org, skipping",
+						"source_key", key, "cloud_key", cloudKey, "org", orgKey)
+					return nil
+				}
 				counter.Success()
 				e.Logger.Info("createProjects: already exists", "source_key", key, "cloud_key", cloudKey, "org", orgKey)
 			} else {

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -383,6 +383,54 @@ func TestCreateProjects_AlreadyExists(t *testing.T) {
 	}
 }
 
+// SonarQube Cloud project keys are GLOBALLY unique, so an
+// "already exists" 400 from /api/projects/create doesn't guarantee
+// the existing project is in our target org — it might be claimed
+// by a different org. If we naively recorded a createProjects entry
+// for it, downstream tasks (setProjectSettings, setGlobalSettings'
+// fan-out) would PATCH a phantom project and get 404s. This test
+// asserts createProjects now verifies the project's actual org via
+// /api/projects/search and refuses to record an entry when the key
+// belongs elsewhere. Issue #193.
+func TestCreateProjects_AlreadyExistsInDifferentOrg(t *testing.T) {
+	// Build a custom Cloud mock that returns "already exists" for
+	// create AND returns an EMPTY project search result, mimicking
+	// SQC saying "the key exists, but not in this org".
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/projects/create", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		fmt.Fprint(w, `{"errors":[{"msg":"Could not create Project, key already exists: x"}]}`)
+	})
+	mux.HandleFunc("GET /api/projects/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"components": []map[string]any{}})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	setupCSVs(t, dir)
+	runTask(t, e, "generateProjectMappings")
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["createProjects"].Run(context.Background(), e); err != nil {
+		t.Fatalf("createProjects: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("createProjects")
+	if len(items) != 0 {
+		t.Fatalf("expected NO createProjects records when key exists in another org, got %d: %s",
+			len(items), items)
+	}
+}
+
 func TestCreateProfiles_AlreadyExists(t *testing.T) {
 	cloudSrv := newAlreadyExistsCloudServer()
 	defer cloudSrv.Close()

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -264,6 +264,19 @@ func newAlreadyExistsCloudServer() *httptest.Server {
 	})
 
 	// GET search endpoints — return existing resources for lookup.
+	mux.HandleFunc("GET /api/projects/search", func(w http.ResponseWriter, r *http.Request) {
+		// Mimic the happy path: the project key SQC reports as
+		// "already exists" actually belongs to OUR target org, so
+		// createProjects' verify-already-exists step finds it
+		// (issue #193). A test that wants to simulate the
+		// other-org case wires a different handler.
+		projectKey := r.URL.Query().Get("projects")
+		json.NewEncoder(w).Encode(map[string]any{
+			"components": []map[string]any{
+				{"key": projectKey, "name": projectKey},
+			},
+		})
+	})
 	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"profiles": []map[string]any{

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -185,6 +185,45 @@ func TestProjectsSetTags(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestProjectsExistsInOrg covers the disambiguator the migration tool
+// uses to resolve /api/projects/create's "key already exists" 400
+// (issue #193). SQC project keys are globally unique, so an
+// "already-exists" response doesn't tell us whether the existing
+// project is in our target org or in a different one that claimed
+// the same key — we have to verify via /api/projects/search filtered
+// to (org, projects).
+func TestProjectsExistsInOrg(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/projects/search", func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
+			assert.Equal(t, "myorg_proj1", r.URL.Query().Get("projects"))
+			writeJSON(w, types.ProjectsSearchResponse{
+				Components: []types.Project{{Key: "myorg_proj1", Name: "Proj 1"}},
+			})
+		})
+		cc := newTestCloud(t, mux)
+		ok, err := cc.Projects.ExistsInOrg(context.Background(), "myorg_proj1", "myorg")
+		require.NoError(t, err)
+		assert.True(t, ok)
+	})
+
+	t.Run("absent in org but key claimed elsewhere", func(t *testing.T) {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/api/projects/search", func(w http.ResponseWriter, r *http.Request) {
+			// SQC returns an empty list when the project is NOT in
+			// the queried org, even if the key exists in some
+			// other org. This is the case createProjects must
+			// catch — the "already exists" 400 is misleading.
+			writeJSON(w, types.ProjectsSearchResponse{Components: nil})
+		})
+		cc := newTestCloud(t, mux)
+		ok, err := cc.Projects.ExistsInOrg(context.Background(), "myorg_proj1", "myorg")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+}
+
 // --- Groups ---
 
 func TestGroupsCreate(t *testing.T) {

--- a/lib/sq-api-go/cloud/projects.go
+++ b/lib/sq-api-go/cloud/projects.go
@@ -66,3 +66,31 @@ func (p *ProjectsClient) SetTags(ctx context.Context, projectKey, tags string) e
 	form.Set("tags", tags)
 	return p.postForm(ctx, "api/project_tags/set", form, nil)
 }
+
+// ExistsInOrg reports whether a project with the given key is
+// accessible in the given SonarQube Cloud organization. Used to
+// disambiguate /api/projects/create's "key already exists" response
+// (issue #193): SQC project keys are globally unique, so a 400
+// rejection doesn't tell us whether the existing project is in our
+// target org or some other org that happens to claim the same key.
+// A positive result confirms our migration can adopt the existing
+// project; a negative result means createProjects should treat the
+// case as a failure and skip the project from downstream tasks.
+//
+// Implementation: GET /api/projects/search filtered to (org, projects).
+// SQC returns the project in the response only when both match.
+func (p *ProjectsClient) ExistsInOrg(ctx context.Context, projectKey, organization string) (bool, error) {
+	q := url.Values{}
+	q.Set("organization", organization)
+	q.Set("projects", projectKey)
+	var resp types.ProjectsSearchResponse
+	if err := p.getJSON(ctx, "api/projects/search?"+q.Encode(), &resp); err != nil {
+		return false, err
+	}
+	for _, proj := range resp.Components {
+		if proj.Key == projectKey {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
## Summary

Closes #193. SonarQube Cloud project keys are globally unique, not org-scoped, so a 400 *"Could not create Project, key already exists"* from `/api/projects/create` doesn't tell us whether the existing project is in our target org or in a different one that happens to claim the same key. The previous code unconditionally trusted the rejection and recorded a `createProjects` entry — which then poisoned `projectKeyMap`. Downstream tasks (`setProjectSettings`, the `setGlobalSettings` fan-out from #189/#191, `setProjectTags`, etc.) issued PATCHes against phantom projects and produced cascades of 404 *"Project doesn't exist"* warnings.

The fix adds `cloud.ProjectsClient.ExistsInOrg` — a `GET /api/projects/search?organization=X&projects=Y` lookup — and gates the AlreadyExists branch on it. If the key exists elsewhere, `createProjects` now logs a Warn, counts a Fail, and refuses to record a JSONL entry. Downstream tasks never see the phantom project.

## Test plan
- [x] `go test ./...` in both modules green.
- [x] `go vet ./internal/migrate/...` clean.
- [x] New `TestProjectsExistsInOrg` (SDK) covers present + absent cases.
- [x] New `TestCreateProjects_AlreadyExistsInDifferentOrg` (migrate) asserts: 400 already-exists + empty search response → no createProjects record.
- [x] Existing `TestCreateProjects_AlreadyExists` still passes (mock server updated with a positive `/api/projects/search` handler to confirm the project is in the target org).
- [ ] Live re-run against staging: re-create the conditions that produced the 404 cascade for `fubar_test:project2` / `fubar_okorach-org_pr-demo_*` etc. and confirm those keys are no longer in `createProjects`, and that the downstream Warn cascade is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
