### PR TITLE
Issue #176 reset accepts the same --config file as migrate

### DIFF
--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
@@ -55,16 +53,15 @@ func init() {
 func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfig, error) {
 	var cfg migrate.MigrateConfig
 
-	// Load config file if specified.
+	// Load config file if specified. Supports flat, command-sectioned, and
+	// side-sectioned shapes (issue #176).
 	configFile, _ := cmd.Flags().GetString("config")
 	if configFile != "" {
-		data, err := os.ReadFile(configFile)
+		loaded, err := migrate.LoadMigrateConfigFile(configFile)
 		if err != nil {
-			return cfg, fmt.Errorf("reading config file: %w", err)
+			return cfg, err
 		}
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return cfg, fmt.Errorf("parsing config file: %w", err)
-		}
+		cfg = loaded
 	}
 
 	// CLI args override config file.

--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -8,25 +8,17 @@ import (
 )
 
 var resetCmd = &cobra.Command{
-	Use:   "reset <token> <enterprise_key>",
+	Use:   "reset [token] [enterprise_key]",
 	Short: "Reset a SonarQube Cloud Enterprise",
 	Long:  "Resets a SonarQube Cloud Enterprise back to its original state. Warning: this will delete everything in every organization within the enterprise.",
-	Args:  cobra.ExactArgs(2),
+	Args:  cobra.MaximumNArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		edition, _ := cmd.Flags().GetString("edition")
-		url, _ := cmd.Flags().GetString("url")
-		concurrency, _ := cmd.Flags().GetInt("concurrency")
-		exportDir, _ := cmd.Flags().GetString("export_directory")
-		debug, _ := cmd.Flags().GetBool("debug")
-
-		cfg := migrate.ResetConfig{
-			Token:           args[0],
-			EnterpriseKey:   args[1],
-			Edition:         edition,
-			URL:             url,
-			Concurrency:     concurrency,
-			ExportDirectory: exportDir,
-			Debug:           debug,
+		cfg, err := buildResetConfig(cmd, args)
+		if err != nil {
+			return err
+		}
+		if cfg.Token == "" || cfg.EnterpriseKey == "" {
+			return fmt.Errorf("TOKEN and ENTERPRISE_KEY are required (either as arguments or in config file)")
 		}
 
 		fmt.Println("WARNING: This will delete everything in every organization within the enterprise.")
@@ -36,9 +28,42 @@ var resetCmd = &cobra.Command{
 
 func init() {
 	f := resetCmd.Flags()
+	f.String("config", "", "Path to JSON configuration file (same format as migrate --config)")
 	f.String("edition", "enterprise", "SonarQube Cloud license edition")
 	f.String("url", "https://sonarcloud.io/", "URL of SonarQube Cloud")
 	f.Int("concurrency", 25, "Maximum number of concurrent requests")
 	f.String("export_directory", "/app/files/", "Directory to place all interim files")
 	f.Bool("debug", false, "Enable debug-level logging (verbose request payloads, more detail per task)")
+}
+
+func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, error) {
+	var cfg migrate.ResetConfig
+
+	configFile, _ := cmd.Flags().GetString("config")
+	if configFile != "" {
+		loaded, err := migrate.LoadResetConfigFile(configFile)
+		if err != nil {
+			return cfg, err
+		}
+		cfg = loaded
+	}
+
+	// CLI args override config file.
+	if len(args) > 0 && args[0] != "" {
+		cfg.Token = args[0]
+	}
+	if len(args) > 1 && args[1] != "" {
+		cfg.EnterpriseKey = args[1]
+	}
+
+	// Flags override everything.
+	overrideString(cmd, "edition", &cfg.Edition)
+	overrideString(cmd, "url", &cfg.URL)
+	overrideString(cmd, "export_directory", &cfg.ExportDirectory)
+	overrideInt(cmd, "concurrency", &cfg.Concurrency)
+	if cmd.Flags().Changed("debug") {
+		cfg.Debug, _ = cmd.Flags().GetBool("debug")
+	}
+
+	return cfg, nil
 }

--- a/go/cmd/reset_test.go
+++ b/go/cmd/reset_test.go
@@ -1,0 +1,182 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newResetTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "reset"}
+	f := cmd.Flags()
+	f.String("config", "", "")
+	f.String("edition", "enterprise", "")
+	f.String("url", "https://sonarcloud.io/", "")
+	f.Int("concurrency", 25, "")
+	f.String("export_directory", "/app/files/", "")
+	f.Bool("debug", false, "")
+	return cmd
+}
+
+func writeConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "reset-cfg-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+func TestBuildResetConfigFromConfigFile(t *testing.T) {
+	path := writeConfigFile(t, `{
+		"token": "cfg-token",
+		"enterprise_key": "cfg-ent",
+		"url": "https://cfg.example.com/",
+		"export_directory": "/cfg/files",
+		"concurrency": 7
+	}`)
+
+	cmd := newResetTestCmd()
+	if err := cmd.Flags().Set("config", path); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := buildResetConfig(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Token != "cfg-token" {
+		t.Errorf("Token: got %q want cfg-token", cfg.Token)
+	}
+	if cfg.EnterpriseKey != "cfg-ent" {
+		t.Errorf("EnterpriseKey: got %q want cfg-ent", cfg.EnterpriseKey)
+	}
+	if cfg.URL != "https://cfg.example.com/" {
+		t.Errorf("URL: got %q", cfg.URL)
+	}
+	if cfg.ExportDirectory != "/cfg/files" {
+		t.Errorf("ExportDirectory: got %q", cfg.ExportDirectory)
+	}
+	if cfg.Concurrency != 7 {
+		t.Errorf("Concurrency: got %d want 7", cfg.Concurrency)
+	}
+}
+
+func TestBuildResetConfigFlagsOverrideConfig(t *testing.T) {
+	path := writeConfigFile(t, `{
+		"token": "cfg-token",
+		"enterprise_key": "cfg-ent",
+		"url": "https://cfg.example.com/",
+		"concurrency": 7
+	}`)
+
+	cmd := newResetTestCmd()
+	_ = cmd.Flags().Set("config", path)
+	_ = cmd.Flags().Set("url", "https://flag.example.com/")
+	_ = cmd.Flags().Set("concurrency", "99")
+	_ = cmd.Flags().Set("debug", "true")
+
+	cfg, err := buildResetConfig(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.URL != "https://flag.example.com/" {
+		t.Errorf("URL: flag should win, got %q", cfg.URL)
+	}
+	if cfg.Concurrency != 99 {
+		t.Errorf("Concurrency: flag should win, got %d", cfg.Concurrency)
+	}
+	if !cfg.Debug {
+		t.Errorf("Debug: flag should win (true)")
+	}
+	if cfg.Token != "cfg-token" || cfg.EnterpriseKey != "cfg-ent" {
+		t.Errorf("config-file values should persist when no flag/arg overrides them, got token=%q ent=%q",
+			cfg.Token, cfg.EnterpriseKey)
+	}
+}
+
+func TestBuildResetConfigPositionalArgsOverrideConfig(t *testing.T) {
+	path := writeConfigFile(t, `{
+		"token": "cfg-token",
+		"enterprise_key": "cfg-ent"
+	}`)
+
+	cmd := newResetTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	cfg, err := buildResetConfig(cmd, []string{"arg-token", "arg-ent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Token != "arg-token" {
+		t.Errorf("Token: positional should win, got %q", cfg.Token)
+	}
+	if cfg.EnterpriseKey != "arg-ent" {
+		t.Errorf("EnterpriseKey: positional should win, got %q", cfg.EnterpriseKey)
+	}
+}
+
+func TestBuildResetConfigNoConfigUsesPositionalAndFlags(t *testing.T) {
+	cmd := newResetTestCmd()
+	_ = cmd.Flags().Set("url", "https://manual.example.com/")
+	_ = cmd.Flags().Set("export_directory", "/manual/dir")
+
+	cfg, err := buildResetConfig(cmd, []string{"tok", "ent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Token != "tok" {
+		t.Errorf("Token: got %q", cfg.Token)
+	}
+	if cfg.EnterpriseKey != "ent" {
+		t.Errorf("EnterpriseKey: got %q", cfg.EnterpriseKey)
+	}
+	if cfg.URL != "https://manual.example.com/" {
+		t.Errorf("URL: got %q", cfg.URL)
+	}
+	if cfg.ExportDirectory != "/manual/dir" {
+		t.Errorf("ExportDirectory: got %q", cfg.ExportDirectory)
+	}
+}
+
+func TestBuildResetConfigShape3FromExampleFile(t *testing.T) {
+	// Round-trip the documented side-sectioned example via buildResetConfig.
+	path, err := filepath.Abs("../../examples/migration-config.example.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := newResetTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	cfg, err := buildResetConfig(cmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Token != "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE" {
+		t.Errorf("Token: got %q", cfg.Token)
+	}
+	if cfg.EnterpriseKey != "YOUR_ENTERPRISE_KEY_HERE" {
+		t.Errorf("EnterpriseKey: got %q", cfg.EnterpriseKey)
+	}
+	if cfg.URL != "https://sonarcloud.io/" {
+		t.Errorf("URL: got %q", cfg.URL)
+	}
+	if cfg.ExportDirectory != "./files" {
+		t.Errorf("ExportDirectory: got %q", cfg.ExportDirectory)
+	}
+	if cfg.Concurrency != 10 {
+		t.Errorf("Concurrency: got %d", cfg.Concurrency)
+	}
+}

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -1,0 +1,128 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// configFileShape is the union of the three documented config-file formats
+// (see examples/config-migrate.example.json, examples/config.example.json,
+// and examples/migration-config.example.json). Issue #176.
+//
+// Detection at parse time:
+//   - sonarcloud present -> shape 3 (side-sectioned)
+//   - migrate present    -> shape 2 (command-sectioned)
+//   - else               -> shape 1 (flat)
+type configFileShape struct {
+	// Shape 1 (flat) fields. Also reused inside Shape 2's "migrate" object.
+	Token              string `json:"token"`
+	EnterpriseKey      string `json:"enterprise_key"`
+	URL                string `json:"url"`
+	Edition            string `json:"edition"`
+	ExportDirectory    string `json:"export_directory"`
+	Concurrency        int    `json:"concurrency"`
+	RunID              string `json:"run_id"`
+	TargetTask         string `json:"target_task"`
+	SkipProfiles       bool   `json:"skip_profiles"`
+	IncludeScanHistory bool   `json:"include_scan_history"`
+	Debug              bool   `json:"debug"`
+
+	// Shape 2 (command-sectioned).
+	Migrate *configFileShape `json:"migrate"`
+
+	// Shape 3 (side-sectioned). sonarqube + extract blocks are ignored —
+	// migrate/reset only consume SonarCloud-side values.
+	SonarCloud *sonarCloudBlock `json:"sonarcloud"`
+	Settings   *settingsBlock   `json:"settings"`
+}
+
+type sonarCloudBlock struct {
+	URL           string `json:"url"`
+	Token         string `json:"token"`
+	EnterpriseKey string `json:"enterprise_key"`
+	Edition       string `json:"edition"`
+}
+
+type settingsBlock struct {
+	ExportDirectory string `json:"export_directory"`
+	Concurrency     int    `json:"concurrency"`
+}
+
+func parseConfigFile(path string) (configFileShape, error) {
+	var shape configFileShape
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return shape, fmt.Errorf("reading config file: %w", err)
+	}
+	if len(data) == 0 {
+		return shape, fmt.Errorf("config file %s is empty", path)
+	}
+	if err := json.Unmarshal(data, &shape); err != nil {
+		return shape, fmt.Errorf("parsing config file: %w", err)
+	}
+	return shape, nil
+}
+
+func (s configFileShape) toMigrateConfig() MigrateConfig {
+	var cfg MigrateConfig
+	switch {
+	case s.SonarCloud != nil:
+		cfg.Token = s.SonarCloud.Token
+		cfg.URL = s.SonarCloud.URL
+		cfg.EnterpriseKey = s.SonarCloud.EnterpriseKey
+		cfg.Edition = s.SonarCloud.Edition
+		if s.Settings != nil {
+			cfg.ExportDirectory = s.Settings.ExportDirectory
+			cfg.Concurrency = s.Settings.Concurrency
+		}
+	case s.Migrate != nil:
+		return s.Migrate.toMigrateConfig()
+	default:
+		cfg.Token = s.Token
+		cfg.EnterpriseKey = s.EnterpriseKey
+		cfg.URL = s.URL
+		cfg.Edition = s.Edition
+		cfg.ExportDirectory = s.ExportDirectory
+		cfg.Concurrency = s.Concurrency
+		cfg.RunID = s.RunID
+		cfg.TargetTask = s.TargetTask
+		cfg.SkipProfiles = s.SkipProfiles
+		cfg.IncludeScanHistory = s.IncludeScanHistory
+		cfg.Debug = s.Debug
+	}
+	return cfg
+}
+
+func (s configFileShape) toResetConfig() ResetConfig {
+	m := s.toMigrateConfig()
+	return ResetConfig{
+		Token:           m.Token,
+		EnterpriseKey:   m.EnterpriseKey,
+		Edition:         m.Edition,
+		URL:             m.URL,
+		Concurrency:     m.Concurrency,
+		ExportDirectory: m.ExportDirectory,
+		Debug:           m.Debug,
+	}
+}
+
+// LoadMigrateConfigFile parses a JSON config file in any of the three
+// documented shapes and returns the populated MigrateConfig.
+func LoadMigrateConfigFile(path string) (MigrateConfig, error) {
+	shape, err := parseConfigFile(path)
+	if err != nil {
+		return MigrateConfig{}, err
+	}
+	return shape.toMigrateConfig(), nil
+}
+
+// LoadResetConfigFile parses a JSON config file in any of the three
+// documented shapes and returns the populated ResetConfig.
+func LoadResetConfigFile(path string) (ResetConfig, error) {
+	shape, err := parseConfigFile(path)
+	if err != nil {
+		return ResetConfig{}, err
+	}
+	return shape.toResetConfig(), nil
+}

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -1,0 +1,155 @@
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const examplesDir = "../../../examples"
+
+func TestLoadMigrateConfigFileShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want MigrateConfig
+	}{
+		{
+			name: "shape 1 - flat",
+			file: "config-migrate.example.json",
+			want: MigrateConfig{
+				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
+				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
+				URL:             "https://sonarcloud.io/",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+			},
+		},
+		{
+			name: "shape 2 - command-sectioned",
+			file: "config.example.json",
+			want: MigrateConfig{
+				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
+				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
+				URL:             "https://sonarcloud.io/",
+				Edition:         "enterprise",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+			},
+		},
+		{
+			name: "shape 3 - side-sectioned",
+			file: "migration-config.example.json",
+			want: MigrateConfig{
+				Token:           "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE",
+				EnterpriseKey:   "YOUR_ENTERPRISE_KEY_HERE",
+				URL:             "https://sonarcloud.io/",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LoadMigrateConfigFile(filepath.Join(examplesDir, tc.file))
+			if err != nil {
+				t.Fatalf("LoadMigrateConfigFile(%s): %v", tc.file, err)
+			}
+			if got != tc.want {
+				t.Errorf("MigrateConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadResetConfigFileShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want ResetConfig
+	}{
+		{
+			name: "shape 1 - flat",
+			file: "config-migrate.example.json",
+			want: ResetConfig{
+				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
+				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
+				URL:             "https://sonarcloud.io/",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+			},
+		},
+		{
+			name: "shape 2 - command-sectioned",
+			file: "config.example.json",
+			want: ResetConfig{
+				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
+				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
+				URL:             "https://sonarcloud.io/",
+				Edition:         "enterprise",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+			},
+		},
+		{
+			name: "shape 3 - side-sectioned",
+			file: "migration-config.example.json",
+			want: ResetConfig{
+				Token:           "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE",
+				EnterpriseKey:   "YOUR_ENTERPRISE_KEY_HERE",
+				URL:             "https://sonarcloud.io/",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LoadResetConfigFile(filepath.Join(examplesDir, tc.file))
+			if err != nil {
+				t.Fatalf("LoadResetConfigFile(%s): %v", tc.file, err)
+			}
+			if got != tc.want {
+				t.Errorf("ResetConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfigFileErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := LoadMigrateConfigFile("/nonexistent/path/does-not-exist.json")
+		if err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "bad-*.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.WriteString("{not valid json"); err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		_, err = LoadMigrateConfigFile(f.Name())
+		if err == nil {
+			t.Fatal("expected error for malformed JSON, got nil")
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "empty-*.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		_, err = LoadResetConfigFile(f.Name())
+		if err == nil {
+			t.Fatal("expected error for empty file, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #176. Before this PR:

```
sonar-migration-tool migrate --config migrate-config.json
sonar-migration-tool reset <token> <enterprise_key> --url <sqc_url> --export_directory <dir>
```

After:

```
sonar-migration-tool migrate --config migrate-config.json
sonar-migration-tool reset   --config migrate-config.json
```

### What changed

- `reset` now accepts `--config <file>`.
- Token + enterprise-key positional args are now optional (`cobra.MaximumNArgs(2)`); they can come from the config file, the args, or the flags. Precedence: **flags > args > config**.
- Both `reset --config` and `migrate --config` route through a shared loader that recognises any of the three documented JSON shapes from `examples/`:
  1. **Flat** — `examples/config-migrate.example.json`
  2. **Command-sectioned** — `examples/config.example.json` (`{ migrate: {...} }`)
  3. **Side-sectioned** — `examples/migration-config.example.json` (`{ sonarcloud: {...}, settings: {...} }`)

### Latent bug fixed for migrate too

`MigrateConfig` had no `json:` struct tags, so `migrate --config` was silently dropping every snake_case key (`enterprise_key`, `export_directory`, `run_id`, `target_task`, `skip_profiles`, `include_scan_history`). The documented example files only loaded `token`, `url`, and `concurrency`. They now load fully.

Anyone relying on the undocumented "camelCase keys via Go case-insensitive match" form should note: `Token`, `URL`, `Concurrency` still work; `EnterpriseKey` / `ExportDirectory` never worked correctly anyway (the documented snake_case form was broken), so this PR is a fix not a regression.

## Test plan
- [x] `go test ./...` green (full module).
- [x] New `internal/migrate/config_file_test.go` — all three shapes for both `LoadMigrateConfigFile` and `LoadResetConfigFile`, plus error cases (missing file, malformed JSON, empty file).
- [x] New `cmd/reset_test.go` — `buildResetConfig` precedence: config-file values, flag overrides, positional-arg overrides, round-trip through the shape-3 example file.
- [x] `./sonar-migration-tool reset --help` shows `--config` between the other flags.
- [ ] Live smoke: `reset --config examples/config-migrate.example.json` against a throwaway SQC.
- [ ] Live smoke: `migrate --config examples/config-migrate.example.json` no longer needs `enterprise_key` / `export_directory` on the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
