### PR TITLE
Issue #154 Report unmigrated applications in a Migration limitations section

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -2,6 +2,7 @@ package summary
 
 import (
 	"encoding/json"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -47,7 +48,41 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 		RunID:       runID,
 		GeneratedAt: time.Now(),
 		Sections:    sections,
+		Limitations: collectLimitations(exportDir, extractMapping),
 	}, nil
+}
+
+// collectLimitations builds the free-text bullet list rendered in the
+// "Migration limitations" section at the end of the report (issue
+// #154). Today there's exactly one entry — SonarQube Server's
+// Applications feature has no SonarQube Cloud counterpart — and the
+// list only includes it when the SQS instance actually had
+// applications configured. More entries can be appended here as
+// other limitations are surfaced.
+func collectLimitations(exportDir string, mapping structure.ExtractMapping) []string {
+	var out []string
+	if appCount := countExtractItems(exportDir, mapping, "getApplications"); appCount > 0 {
+		out = append(out,
+			fmt.Sprintf("Applications do not exist on SonarQube Cloud, %d SQS applications were not migrated.",
+				appCount))
+	}
+	return out
+}
+
+// countExtractItems returns the number of JSONL records the extract
+// task wrote across every server URL in the mapping. Returns 0 if
+// the extract didn't run or the read failed — the limitations
+// collector treats absence as "no records," which is the correct
+// fall-back behaviour.
+func countExtractItems(exportDir string, mapping structure.ExtractMapping, taskKey string) int {
+	if mapping == nil {
+		return 0
+	}
+	items, err := structure.ReadExtractData(exportDir, mapping, taskKey)
+	if err != nil {
+		return 0
+	}
+	return len(items)
 }
 
 // collectFailures parses the requests.log and groups failures by entity type.

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -885,6 +885,71 @@ func TestCollectGlobalSettingsRoutesSQSOnlyNotesToSkipped(t *testing.T) {
 	}
 }
 
+// When the SQS instance had applications configured, the summary
+// must include a Migration-limitations entry mentioning that
+// Applications don't exist on SQC (issue #154). The count must match
+// the number of records in the getApplications extract.
+func TestCollectSummaryMentionsUnmigratedApplications(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-apps"
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	writeTaskJSONL(t, extractDir, "getApplications", []map[string]any{
+		{"key": "app1", "name": "Application 1"},
+		{"key": "app2", "name": "Application 2"},
+		{"key": "app3", "name": "Application 3"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	if len(summary.Limitations) == 0 {
+		t.Fatalf("Limitations: want a non-empty list when SQS had apps, got empty")
+	}
+	found := false
+	for _, msg := range summary.Limitations {
+		if strings.Contains(msg, "Applications do not exist on SonarQube Cloud") &&
+			strings.Contains(msg, "3 SQS applications") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Limitations must mention applications count, got %v", summary.Limitations)
+	}
+}
+
+// When the SQS instance had no applications, the limitations list
+// must NOT include the applications entry — otherwise every report
+// would carry an irrelevant note.
+func TestCollectSummaryNoApplicationsLimitation(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-no-apps"
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	// getApplications dir exists but is empty.
+	writeTaskJSONL(t, extractDir, "getApplications", nil)
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	for _, msg := range summary.Limitations {
+		if strings.Contains(msg, "Applications") {
+			t.Errorf("Limitations must NOT mention applications when none extracted, got %q", msg)
+		}
+	}
+}
+
 // --- helpers ---
 
 func findSection(s *MigrationSummary, name string) *Section {

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -75,11 +75,38 @@ func RenderPDF(summary *MigrationSummary) ([]byte, error) {
 		renderSection(pdf, section)
 	}
 
+	renderLimitations(pdf, summary.Limitations)
+
 	var buf bytes.Buffer
 	if err := pdf.Output(&buf); err != nil {
 		return nil, fmt.Errorf("generating PDF: %w", err)
 	}
 	return buf.Bytes(), nil
+}
+
+// renderLimitations writes the "Migration limitations" section at the
+// very end of the report (issue #154). Each entry is rendered as a
+// single bulleted line. No-op when the list is empty so reports for
+// instances without any limitation stay clean.
+func renderLimitations(pdf *fpdf.Fpdf, limitations []string) {
+	if len(limitations) == 0 {
+		return
+	}
+	pdf.Ln(8)
+	checkPageBreak(pdf, 30)
+
+	setColor(pdf, colorMedBlue)
+	pdf.SetFont(pdfFontFamily, "B", 14)
+	pdf.CellFormat(0, 10, "Migration limitations", "", 1, "L", false, 0, "")
+
+	setColor(pdf, colorBlack)
+	pdf.SetFont(pdfFontFamily, "", 9)
+	for _, line := range limitations {
+		// MultiCell so long messages wrap instead of running off
+		// the edge. Bullet prefix mirrors the visual treatment used
+		// by other free-text sections.
+		pdf.MultiCell(0, 5, "• "+sanitizeForPDF(line), "", "L", false)
+	}
 }
 
 // registerUnicodeFont registers the embedded Noto Sans regular + bold variants

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -4,10 +4,17 @@ package summary
 import "time"
 
 // MigrationSummary holds the collected data for the PDF report.
+//
+// Limitations is a list of free-text messages rendered as a
+// "Migration limitations" section at the very end of the report
+// (issue #154). It documents SonarQube Server features that have no
+// SonarQube Cloud counterpart, so the operator knows which parts of
+// the source platform did NOT make it across — e.g. applications.
 type MigrationSummary struct {
 	RunID       string
 	GeneratedAt time.Time
 	Sections    []Section
+	Limitations []string
 }
 
 // Section represents a category of migrated entities (e.g., Projects, Quality Gates).


### PR DESCRIPTION
## Summary

Closes #154. SonarQube Server's Applications feature has no SonarQube Cloud counterpart. Until now the migration report had no mention of them — operators couldn't tell from the report alone that those entities didn't make it across.

The migration summary now gains a free-text **"Migration limitations"** section at the very end of the PDF (after the regular per-entity sections). When the SQS extract recorded N applications, the section contains:

> • Applications do not exist on SonarQube Cloud, N SQS applications were not migrated.

The list is built generically through `MigrationSummary.Limitations []string` so future limitations (other SQS-only features, edition mismatches, etc.) can append to the same area without touching the rendering code.

### Implementation

- **Schema** — `MigrationSummary` gains a `Limitations []string` field.
- **Collector** — `collectLimitations` reads the `getApplications` extract via `structure.ReadExtractData` across every server URL in the mapping and appends an entry when count > 0. A thin generic helper `countExtractItems` keeps the door open for future extract-task-based limitations.
- **PDF** — `RenderPDF` calls a new `renderLimitations` after the regular section loop. No-op for empty lists, so reports without applications stay visually unchanged.

## Test plan
- [x] `go test ./...` green.
- [x] `go vet ./internal/report/summary/...` clean (pre-existing vet warnings in other report sub-packages are unrelated to this change).
- [x] `TestCollectSummaryMentionsUnmigratedApplications` writes 3 applications and asserts the limitation appears with the right count.
- [x] `TestCollectSummaryNoApplicationsLimitation` writes an empty getApplications extract and asserts no applications-related limitation is added.
- [ ] Live re-run against an SQS with applications: the PDF should end with the "Migration limitations" section listing the count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
