### PR TITLE
Issue #190 Grant the migration user Browse/Administer on every created project

### DIFF
--- a/go/internal/migrate/tasks_alm.go
+++ b/go/internal/migrate/tasks_alm.go
@@ -18,8 +18,10 @@ func almTasks() []TaskDef {
 			Run:          runMatchProjectRepos,
 		},
 		{
+			// Project DevOps binding writes need the migration user
+			// to be a project admin (issue #190).
 			Name:         "setProjectBinding",
-			Dependencies: []string{"matchProjectRepos"},
+			Dependencies: []string{"matchProjectRepos", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectBinding,
 		},
 	}

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -19,34 +19,41 @@ import (
 // associateTasks returns tasks that associate projects with profiles, gates, etc.
 func associateTasks() []TaskDef {
 	return []TaskDef{
+		// Every per-project mutation below also depends on
+		// grantMigrationUserProjectPermissions so the migration
+		// user has Browse/Administer/Administer-Issues/Administer-
+		// Hotspots before any settings/profile/gate/tag/NCD/group
+		// write reaches a project (issue #190). The dep is in
+		// addition to createProjects — the DAG resolver picks the
+		// right order regardless.
 		{
 			Name:         "setProjectProfiles",
-			Dependencies: []string{"createProfiles", "createProjects"},
+			Dependencies: []string{"createProfiles", "createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectProfiles,
 		},
 		{
 			Name:         "setProjectGates",
-			Dependencies: []string{"createGates", "createProjects"},
+			Dependencies: []string{"createGates", "createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectGates,
 		},
 		{
 			Name:         "setProjectGroupPermissions",
-			Dependencies: []string{"createGroups", "createProjects"},
+			Dependencies: []string{"createGroups", "createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectGroupPermissions,
 		},
 		{
 			Name:         "setProjectSettings",
-			Dependencies: []string{"createProjects"},
+			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectSettings,
 		},
 		{
 			Name:         "setProjectTags",
-			Dependencies: []string{"createProjects"},
+			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectTags,
 		},
 		{
 			Name:         "setNewCodePeriods",
-			Dependencies: []string{"createProjects"},
+			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetNewCodePeriods,
 		},
 		{

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -3,6 +3,9 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
 	"testing"
 )
 
@@ -288,6 +291,141 @@ func TestCreateMigrationGroups(t *testing.T) {
 	err := reg["createMigrationGroups"].Run(context.Background(), e)
 	if err != nil {
 		t.Fatalf("createMigrationGroups: %v", err)
+	}
+}
+
+// TestGrantMigrationUserProjectPermissions asserts each newly-created
+// project receives the four expected permission grants for the
+// migration user (issue #190): user, admin, issueadmin,
+// securityhotspotadmin. The grant fires BEFORE the per-project
+// mutations downstream — verified here by the dependency-graph
+// assertion at the bottom.
+func TestGrantMigrationUserProjectPermissions(t *testing.T) {
+	type call struct {
+		login      string
+		permission string
+		project    string
+		org        string
+	}
+	var (
+		mu       sync.Mutex
+		recorded []call
+	)
+	// Custom cloud mock that captures add_user calls. Everything else
+	// is taken from newMockCloudServer's behaviour (it would otherwise
+	// answer 200 to whatever else is hit during ReadAll fixture).
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		recorded = append(recorded, call{
+			login:      r.FormValue("login"),
+			permission: r.FormValue("permission"),
+			project:    r.FormValue("projectKey"),
+			org:        r.FormValue("organization"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	// getMigrationUser → login.
+	uw, _ := e.Store.Writer("getMigrationUser")
+	uw.WriteOne([]byte(`{"login":"migration-bot","name":"Migration Bot"}`))
+	// createProjects → two projects across two orgs.
+	pw, _ := e.Store.Writer("createProjects")
+	for _, p := range []map[string]any{
+		{"key": "src-a", "server_url": testServerURL,
+			"sonarcloud_org_key": "orgA", "cloud_project_key": "orgA_src-a"},
+		{"key": "src-b", "server_url": testServerURL,
+			"sonarcloud_org_key": "orgB", "cloud_project_key": "orgB_src-b"},
+	} {
+		b, _ := json.Marshal(p)
+		pw.WriteOne(b)
+	}
+
+	if err := runGrantMigrationUserProjectPermissions(context.Background(), e); err != nil {
+		t.Fatalf("runGrantMigrationUserProjectPermissions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// 2 projects × 4 permissions = 8 calls.
+	if len(recorded) != 8 {
+		t.Fatalf("expected 8 calls (2 projects × 4 perms), got %d: %+v", len(recorded), recorded)
+	}
+	// Assert: every call carries the migration-user login, each
+	// project receives EXACTLY the 4 permissions in the list, and
+	// the project + org pair on the call match createProjects.
+	wantPerms := map[string]bool{
+		"user":                 true,
+		"admin":                true,
+		"issueadmin":           true,
+		"securityhotspotadmin": true,
+	}
+	gotPermsPerProject := make(map[string]map[string]int)
+	for _, c := range recorded {
+		if c.login != "migration-bot" {
+			t.Errorf("login: want migration-bot, got %q", c.login)
+		}
+		if !wantPerms[c.permission] {
+			t.Errorf("unexpected permission %q on project %q", c.permission, c.project)
+		}
+		if gotPermsPerProject[c.project] == nil {
+			gotPermsPerProject[c.project] = make(map[string]int)
+		}
+		gotPermsPerProject[c.project][c.permission]++
+	}
+	for _, project := range []string{"orgA_src-a", "orgB_src-b"} {
+		got := gotPermsPerProject[project]
+		for perm := range wantPerms {
+			if got[perm] != 1 {
+				t.Errorf("project %q permission %q: want exactly 1 grant, got %d",
+					project, perm, got[perm])
+			}
+		}
+	}
+}
+
+// Per-project mutations must depend on
+// grantMigrationUserProjectPermissions so the DAG runs the grant
+// BEFORE any project-scoped write. Pin the dependency at the
+// registry level so a refactor that drops the dep is caught here.
+func TestGrantMigrationUserIsAPrerequisiteForPerProjectTasks(t *testing.T) {
+	reg := BuildMigrateRegistry(RegisterAll())
+	for _, name := range []string{
+		"setProjectProfiles",
+		"setProjectGates",
+		"setProjectGroupPermissions",
+		"setProjectSettings",
+		"setProjectTags",
+		"setNewCodePeriods",
+		"setProjectBinding",
+	} {
+		task := reg[name]
+		if task == nil {
+			t.Errorf("task %q not registered", name)
+			continue
+		}
+		found := false
+		for _, dep := range task.Dependencies {
+			if dep == "grantMigrationUserProjectPermissions" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("task %q must list grantMigrationUserProjectPermissions in Dependencies, got %v",
+				name, task.Dependencies)
+		}
 	}
 }
 

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -44,7 +44,77 @@ func permissionTasks() []TaskDef {
 			Dependencies: []string{"createProfiles", "createGroups"},
 			Run:          runSetProfileGroupPermissions,
 		},
+		{
+			// Issue #190: depending on the SQS permission template
+			// the user provisioned the SQC org with, the migration
+			// user can end up without Browse/Administer on the
+			// projects it just created — which then makes every
+			// downstream per-project mutation (settings, profiles,
+			// gates, tags, NCD, group perms, binding) 403. Grant the
+			// migration user user/admin/issueadmin/securityhotspotadmin
+			// on every newly-created project as the FIRST step after
+			// createProjects; the other per-project tasks list this
+			// task as an additional dependency so the DAG enforces
+			// the order.
+			Name:         "grantMigrationUserProjectPermissions",
+			Dependencies: []string{"createProjects", "getMigrationUser"},
+			Run:          runGrantMigrationUserProjectPermissions,
+		},
 	}
+}
+
+// migrationUserProjectPermissions are the four permissions the
+// migration user grants itself on every project it just created.
+// user=Browse, admin=Administer, issueadmin=Administer Issues,
+// securityhotspotadmin=Administer Security Hotspots. The latter two
+// anticipate the project-data migration feature (issues + hotspots
+// status changes).
+var migrationUserProjectPermissions = []string{
+	"user",
+	"admin",
+	"issueadmin",
+	"securityhotspotadmin",
+}
+
+func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) error {
+	userItems, _ := e.Store.ReadAll("getMigrationUser")
+	if len(userItems) == 0 {
+		e.Logger.Info("grantMigrationUserProjectPermissions: no migration user record, nothing to grant")
+		return nil
+	}
+	login := extractField(userItems[0], "login")
+	if login == "" {
+		e.Logger.Info("grantMigrationUserProjectPermissions: migration user has no login, nothing to grant")
+		return nil
+	}
+
+	counter := NewTaskCounter("grantMigrationUserProjectPermissions")
+	err := forEachMigrateItem(ctx, e, "grantMigrationUserProjectPermissions", "createProjects",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			cloudKey := extractField(item, "cloud_project_key")
+			if cloudKey == "" {
+				return nil
+			}
+			for _, perm := range migrationUserProjectPermissions {
+				e.Logger.Debug("grantMigrationUserProjectPermissions: POST /api/permissions/add_user",
+					"login", login, "perm", perm, "project", cloudKey, "org", orgKey)
+				err := e.Cloud.Permissions.AddUser(ctx, login, perm, orgKey, cloudKey)
+				if err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "grantMigrationUserProjectPermissions failed", err,
+						"login", login, "project", cloudKey, "perm", perm)
+					continue
+				}
+				counter.Success()
+			}
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
 }
 
 func runCreateMigrationGroups(ctx context.Context, e *Executor) error {

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -156,6 +156,10 @@ func newMockCloudServer() *httptest.Server {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
+	mux.HandleFunc("POST /api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
 	mux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -634,6 +634,39 @@ func TestPermissionsAddGroupOrgLevel(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// AddUser is used by the migration tool (issue #190) to grant the
+// migration user user/admin/issueadmin/securityhotspotadmin on every
+// newly-created project so the subsequent per-project mutations
+// don't fail with "Insufficient privileges". The endpoint shape
+// mirrors AddGroup but takes login instead of groupName.
+func TestPermissionsAddUser(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		assertFormValue(t, r, "login", "migration-bot")
+		assertFormValue(t, r, "permission", "admin")
+		assertFormValue(t, r, "organization", "myorg")
+		assertFormValue(t, r, "projectKey", "myorg_proj1")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.Permissions.AddUser(context.Background(), "migration-bot", "admin", "myorg", "myorg_proj1")
+	require.NoError(t, err)
+}
+
+func TestPermissionsAddUserOrgLevel(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/permissions/add_user", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		assert.Empty(t, r.FormValue("projectKey"))
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.Permissions.AddUser(context.Background(), "migration-bot", "admin", "myorg", "")
+	require.NoError(t, err)
+}
+
 func TestPermissionsAddGroupToTemplate(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/permissions/add_group_to_template", func(w http.ResponseWriter, r *http.Request) {

--- a/lib/sq-api-go/cloud/permissions.go
+++ b/lib/sq-api-go/cloud/permissions.go
@@ -80,3 +80,21 @@ func (p *PermissionsClient) AddGroupToTemplate(ctx context.Context, templateID, 
 	form.Set("organization", organization)
 	return p.postForm(ctx, "api/permissions/add_group_to_template", form, nil)
 }
+
+// AddUser grants a permission to a user at the organization or
+// project level via /api/permissions/add_user. login is the SQC
+// user's login (NOT the display name). projectKey is optional;
+// omit for org-level grants. Used by the migration to grant the
+// migration user elevated perms on every newly-created project
+// (issue #190) so subsequent per-project mutations don't fail with
+// "Insufficient privileges".
+func (p *PermissionsClient) AddUser(ctx context.Context, login, permission, organization, projectKey string) error {
+	form := url.Values{}
+	form.Set("login", login)
+	form.Set("permission", permission)
+	form.Set("organization", organization)
+	if projectKey != "" {
+		form.Set("projectKey", projectKey)
+	}
+	return p.postForm(ctx, "api/permissions/add_user", form, nil)
+}


### PR DESCRIPTION
## Summary

Closes #190. Depending on the SonarQube Cloud permission template the operator provisioned the org with, a freshly-created project can end up without the migration user in its visibility scope. That breaks two things:

- Operators have to *Restore access* by hand to see the project after the migration finishes.
- Every downstream per-project mutation that needs admin (settings, gates, profiles, tags, NCD, group perms, ALM binding) silently 403s with *"Insufficient privileges"*, leaving the migration incomplete.

A new task — `grantMigrationUserProjectPermissions` — runs immediately after `createProjects` and before any per-project mutation. It uses the migration user record already produced by `getMigrationUser` to look up the login, then for every `(org, cloud_project_key)` in the `createProjects` output grants four permissions:

| Permission | SonarQube label |
|---|---|
| `user` | Browse |
| `admin` | Administer |
| `issueadmin` | Administer Issues |
| `securityhotspotadmin` | Administer Security Hotspots |

The latter two anticipate the project-data migration feature that needs to change issue and hotspot statuses.

### DAG ordering

The new task is added as an additional dependency to every per-project mutation: `setProjectProfiles`, `setProjectGates`, `setProjectGroupPermissions`, `setProjectSettings`, `setProjectTags`, `setNewCodePeriods`, `setProjectBinding`. A new `TestGrantMigrationUserIsAPrerequisiteForPerProjectTasks` pins this at the registry level so a future refactor can't silently drop the dep.

### SDK

`PermissionsClient.AddUser` wraps `POST /api/permissions/add_user` with the same shape as the existing `AddGroup` helper.

## Test plan
- [x] `go test ./...` in both modules green.
- [x] SDK: `TestPermissionsAddUser` (+ org-level variant) pin the request shape.
- [x] migrate: `TestGrantMigrationUserProjectPermissions` asserts 2 projects × 4 perms = 8 `add_user` calls with the correct login/permission/project.
- [x] migrate: `TestGrantMigrationUserIsAPrerequisiteForPerProjectTasks` pins the DAG edge.
- [ ] Live re-run against staging: after a fresh migration, verify the migration user has Browse/Administer/Administer-Issues/Administer-Hotspots on every newly-created project (visible in the SQC UI under Project → Administration → Permissions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
