### PR TITLE
Issue #196 Skip global settings whose value equals the SQS default

### DIFF
--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -629,26 +629,75 @@ func unionPreservingOrder(a, b []string) []string {
 }
 
 // isSettingCustomized reports whether the SQS-side value for a setting
-// differs from its declared defaultValue. SQS exposes values in three
-// shapes (value / values / fieldValues); for the comparison we collapse
-// each into a comparable scalar string — fieldValues collapses to its
-// JSON encoding, values to a sorted CSV.
+// actually differs from its default. SQS reveals the default in two
+// places, in priority order:
+//
+//  1. parentValue / parentValues on the value record itself — SQS's
+//     own "this is the default the user is inheriting from" hint.
+//     Present whenever a global setting has been explicitly set,
+//     even if to the same value as the default.
+//  2. defaultValue on the list_definitions record — the static
+//     declared default. Some setting keys don't expose this field,
+//     which is why parentValue is the more reliable signal.
+//
+// Issue #196: after several SQS upgrades, operators sometimes end up
+// with global settings explicitly set to values identical to the
+// default. Without comparing against parentValue/parentValues those
+// settings would be migrated unnecessarily, inflating the SQC API
+// call count and noising up the migration report.
 func isSettingCustomized(raw json.RawMessage, defaultValue string) bool {
 	if fvs := extractObjectArray(raw, "fieldValues"); len(fvs) > 0 {
-		// PROPERTY_SET — defaultValue is unlikely to match a complex
-		// JSON payload, so treat any populated fieldValues as
-		// customized.
+		// PROPERTY_SET — comparing two arbitrary JSON object arrays
+		// for "is this the default" is non-trivial, and these
+		// settings are rarely set to default by accident. Treat any
+		// populated fieldValues as customized.
 		return true
 	}
 	if vals := extractStringArray(raw, "values"); len(vals) > 0 {
-		sorted := append([]string(nil), vals...)
-		sort.Strings(sorted)
-		joined := strings.Join(sorted, ",")
-		defSorted := strings.Split(defaultValue, ",")
-		sort.Strings(defSorted)
-		return joined != strings.Join(defSorted, ",")
+		// Prefer parentValues (SQS-side default for this very key)
+		// over defaultValue from list_definitions: parentValues is
+		// always populated when the setting is set; defaultValue is
+		// sometimes missing from list_definitions.
+		if pvals := extractStringArray(raw, "parentValues"); len(pvals) > 0 {
+			return !equalSortedStrings(vals, pvals)
+		}
+		return !equalSortedStrings(vals, splitDefaultCSV(defaultValue))
 	}
-	return extractField(raw, "value") != defaultValue
+	v := extractField(raw, "value")
+	if pv := extractField(raw, "parentValue"); pv != "" {
+		return v != pv
+	}
+	return v != defaultValue
+}
+
+// equalSortedStrings reports whether a and b contain the same set of
+// elements, ignoring order. Both slices are sorted on a copy so the
+// callers' originals are untouched.
+func equalSortedStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	sa := append([]string(nil), a...)
+	sb := append([]string(nil), b...)
+	sort.Strings(sa)
+	sort.Strings(sb)
+	for i := range sa {
+		if sa[i] != sb[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// splitDefaultCSV turns SQS's comma-joined default representation
+// ("a,b,c") into a string slice, treating an empty defaultValue as the
+// empty slice (NOT a slice with one empty element, which is what
+// strings.Split returns by default).
+func splitDefaultCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	return strings.Split(s, ",")
 }
 
 // readSettingPayload extracts the three possible value shapes from a

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1001,6 +1001,105 @@ func TestRunSetGlobalSettingsFanOutPartialRendersAsPartial(t *testing.T) {
 	}
 }
 
+// isSettingCustomized's job is to filter out SQS-side global settings
+// whose value happens to equal the SQS default — those are not real
+// customizations and migrating them just inflates the SQC API call
+// count (issue #196). The comparison uses parentValue / parentValues
+// as the primary signal because list_definitions's defaultValue is
+// missing for some setting keys.
+func TestIsSettingCustomized(t *testing.T) {
+	mk := func(m map[string]any) json.RawMessage {
+		b, _ := json.Marshal(m)
+		return b
+	}
+	cases := []struct {
+		name        string
+		raw         map[string]any
+		defaultVal  string
+		wantCustom  bool
+		description string
+	}{
+		// Scalar paths
+		{
+			name:        "scalar value matches parentValue",
+			raw:         map[string]any{"value": "20", "parentValue": "20"},
+			wantCustom:  false,
+			description: "value=parentValue → not customized (issue #196 case)",
+		},
+		{
+			name:       "scalar value matches defaultValue (no parentValue)",
+			raw:        map[string]any{"value": "true"},
+			defaultVal: "true",
+			wantCustom: false,
+		},
+		{
+			name:       "scalar value differs from parentValue",
+			raw:        map[string]any{"value": "true", "parentValue": "false"},
+			wantCustom: true,
+		},
+		{
+			name:        "parentValue takes precedence when both available",
+			raw:         map[string]any{"value": "true", "parentValue": "true"},
+			defaultVal:  "false", // intentional mismatch; parentValue wins
+			wantCustom:  false,
+			description: "if parentValue agrees with value, it's not customized even when list_definitions says otherwise",
+		},
+
+		// Multi-value paths
+		{
+			name:        "multi values match parentValues (different order)",
+			raw:         map[string]any{"values": []string{".kt", ".kts"}, "parentValues": []string{".kts", ".kt"}},
+			wantCustom:  false,
+			description: "sorted equality — order doesn't matter",
+		},
+		{
+			name:       "multi values match defaultValue CSV (no parentValues)",
+			raw:        map[string]any{"values": []string{"a", "b"}},
+			defaultVal: "b,a",
+			wantCustom: false,
+		},
+		{
+			name:       "multi values differ in element count",
+			raw:        map[string]any{"values": []string{".kt"}, "parentValues": []string{".kt", ".kts"}},
+			wantCustom: true,
+		},
+		{
+			name:       "multi values differ in element content",
+			raw:        map[string]any{"values": []string{"a", "c"}, "parentValues": []string{"a", "b"}},
+			wantCustom: true,
+		},
+		{
+			name:       "parentValues takes precedence over defaultValue",
+			raw:        map[string]any{"values": []string{"a", "b"}, "parentValues": []string{"a", "b"}},
+			defaultVal: "x,y", // intentional mismatch
+			wantCustom: false,
+		},
+
+		// Property-set path — opaque, always treated as customized
+		{
+			name:       "property-set (fieldValues populated)",
+			raw:        map[string]any{"fieldValues": []map[string]any{{"k": "v"}}},
+			wantCustom: true,
+		},
+
+		// Missing both parentValue/parentValues AND defaultValue
+		{
+			name:       "scalar with no signal — treated as customized",
+			raw:        map[string]any{"value": "anything"},
+			wantCustom: true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := isSettingCustomized(mk(c.raw), c.defaultVal)
+			if got != c.wantCustom {
+				t.Errorf("%s: want customized=%v, got %v (raw=%v default=%q)",
+					c.description, c.wantCustom, got, c.raw, c.defaultVal)
+			}
+		})
+	}
+}
+
 // Compile-time guard: catch accidental removal of the helper that drives
 // most tests above.
 var _ = sync.Mutex{}


### PR DESCRIPTION
## Summary

Closes #196. After several SQS upgrades, operators sometimes end up with global settings explicitly set to the same value as the default. The previous filter compared against `defaultValue` from `/api/settings/list_definitions`, but some setting keys don't expose `defaultValue` there — so those settings slipped through and were migrated to SQC unnecessarily, inflating the API call count.

SQS itself ships the default in the value record: the `parentValue` / `parentValues` field tells us exactly what value is being inherited from. **`isSettingCustomized` now uses parentValue/parentValues as the primary signal**, falling back to `defaultValue` only when SQS doesn't surface a parent.

### Verified against the user's run

Cross-checking your latest `setGlobalSettings` output against `getServerSettings`, 9 records were being migrated despite `value == parentValue`:

```
sonar.filesize.limit                                   value=20 == parentValue=20
sonar.cpd.cobol.minimumTokens                          value=100 == parentValue=100
sonar.notifications.delay                              value=60 == parentValue=60
sonar.cpd.abap.minimumTokens                           value=100 == parentValue=100
sonar.notifications.runningDelayBeforeReportingStatus  value=600 == parentValue=600
sonar.multi-quality-mode.enabled                       value=true == parentValue=true
sonar.authenticator.downcase                           value=false == parentValue=false
sonar.cpd.cobol.minimumLines                           value=30 == parentValue=30
sonar.cpd.abap.minimumLines                            value=20 == parentValue=20
```

None of these keys has a `defaultValue` in `list_definitions`. After this fix, they'll be skipped before reaching the customized list — saving ~9 settings × 4 orgs ≈ 36 SQC API calls and a chunk of report rows.

### Comparison rules

| Shape | Primary signal | Fallback |
|---|---|---|
| scalar | `value == parentValue` → not customized | `value == defaultValue` |
| multi  | sorted `values == parentValues` (order-independent) | sorted `values == defaultValue.split(",")` |
| property-set | always treated as customized (opaque) | — |

Multi-value sorted equality is extracted into a shared `equalSortedStrings` helper so the comparison can't false-negative on different element ordering.

## Test plan
- [x] `go test ./...` green in both modules.
- [x] `go vet ./internal/migrate/...` clean.
- [x] 11-case table test (`TestIsSettingCustomized`) pins each branch: parentValue precedence, defaultValue fallback, sorted multi-value equality, missing-signal default, property-set opacity.
- [ ] Live re-run against staging: expect ~9 fewer rows in the Global Settings section of the PDF and a smaller `customized_settings=N` count at the start of the setGlobalSettings task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
