### PR TITLE
Issue #200 Skip SQS-only settings before they reach SQC

### DIFF
--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -36,6 +36,97 @@ type exclusionPair struct {
 	SQSLocalKey string
 }
 
+// sqsOnlyDecision tells partitionSQSOnlySettings what to do with one
+// SQS setting that has no SonarQube Cloud equivalent.
+//
+//   - SkipSilently=true: drop the record entirely, no API call, no
+//     report row.
+//   - SkipSilently=false: drop from the API loop AND emit one
+//     section-level note row at the bottom of the Global Settings
+//     report section. Note carries the wording the report displays.
+type sqsOnlyDecision struct {
+	SkipSilently bool
+	Note         string
+}
+
+// sqsOnlySettings names the SQS settings that have no SQC counterpart
+// (issue #200) and the per-key rule for what to do with them. The
+// migration loop short-circuits them before any API call so they
+// never produce "not-on-sqc" Warns or settings.set failures.
+//
+// Decision functions receive the raw getServerSettings record so they
+// can inspect value / values / parentValue to decide between
+// silent-skip and emit-a-note.
+var sqsOnlySettings = map[string]func(raw json.RawMessage) sqsOnlyDecision{
+	"sonar.core.serverBaseURL": func(_ json.RawMessage) sqsOnlyDecision {
+		return sqsOnlyDecision{SkipSilently: true}
+	},
+	"sonar.builtInQualityProfiles.disableNotificationOnUpdate": func(_ json.RawMessage) sqsOnlyDecision {
+		return sqsOnlyDecision{SkipSilently: true}
+	},
+	"sonar.qualityProfiles.allowDisableInheritedRules": func(raw json.RawMessage) sqsOnlyDecision {
+		// Only worth mentioning when the SQS-side operator
+		// explicitly enabled the feature; the default ("false") is
+		// the same as "doesn't exist", so no note then.
+		if extractField(raw, "value") == "true" {
+			return sqsOnlyDecision{
+				Note: "Setting does not exist on SonarQube Cloud; the SQS feature flag is not portable.",
+			}
+		}
+		return sqsOnlyDecision{SkipSilently: true}
+	},
+	"sonar.technicalDebt.ratingGrid": func(raw json.RawMessage) sqsOnlyDecision {
+		// SQC always uses the platform default. Mention this only
+		// when SQS was customized away from that default value.
+		const ratingGridDefault = "0.05,0.1,0.2,0.5"
+		v := extractField(raw, "value")
+		if v == "" || v == ratingGridDefault {
+			return sqsOnlyDecision{SkipSilently: true}
+		}
+		return sqsOnlyDecision{
+			Note: "Not customizable on SonarQube Cloud — SQS value " + v +
+				" will revert to the platform default " + ratingGridDefault + ".",
+		}
+	},
+}
+
+// partitionSQSOnlySettings splits the customized list, removing any
+// key that's known to have no SQC counterpart (issue #200). Keys
+// returned in `notes` carry one synthetic outcome with Org="" so the
+// report renders them once at the bottom of the section, NOT per-org.
+func partitionSQSOnlySettings(customized []json.RawMessage) (remaining []json.RawMessage, notes []globalSettingResult) {
+	remaining = customized[:0]
+	for _, raw := range customized {
+		key := extractField(raw, "key")
+		handler, isSQSOnly := sqsOnlySettings[key]
+		if !isSQSOnly {
+			remaining = append(remaining, raw)
+			continue
+		}
+		decision := handler(raw)
+		if decision.SkipSilently {
+			continue
+		}
+		rec := globalSettingResult{Key: key}
+		rec.Value, rec.Values, rec.FieldValues = readSettingPayload(raw)
+		rec.Outcomes = []orgOutcome{{
+			Org:    "",
+			Status: outcomeSkipped,
+			Reason: skipReasonSQSOnlyValue,
+			Detail: decision.Note,
+		}}
+		notes = append(notes, rec)
+	}
+	return remaining, notes
+}
+
+// skipReasonSQSOnlyValue is the reason marker placed on per-section
+// note rows so the report can both group them under the right label
+// and order them last in the Skipped bucket. Mirrors the constant
+// exported from the report package — kept here too to avoid a
+// migrate -> report dependency direction reversal.
+const skipReasonSQSOnlyValue = "sqs-only"
+
 var globalExclusionPairs = []exclusionPair{
 	{SQSGlobalKey: "sonar.global.exclusions", SQSLocalKey: "sonar.exclusions"},
 	{SQSGlobalKey: "sonar.global.test.exclusions", SQSLocalKey: "sonar.test.exclusions"},
@@ -116,6 +207,13 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 		customized = mergeGlobalIntoLocal(pair, sqsValues, customized, e.Logger)
 	}
 
+	// Issue #200 — partition off the SQS settings that have no SQC
+	// counterpart. Each handled key is either:
+	//   - dropped silently (no API call, no report row); or
+	//   - kept out of the API loop but emitted as a single
+	//     section-level note row at the bottom of the report.
+	customized, sqsOnlyNotes := partitionSQSOnlySettings(customized)
+
 	// Target SQC orgs.
 	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")
 	orgs := make(map[string]struct{})
@@ -187,6 +285,18 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
+
+	// Section-level notes for SQS-only settings (issue #200).
+	// Written AFTER the parallel loop so they always trail the
+	// regular per-org rows in the report's Skipped bucket — and
+	// because the writer is shared, the mutex still applies.
+	for _, rec := range sqsOnlyNotes {
+		b, _ := json.Marshal(rec)
+		mu.Lock()
+		_ = w.WriteOne(b)
+		mu.Unlock()
+	}
+
 	counter.LogSummary(e.Logger)
 	return nil
 }

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -90,13 +90,20 @@ var sqsOnlySettings = map[string]func(raw json.RawMessage) sqsOnlyDecision{
 	},
 }
 
-// partitionSQSOnlySettings splits the customized list, removing any
-// key that's known to have no SQC counterpart (issue #200). Keys
-// returned in `notes` carry one synthetic outcome with Org="" so the
-// report renders them once at the bottom of the section, NOT per-org.
-func partitionSQSOnlySettings(customized []json.RawMessage) (remaining []json.RawMessage, notes []globalSettingResult) {
-	remaining = customized[:0]
-	for _, raw := range customized {
+// partitionSQSOnlySettings splits the raw SQS getServerSettings list,
+// removing any key that's known to have no SQC counterpart (issue
+// #200). The function is called BEFORE the "customized vs default"
+// filter so the per-key handlers can decide based on the raw value
+// even when that value happens to match SQS's default (e.g.
+// sonar.qualityProfiles.allowDisableInheritedRules=true, which is
+// SQS's default but still wants a report note).
+//
+// Keys returned in `notes` carry one synthetic outcome with Org=""
+// so the report renders them once at the bottom of the section, NOT
+// per-org.
+func partitionSQSOnlySettings(values []json.RawMessage) (remaining []json.RawMessage, notes []globalSettingResult) {
+	remaining = values[:0]
+	for _, raw := range values {
 		key := extractField(raw, "key")
 		handler, isSQSOnly := sqsOnlySettings[key]
 		if !isSQSOnly {
@@ -183,6 +190,18 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	for _, it := range sqsItems {
 		sqsValues = append(sqsValues, it.Data)
 	}
+
+	// Issue #200 — partition off the SQS-only settings BEFORE the
+	// customized filter. For these keys the per-handler logic decides
+	// what to do based on the raw value, not on whether the value
+	// differs from SQS's default. The previous order (customized
+	// filter first, then partition) hid keys whose value happened to
+	// equal SQS's default — e.g. sonar.qualityProfiles.allowDisable
+	// InheritedRules=true where SQS's parentValue is also true: the
+	// customized filter dropped it, and the section-level note for
+	// "exists only on SQS" never reached the report.
+	sqsValues, sqsOnlyNotes := partitionSQSOnlySettings(sqsValues)
+
 	customized := make([]json.RawMessage, 0, len(sqsValues))
 	for _, raw := range sqsValues {
 		key := extractField(raw, "key")
@@ -206,13 +225,6 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	for _, pair := range globalExclusionPairs {
 		customized = mergeGlobalIntoLocal(pair, sqsValues, customized, e.Logger)
 	}
-
-	// Issue #200 — partition off the SQS settings that have no SQC
-	// counterpart. Each handled key is either:
-	//   - dropped silently (no API call, no report row); or
-	//   - kept out of the API loop but emitted as a single
-	//     section-level note row at the bottom of the report.
-	customized, sqsOnlyNotes := partitionSQSOnlySettings(customized)
 
 	// Target SQC orgs.
 	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1100,6 +1100,178 @@ func TestIsSettingCustomized(t *testing.T) {
 	}
 }
 
+// SQS-only settings (issue #200) must be intercepted before the API
+// loop. Some are dropped silently — no report row at all — and some
+// emit a single section-level note (Organization="") describing why
+// the value isn't portable. This table test pins each of the four
+// keys plus a control key that should pass through unchanged.
+func TestPartitionSQSOnlySettings(t *testing.T) {
+	mk := func(m map[string]any) json.RawMessage {
+		b, _ := json.Marshal(m)
+		return b
+	}
+	cases := []struct {
+		name       string
+		raw        map[string]any
+		wantSilent bool
+		wantNote   string // empty == not emitted; substring match
+	}{
+		{
+			name:       "serverBaseURL is always silent",
+			raw:        map[string]any{"key": "sonar.core.serverBaseURL", "value": "https://my-sonar.example.com"},
+			wantSilent: true,
+		},
+		{
+			name:       "disableNotificationOnUpdate is always silent",
+			raw:        map[string]any{"key": "sonar.builtInQualityProfiles.disableNotificationOnUpdate", "value": "true"},
+			wantSilent: true,
+		},
+		{
+			name:       "allowDisableInheritedRules=false is silent",
+			raw:        map[string]any{"key": "sonar.qualityProfiles.allowDisableInheritedRules", "value": "false"},
+			wantSilent: true,
+		},
+		{
+			name:     "allowDisableInheritedRules=true emits a note",
+			raw:      map[string]any{"key": "sonar.qualityProfiles.allowDisableInheritedRules", "value": "true"},
+			wantNote: "does not exist on SonarQube Cloud",
+		},
+		{
+			name:       "ratingGrid at default is silent",
+			raw:        map[string]any{"key": "sonar.technicalDebt.ratingGrid", "value": "0.05,0.1,0.2,0.5"},
+			wantSilent: true,
+		},
+		{
+			name:     "ratingGrid customized emits a note",
+			raw:      map[string]any{"key": "sonar.technicalDebt.ratingGrid", "value": "0.03,0.07,0.2,0.5"},
+			wantNote: "revert to the platform default 0.05,0.1,0.2,0.5",
+		},
+		{
+			name: "unknown setting passes through",
+			raw:  map[string]any{"key": "sonar.exclusions", "values": []string{"a"}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rem, notes := partitionSQSOnlySettings([]json.RawMessage{mk(c.raw)})
+			isSQSOnly := c.wantSilent || c.wantNote != ""
+			if isSQSOnly {
+				if len(rem) != 0 {
+					t.Errorf("SQS-only key must be removed from customized, got %d", len(rem))
+				}
+			} else {
+				if len(rem) != 1 {
+					t.Errorf("non-SQS-only key must pass through, got %d", len(rem))
+				}
+			}
+			if c.wantSilent {
+				if len(notes) != 0 {
+					t.Errorf("silent skip must emit no note, got %+v", notes)
+				}
+				return
+			}
+			if c.wantNote != "" {
+				if len(notes) != 1 {
+					t.Fatalf("expected one note, got %d", len(notes))
+				}
+				if !strings.Contains(notes[0].Outcomes[0].Detail, c.wantNote) {
+					t.Errorf("note Detail must contain %q, got %q", c.wantNote, notes[0].Outcomes[0].Detail)
+				}
+				if notes[0].Outcomes[0].Org != "" {
+					t.Errorf("note must NOT carry an Org (section-level), got %q", notes[0].Outcomes[0].Org)
+				}
+				if notes[0].Outcomes[0].Reason != "sqs-only" {
+					t.Errorf("note Reason must be \"sqs-only\" for report grouping, got %q", notes[0].Outcomes[0].Reason)
+				}
+			}
+		})
+	}
+}
+
+// End-to-end: when an SQS-only setting is customized, the API must
+// NOT be called for it; the only sign in the JSONL output is the
+// section-level note row.
+func TestRunSetGlobalSettingsInterceptsSQSOnlyKeys(t *testing.T) {
+	cloudMux := http.NewServeMux()
+	mu, hitsPtr := mountSettingsSetCapture(cloudMux)
+	mountSettingsDefinitions(cloudMux,
+		// Pretend SQC knows about sonar.exclusions but NOT the
+		// SQS-only keys; the migrate code shouldn't reach this
+		// handler for them anyway.
+		map[string]any{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
+	)
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+		// Two SQS-only keys: one silent, one with a note.
+		{"key": "sonar.core.serverBaseURL", "value": "https://my-sonar.example.com"},
+		{"key": "sonar.technicalDebt.ratingGrid", "value": "0.03,0.07,0.2,0.5"},
+		// One legit customization that SHOULD be migrated.
+		{"key": "sonar.exclusions", "values": []string{"**/*.gen"}},
+	})
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+		{"key": "sonar.core.serverBaseURL", "type": "STRING", "defaultValue": ""},
+		{"key": "sonar.technicalDebt.ratingGrid", "type": "STRING", "defaultValue": "0.05,0.1,0.2,0.5"},
+		{"key": "sonar.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
+	})
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"sonarcloud_org_key": "orgA"},
+		{"sonarcloud_org_key": "orgB"},
+	})
+
+	if err := runSetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetGlobalSettings: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Exactly the customized sonar.exclusions PATCHes — one per
+	// org. The SQS-only keys MUST not produce any settings.set call.
+	if len(*hitsPtr) != 2 {
+		t.Fatalf("expected only sonar.exclusions PATCHes (2 orgs × 1 key), got %d: %+v", len(*hitsPtr), *hitsPtr)
+	}
+	for _, h := range *hitsPtr {
+		if h.key != "sonar.exclusions" {
+			t.Errorf("unexpected SQS-only key reached SQC: %s", h.key)
+		}
+	}
+
+	// JSONL output must contain a single section-level note for
+	// the customized ratingGrid; serverBaseURL was silent so
+	// nothing should appear for it.
+	records, _ := e.Store.ReadAll("setGlobalSettings")
+	noteCount := 0
+	for _, raw := range records {
+		key, _ := jsonpathString(raw, "key")
+		if key == "sonar.technicalDebt.ratingGrid" || key == "sonar.core.serverBaseURL" {
+			noteCount++
+		}
+	}
+	if noteCount != 1 {
+		t.Errorf("expected exactly one SQS-only note row (ratingGrid), got %d", noteCount)
+	}
+}
+
+// jsonpathString is a tiny helper for the test above — pull a top
+// level string field from a raw JSON line.
+func jsonpathString(raw []byte, key string) (string, bool) {
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return "", false
+	}
+	s, ok := m[key].(string)
+	return s, ok
+}
+
 // Compile-time guard: catch accidental removal of the helper that drives
 // most tests above.
 var _ = sync.Mutex{}

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1188,6 +1188,81 @@ func TestPartitionSQSOnlySettings(t *testing.T) {
 	}
 }
 
+// Regression for issue #200: when an SQS-only setting's value equals
+// SQS's parentValue (i.e. it's at SQS's "default") but the per-key
+// rule still wants a note — e.g.
+// sonar.qualityProfiles.allowDisableInheritedRules=true on a SQS
+// where parentValue=true — the note must still reach the report.
+// The previous order ran isSettingCustomized BEFORE
+// partitionSQSOnlySettings, so this key was dropped as
+// "not-customized" and the section-level note never fired.
+func TestRunSetGlobalSettingsSQSOnlyNoteFiresEvenAtSQSDefault(t *testing.T) {
+	cloudMux := http.NewServeMux()
+	_, _ = mountSettingsSetCapture(cloudMux)
+	mountSettingsDefinitions(cloudMux)
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+		// value matches parentValue — isSettingCustomized's #196
+		// fix would discard this if it ran first. The SQS-only
+		// interceptor must catch it before that.
+		{"key": "sonar.qualityProfiles.allowDisableInheritedRules",
+			"value": "true", "parentValue": "true"},
+	})
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+		{"key": "sonar.qualityProfiles.allowDisableInheritedRules",
+			"type": "BOOLEAN", "defaultValue": "true"},
+	})
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"sonarcloud_org_key": "orgA"},
+	})
+
+	if err := runSetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetGlobalSettings: %v", err)
+	}
+
+	records, _ := e.Store.ReadAll("setGlobalSettings")
+	foundNote := false
+	for _, raw := range records {
+		key, _ := jsonpathString(raw, "key")
+		if key != "sonar.qualityProfiles.allowDisableInheritedRules" {
+			continue
+		}
+		var rec struct {
+			Outcomes []struct {
+				Org    string `json:"org"`
+				Status string `json:"status"`
+				Reason string `json:"reason"`
+				Detail string `json:"detail"`
+			} `json:"outcomes"`
+		}
+		_ = json.Unmarshal(raw, &rec)
+		if len(rec.Outcomes) != 1 {
+			t.Fatalf("expected one section-level outcome, got %d", len(rec.Outcomes))
+		}
+		oc := rec.Outcomes[0]
+		if oc.Org != "" || oc.Reason != "sqs-only" {
+			t.Errorf("note must be section-level (Org=\"\") with Reason=sqs-only, got %+v", oc)
+		}
+		if !strings.Contains(oc.Detail, "does not exist on SonarQube Cloud") {
+			t.Errorf("Detail must explain the SQS-only nature, got %q", oc.Detail)
+		}
+		foundNote = true
+	}
+	if !foundNote {
+		t.Errorf("section-level note for SQS-only key did NOT reach the report (even though value=true)")
+	}
+}
+
 // End-to-end: when an SQS-only setting is customized, the API must
 // NOT be called for it; the only sign in the JSONL output is the
 // section-level note row.

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -835,6 +835,56 @@ func TestCollectGlobalSettingsIncludesNewCodePeriod(t *testing.T) {
 	}
 }
 
+// Section-level note rows (Organization="", SkipReason="sqs-only")
+// must route to the Skipped bucket so the PDF places them at the
+// bottom of the Global Settings section with the "Not applicable on
+// SonarQube Cloud" label. Issue #200.
+func TestCollectGlobalSettingsRoutesSQSOnlyNotesToSkipped(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskJSONL(t, dir, "setGlobalSettings", []map[string]any{
+		// Normal customized setting → succeeded per-org.
+		{
+			"key": "sonar.exclusions", "values": []string{"a"},
+			"outcomes": []map[string]any{
+				{"org": "orgA", "status": "applied", "detail": "Applied (values=[a])"},
+			},
+		},
+		// SQS-only note row (one entry, no Organization).
+		{
+			"key": "sonar.technicalDebt.ratingGrid", "value": "0.03,0.07,0.2,0.5",
+			"outcomes": []map[string]any{
+				{"org": "", "status": "skipped", "reason": SkipReasonSQSOnly,
+					"detail": "Not customizable on SonarQube Cloud — SQS value 0.03,0.07,0.2,0.5 will revert to the platform default 0.05,0.1,0.2,0.5."},
+			},
+		},
+	})
+
+	summary, err := CollectSummary(dir, "")
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	sec := findSection(summary, "Global Settings")
+	if sec == nil {
+		t.Fatal("missing Global Settings section")
+	}
+	if len(sec.Succeeded) != 1 {
+		t.Errorf("Succeeded: want 1 (sonar.exclusions/orgA), got %d", len(sec.Succeeded))
+	}
+	if len(sec.Skipped) != 1 {
+		t.Fatalf("Skipped: want one entry for the SQS-only note, got %d: %+v", len(sec.Skipped), sec.Skipped)
+	}
+	row := sec.Skipped[0]
+	if row.SkipReason != SkipReasonSQSOnly {
+		t.Errorf("Skipped[0].SkipReason: want SkipReasonSQSOnly, got %q", row.SkipReason)
+	}
+	if row.Organization != "" {
+		t.Errorf("Section-level note must have empty Organization, got %q", row.Organization)
+	}
+	if !strings.Contains(row.Detail, "revert to the platform default") {
+		t.Errorf("Detail must carry the user-facing note text, got %q", row.Detail)
+	}
+}
+
 // --- helpers ---
 
 func findSection(s *MigrationSummary, name string) *Section {

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -274,6 +274,12 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		multiLineFontSize = 6.0
 	)
 	pdf.SetFont(pdfFontFamily, "", bodyFontSize)
+	// Sections where the Name column may carry long setting keys
+	// (e.g. sonar.qualityProfiles.allowDisableInheritedRules) and
+	// must word-wrap instead of truncating. Other sections keep the
+	// truncate behaviour to avoid disturbing layouts that depend on
+	// single-line names.
+	wrapName := section.Name == "Global Settings"
 	for i, row := range rows {
 		// Compute wrapped line count for the Details column so the whole row
 		// (Name, Organization, Outcome) can match that height. SplitLines
@@ -290,6 +296,19 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		pdf.SetFont(pdfFontFamily, "", bodyFontSize)
 		if lineCount < 1 {
 			lineCount = 1
+		}
+		// If the Name column word-wraps, compute its line count too
+		// and take the max so the row is tall enough for either side.
+		nameText := row.displayName()
+		nameLineCount := 1
+		if wrapName {
+			nameLineCount = len(pdf.SplitLines([]byte(nameText), widths[0]))
+			if nameLineCount < 1 {
+				nameLineCount = 1
+			}
+			if nameLineCount > lineCount {
+				lineCount = nameLineCount
+			}
 		}
 		var lineH, rowHeight float64
 		if lineCount == 1 {
@@ -313,7 +332,16 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section) {
 		if hideOrg {
 			nameLimit = 60
 		}
-		pdf.CellFormat(widths[col], rowHeight, truncate(row.displayName(), nameLimit), "1", 0, "L", true, 0, "")
+		if wrapName {
+			// Use MultiCell so long setting keys wrap. MultiCell
+			// advances the cursor down, so capture (x, y) first and
+			// restore them after for the remaining cells on this row.
+			x, y := pdf.GetXY()
+			pdf.MultiCell(widths[col], lineH, nameText, "1", "L", true)
+			pdf.SetXY(x+widths[col], y)
+		} else {
+			pdf.CellFormat(widths[col], rowHeight, truncate(nameText, nameLimit), "1", 0, "L", true, 0, "")
+		}
 		col++
 		if !hideOrg {
 			pdf.CellFormat(widths[col], rowHeight, truncate(row.org, 24), "1", 0, "L", true, 0, "")

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -40,6 +40,10 @@ var skipReasonOrder = []struct {
 	{SkipReasonBuiltIn, "Built-in"},
 	{SkipReasonUnused, "Unused"},
 	{"", "Other"},
+	// SQS-only settings appear last so the section ends with the
+	// "not applicable on SQC" notes — one row per such setting,
+	// no Organization (issue #200).
+	{SkipReasonSQSOnly, "Not applicable on SonarQube Cloud"},
 }
 
 // Outcome labels used in the unified per-section table.

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -31,10 +31,17 @@ type EntityItem struct {
 }
 
 // Skip reason constants used when classifying skipped entities.
+//
+// SkipReasonSQSOnly marks rows that describe a SonarQube-Server-only
+// setting which has no SonarQube Cloud counterpart (issue #200). The
+// row carries a single section-level note (Organization is left
+// blank) and is rendered last in the Skipped bucket so it appears at
+// the bottom of the section.
 const (
 	SkipReasonOrgSkipped = "org-skipped"
 	SkipReasonBuiltIn    = "built-in"
 	SkipReasonUnused     = "unused"
+	SkipReasonSQSOnly    = "sqs-only"
 )
 
 // sectionDef maps a report section to its corresponding task names and analysis entity type.


### PR DESCRIPTION
## Summary

Closes #200. A handful of SonarQube Server settings have no SonarQube Cloud counterpart. Until now the migration tool tried to PATCH them anyway, producing noisy report rows the operator couldn't act on.

Each handled key is intercepted before any API call; the result is either a silent drop or a single section-level note row (Organization left blank) at the bottom of the Global Settings section in the report.

### Per-key rules

| Setting | Behaviour |
|---|---|
| `sonar.core.serverBaseURL` | always silent |
| `sonar.builtInQualityProfiles.disableNotificationOnUpdate` | always silent |
| `sonar.qualityProfiles.allowDisableInheritedRules` | silent when `value=false`; note when `value=true` |
| `sonar.technicalDebt.ratingGrid` | silent at default `0.05,0.1,0.2,0.5`; note otherwise (spells out SQS value + SQC fallback default) |

Per your earlier clarification: the notes are listed **once for all** (not per-org), at the **bottom** of the section. The report uses the new `SkipReasonSQSOnly` placed last in the skip-reason order so the rows naturally end up at the bottom of the section under the label "Not applicable on SonarQube Cloud".

## Test plan
- [x] `go test ./...` green in both modules.
- [x] 7-case table test pins the per-key silent/note branches (`TestPartitionSQSOnlySettings`).
- [x] End-to-end migrate test asserts no API call fires for the SQS-only keys and only the customized ratingGrid produces a note row (`TestRunSetGlobalSettingsInterceptsSQSOnlyKeys`).
- [x] Report test asserts the note row lands in Skipped with empty Organization and the new `SkipReasonSQSOnly` (`TestCollectGlobalSettingsRoutesSQSOnlyNotesToSkipped`).
- [ ] Live re-run against staging:
  - Verify no PATCH/POST is logged for the four keys.
  - PDF's Global Settings section ends with one or two "Not applicable on SonarQube Cloud" notes (only when the conditional cases fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
