### PR TITLE
Issue #202 Friendlier progress logs for long-running migration tasks

### DIFF
--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -255,11 +255,19 @@ type progressLogger struct {
 // Tuned for operator-visible cadence (issue #202):
 //   - createProjects is one API call per project and the slowest
 //     per-item task on large platforms; surface progress every 10.
+//   - configurePortfolios issues multiple Enterprise-API calls per
+//     portfolio (create + update + project membership); every 10
+//     keeps progress visible at the user's expected cadence.
+//   - setProjectSettings does multiple HTTP calls per record on
+//     average (definition-driven dispatch, fan-out fallback);
+//     every 50 strikes a balance between visibility and noise.
 //   - setProjectGroupPermissions can run into the tens of thousands
 //     of items (projects × groups × permissions); every 100 keeps
 //     the log readable while still ticking visibly.
 var progressLogInterval = map[string]int64{
 	"createProjects":             10,
+	"configurePortfolios":        10,
+	"setProjectSettings":         50,
 	"setProjectGroupPermissions": 100,
 }
 

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -248,6 +248,21 @@ type progressLogger struct {
 	interval int64
 }
 
+// progressLogInterval names how often (in items) the progress logger
+// should emit an INFO line for a given task. Per-task entries take
+// precedence over the size-based fallback in newProgressLogger.
+//
+// Tuned for operator-visible cadence (issue #202):
+//   - createProjects is one API call per project and the slowest
+//     per-item task on large platforms; surface progress every 10.
+//   - setProjectGroupPermissions can run into the tens of thousands
+//     of items (projects × groups × permissions); every 100 keeps
+//     the log readable while still ticking visibly.
+var progressLogInterval = map[string]int64{
+	"createProjects":             10,
+	"setProjectGroupPermissions": 100,
+}
+
 func newProgressLogger(logger *slog.Logger, task string, total int) *progressLogger {
 	interval := int64(1000)
 	if total < 1000 {
@@ -255,6 +270,15 @@ func newProgressLogger(logger *slog.Logger, task string, total int) *progressLog
 	}
 	if total < 100 {
 		interval = int64(total)
+	}
+	// Per-task override beats the size-based default — operator
+	// cadence trumps "log volume." Capped at total so the very last
+	// item still emits a line when override > total.
+	if explicit, ok := progressLogInterval[task]; ok && explicit > 0 {
+		interval = explicit
+		if int64(total) < interval {
+			interval = int64(total)
+		}
 	}
 	return &progressLogger{task: task, total: total, logger: logger, interval: interval}
 }
@@ -264,8 +288,15 @@ func (p *progressLogger) Increment() {
 		return
 	}
 	n := p.done.Add(1)
-	if n%p.interval == 0 {
-		p.logger.Info("progress", "task", p.task, "completed", n, "total", p.total)
+	if n%p.interval == 0 || int(n) == p.total {
+		percent := 0
+		if p.total > 0 {
+			percent = int(n * 100 / int64(p.total))
+		}
+		// One-line human-readable message per the issue #202 spec
+		// — "task N/M - X%" — so operators tailing the log can read
+		// progress at a glance.
+		p.logger.Info(fmt.Sprintf("%s %d/%d - %d%%", p.task, n, p.total, percent))
 	}
 }
 

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -363,6 +363,20 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 			wantFirstLine: "createProjects 10/975 - 1%",
 		},
 		{
+			task:          "configurePortfolios",
+			total:         87,
+			wantInterval:  10,
+			wantFirstAt:   10,
+			wantFirstLine: "configurePortfolios 10/87 - 11%",
+		},
+		{
+			task:          "setProjectSettings",
+			total:         1234,
+			wantInterval:  50,
+			wantFirstAt:   50,
+			wantFirstLine: "setProjectSettings 50/1234 - 4%",
+		},
+		{
 			task:          "setProjectGroupPermissions",
 			total:         19778,
 			wantInterval:  100,

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -313,7 +312,57 @@ func TestProgressLoggerLogsAtInterval(t *testing.T) {
 		}
 	}
 	prog.Increment() // 50th item
-	if !strings.Contains(buf.String(), fmt.Sprintf("completed=%d", 50)) {
-		t.Errorf("expected progress log at 50, got: %s", buf.String())
+	// Issue #202: message now reads "task N/M - X%" — a single
+	// readable line operators can scan when tailing the log.
+	if !strings.Contains(buf.String(), "test 50/50 - 100%") {
+		t.Errorf("expected progress message \"test 50/50 - 100%%\", got: %s", buf.String())
+	}
+}
+
+// Per-task interval overrides take precedence over the size-based
+// default. createProjects ships at every-10, setProjectGroupPermissions
+// at every-100 (issue #202).
+func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
+	cases := []struct {
+		task          string
+		total         int
+		wantInterval  int64
+		wantFirstAt   int // iteration count when the first log should fire
+		wantFirstLine string
+	}{
+		{
+			task:          "createProjects",
+			total:         975,
+			wantInterval:  10,
+			wantFirstAt:   10,
+			wantFirstLine: "createProjects 10/975 - 1%",
+		},
+		{
+			task:          "setProjectGroupPermissions",
+			total:         19778,
+			wantInterval:  100,
+			wantFirstAt:   100,
+			wantFirstLine: "setProjectGroupPermissions 100/19778 - 0%",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.task, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			prog := newProgressLogger(logger, c.task, c.total)
+			if prog.interval != c.wantInterval {
+				t.Errorf("interval: want %d, got %d", c.wantInterval, prog.interval)
+			}
+			for i := 0; i < c.wantFirstAt-1; i++ {
+				prog.Increment()
+				if buf.Len() > 0 {
+					t.Fatalf("unexpected log at iteration %d for %s", i, c.task)
+				}
+			}
+			prog.Increment() // first interval hit
+			if !strings.Contains(buf.String(), c.wantFirstLine) {
+				t.Errorf("want first log to contain %q, got: %s", c.wantFirstLine, buf.String())
+			}
+		})
 	}
 }

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -319,6 +319,31 @@ func TestProgressLoggerLogsAtInterval(t *testing.T) {
 	}
 }
 
+// The final-item log MUST fire even when total isn't a clean
+// multiple of the interval — e.g. createProjects with 975 items at
+// every-10 logs at 970 then jumps to 975 with a 100% line. Issue
+// #202 spec calls this out explicitly: operators need an explicit
+// "task complete" marker.
+func TestProgressLoggerFiresFinalHundredPercent(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	prog := newProgressLogger(logger, "createProjects", 975) // interval=10
+
+	for i := 0; i < 975; i++ {
+		prog.Increment()
+	}
+	out := buf.String()
+	// Last regularly-scheduled line lands at 970 (interval × 97).
+	if !strings.Contains(out, "createProjects 970/975 - 99%") {
+		t.Errorf("expected interval-aligned line at 970, got:\n%s", out)
+	}
+	// Final line at 975 — fires because (n == total) even though
+	// 975 isn't a multiple of 10.
+	if !strings.Contains(out, "createProjects 975/975 - 100%") {
+		t.Errorf("expected final 100%% line at 975, got:\n%s", out)
+	}
+}
+
 // Per-task interval overrides take precedence over the size-based
 // default. createProjects ships at every-10, setProjectGroupPermissions
 // at every-100 (issue #202).


### PR DESCRIPTION
## Summary

Closes #202. On large SQS platforms the migration's long-running tasks went quiet for minutes — the operator had no signal anything was happening. Two fixes for the shared per-item progress logger:

### Per-task progress cadence

A new `progressLogInterval` map names the preferred granularity for tasks where the default size-based cadence is too sparse:

| Task | Interval | Rationale |
|---|---|---|
| `createProjects` | every 10 | slowest task; one API call per project |
| `configurePortfolios` | every 10 | multiple Enterprise-API calls per portfolio |
| `setProjectSettings` | every 50 | multiple HTTP calls per record on average — 50 balances visibility vs noise |
| `setProjectGroupPermissions` | every 100 | per-call is fast but total can run to 20K+ |

The existing size-based fallback (100 / 1000) stays for tasks that aren't listed.

### One-line readable message

```
INFO  msg="createProjects 260/975 - 27%"
INFO  msg="configurePortfolios 30/87 - 34%"
INFO  msg="setProjectSettings 150/1234 - 12%"
INFO  msg="setProjectGroupPermissions 2650/19778 - 13%"
```

The percent is computed from `current / total`. The final item also emits unconditionally so a task whose total isn't a clean multiple of the interval still ends with a 100% line.

## Test plan
- [x] `go test ./...` green.
- [x] Existing `TestProgressLoggerLogsAtInterval` updated to assert the new message format.
- [x] `TestProgressLoggerHonoursPerTaskInterval` pins the per-task intervals + exact first-log lines for all four tunable tasks.
- [x] `TestProgressLoggerFiresFinalHundredPercent` pins the explicit 100% line at task completion.
- [ ] Live re-run against a large SQS: `migrate.log` should tick visibly during `createProjects`, `configurePortfolios`, `setProjectSettings`, and `setProjectGroupPermissions`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
