### PR TITLE
Two reset correctness fixes: deleteProjects dedup + org-level settings revert

### DIFF
--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -64,10 +64,18 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 	registry := BuildMigrateRegistry(allDefs)
 	registry = FilterByEdition(registry, edition)
 
-	// Target only delete* tasks.
+	// Target the delete* tasks plus the curated set of reset* tasks
+	// whose dependency chains do not pull migrate-only create*/set*
+	// work back into the plan. The other reset* tasks
+	// (resetDefaultProfiles, resetDefaultGates, resetPermissionTemplates)
+	// remain no-ops triggered as side-effects of deletes and are
+	// intentionally NOT in this list.
+	resetPrefixTargets := map[string]bool{
+		"resetGlobalSettings": true,
+	}
 	var targets []string
 	for name := range registry {
-		if strings.HasPrefix(name, "delete") {
+		if strings.HasPrefix(name, "delete") || resetPrefixTargets[name] {
 			targets = append(targets, name)
 		}
 	}

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -59,6 +59,15 @@ func deleteTasks() []TaskDef {
 			Dependencies: []string{"setDefaultTemplates"},
 			Run:          runResetPermissionTemplates,
 		},
+		{
+			// Reverts every org-level setting that has been customized on
+			// SonarQube Cloud back to its default. Setting reset is
+			// scoped per organization; this task iterates the mapped orgs
+			// and resets the union of customized keys in each.
+			Name:         "resetGlobalSettings",
+			Dependencies: []string{"generateOrganizationMappings"},
+			Run:          runResetGlobalSettings,
+		},
 	}
 }
 
@@ -193,6 +202,57 @@ func runDeletePortfolios(ctx context.Context, e *Executor) error {
 			} else {
 				counter.Success()
 			}
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
+}
+
+// runResetGlobalSettings reverts every customized org-level setting on
+// SonarQube Cloud back to its default. SQC's /api/settings/values only
+// returns keys that have been explicitly customized, so the reset key
+// list is naturally bounded — no enumeration of all definitions is
+// required. Iteration is per-org from generateOrganizationMappings so
+// no upstream create*/generate* dependency is pulled into reset's
+// plan.
+func runResetGlobalSettings(ctx context.Context, e *Executor) error {
+	counter := NewTaskCounter("resetGlobalSettings")
+	err := forEachMigrateItem(ctx, e, "resetGlobalSettings", "generateOrganizationMappings",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+
+			values, err := e.Cloud.Settings.Values(ctx, "", orgKey)
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "resetGlobalSettings: listing org settings failed", err, "org", orgKey)
+				return nil
+			}
+
+			var keys []string
+			for _, s := range values {
+				// Skip settings that are still at their inherited default
+				// — only revert what's been explicitly set at org scope.
+				if s.Inherited || s.Key == "" {
+					continue
+				}
+				keys = append(keys, s.Key)
+			}
+			if len(keys) == 0 {
+				counter.Success()
+				return nil
+			}
+
+			e.Logger.Debug("settings api call: POST /api/settings/reset",
+				"org", orgKey, "keys", keys)
+			if err := e.Cloud.Settings.Reset(ctx, "", keys, orgKey); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "resetGlobalSettings: reset failed", err, "org", orgKey, "keys", keys)
+				return nil
+			}
+			counter.Success()
 			return nil
 		})
 	counter.LogSummary(e.Logger)

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -1,0 +1,126 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+)
+
+// TestRunResetGlobalSettings verifies the new task posts /api/settings/reset
+// with the keys reported as customized (Inherited=false) by SQC, and
+// omits keys that are still at their inherited default.
+func TestRunResetGlobalSettings(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		resetKeys   []string
+		resetOrg    string
+		valuesCalls int
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/settings/values", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		valuesCalls++
+		mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]any{
+			"settings": []map[string]any{
+				{"key": "sonar.exclusions", "values": []string{"**/*.gen.java"}, "inherited": false},
+				{"key": "sonar.coverage.exclusions", "value": "**/*.test.java", "inherited": false},
+				{"key": "sonar.inherited.example", "value": "default-value", "inherited": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/settings/reset", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		resetKeys = append(resetKeys, r.FormValue("keys"))
+		resetOrg = r.FormValue("organization")
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// Seed the org mapping so the task has one org to iterate.
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{
+		"sonarqube_org_key":  "org1",
+		"sonarcloud_org_key": testCloudOrg,
+	})
+	w.WriteOne(b)
+
+	if err := runResetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("runResetGlobalSettings: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if valuesCalls != 1 {
+		t.Errorf("Settings.Values expected once, got %d", valuesCalls)
+	}
+	if len(resetKeys) != 1 {
+		t.Fatalf("expected 1 Reset call, got %d", len(resetKeys))
+	}
+	// Inherited setting must not appear; customized ones must be
+	// joined with a comma (SonarQube Web API expects a single "keys"
+	// parameter, not repeated form values).
+	wantKeys := "sonar.exclusions,sonar.coverage.exclusions"
+	if resetKeys[0] != wantKeys {
+		t.Errorf("Reset keys: got %q want %q", resetKeys[0], wantKeys)
+	}
+	if resetOrg != testCloudOrg {
+		t.Errorf("Reset organization: got %q want %q", resetOrg, testCloudOrg)
+	}
+}
+
+// TestRunResetGlobalSettingsAllInherited verifies that when an org has
+// no customized settings (everything inherited), the task still
+// succeeds and does NOT call POST /api/settings/reset (which would 400
+// with an empty keys list).
+func TestRunResetGlobalSettingsAllInherited(t *testing.T) {
+	resetCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/settings/values", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"settings": []map[string]any{
+				{"key": "sonar.foo", "value": "default", "inherited": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/settings/reset", func(w http.ResponseWriter, r *http.Request) {
+		resetCalls++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{
+		"sonarcloud_org_key": testCloudOrg,
+	})
+	w.WriteOne(b)
+
+	if err := runResetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("runResetGlobalSettings: %v", err)
+	}
+	if resetCalls != 0 {
+		t.Errorf("Reset should not be called when no customized settings; got %d calls", resetCalls)
+	}
+}

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -659,6 +659,7 @@ func TestDeleteTasks(t *testing.T) {
 	deleteTasks := []string{
 		"deleteProjects", "deleteProfiles", "deleteGates", "deleteGroups",
 		"deleteTemplates", "resetDefaultProfiles", "resetDefaultGates", "resetPermissionTemplates",
+		"resetGlobalSettings",
 	}
 	for _, name := range deleteTasks {
 		t.Run(name, func(t *testing.T) {

--- a/go/internal/migrate/tasks_read.go
+++ b/go/internal/migrate/tasks_read.go
@@ -38,7 +38,7 @@ func readTasks() []TaskDef {
 		},
 		{
 			Name:         "getCreatedProjects",
-			Dependencies: []string{"createProjects"},
+			Dependencies: []string{"generateOrganizationMappings"},
 			Run:          runGetCreatedProjects,
 		},
 		{
@@ -183,8 +183,15 @@ func runGetMigrationUser(ctx context.Context, e *Executor) error {
 	return w.WriteOne(raw)
 }
 
+// runGetCreatedProjects lists every project in every mapped SonarCloud
+// organization. It iterates generateOrganizationMappings (one record per
+// org) rather than createProjects (one record per project) so that the
+// /api/projects/search call fires exactly once per org. Reset feeds the
+// output to deleteProjects; iterating per-project caused N×N duplicates
+// where reset would try to delete the same key once per createProjects
+// record in that org.
 func runGetCreatedProjects(ctx context.Context, e *Executor) error {
-	return forEachMigrateItem(ctx, e, "getCreatedProjects", "createProjects",
+	return forEachMigrateItem(ctx, e, "getCreatedProjects", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
 			if shouldSkipOrg(orgKey) {

--- a/go/internal/migrate/tasks_read_test.go
+++ b/go/internal/migrate/tasks_read_test.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 )
 
@@ -69,6 +70,51 @@ func TestGetCreatedProjects(t *testing.T) {
 	items, _ := e.Store.ReadAll("getCreatedProjects")
 	if len(items) == 0 {
 		t.Error("expected getCreatedProjects output")
+	}
+}
+
+// Regression: getCreatedProjects must iterate per-org (one
+// /api/projects/search call per organization), not per createProjects
+// record. Reset fed deleteProjects through this task, and the old
+// per-record iteration produced one chunk per createProjects entry —
+// for a tenant with N projects in M orgs, deleteProjects would attempt
+// N deletions per record, returning 404 for every duplicate. Pin the
+// per-org iteration shape so we never regress.
+func TestGetCreatedProjectsDeduplicatesByOrg(t *testing.T) {
+	cloudSrv := newMockCloudServer()
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	setupCreateOutputs(t, e)
+
+	// Write extra createProjects records for the same org. If the
+	// iteration source regressed back to createProjects, getCreatedProjects
+	// would call /api/projects/search once per record and write one
+	// chunk per record. Iterating generateOrganizationMappings (one
+	// record per org) caps it at one chunk per org.
+	w, _ := e.Store.Writer("createProjects")
+	for i := 0; i < 9; i++ {
+		extra, _ := json.Marshal(map[string]any{
+			"sonarcloud_org_key": testCloudOrg,
+			"cloud_project_key":  fmt.Sprintf("cloud-org1_proj%d", i+2),
+		})
+		w.WriteOne(extra)
+	}
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["getCreatedProjects"].Run(context.Background(), e); err != nil {
+		t.Fatalf("getCreatedProjects: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("getCreatedProjects")
+	// Mock returns 1 component per /api/projects/search call. With one
+	// org we expect exactly 1 component. Old behaviour: 10 (1 per
+	// createProjects record).
+	if len(items) != 1 {
+		t.Errorf("expected 1 item (one chunk per org), got %d — iteration likely regressed to per-record", len(items))
 	}
 }
 

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -164,6 +164,20 @@ func newMockCloudServer() *httptest.Server {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
+	mux.HandleFunc("POST /api/settings/reset", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	mux.HandleFunc("GET /api/settings/values", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"settings": []map[string]any{
+				{"key": "sonar.exclusions", "values": []string{"**/*.gen.java"}, "inherited": false},
+				{"key": "sonar.coverage.exclusions", "value": "**/*.test.java", "inherited": false},
+				{"key": "sonar.inherited.example", "value": "default-value", "inherited": true},
+			},
+		})
+	})
+
 	mux.HandleFunc("POST /api/project_tags/set", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -991,6 +991,70 @@ func TestSettingsListDefinitionsWithComponent(t *testing.T) {
 	assert.Equal(t, "sonar.java.file.suffixes", defs[0].Key)
 }
 
+// TestSettingsValuesOrgScope exercises GET /api/settings/values at
+// org scope. SonarQube Cloud only includes settings that have been
+// explicitly customized — defaults are omitted from the response.
+// Reset uses this to enumerate which org-level keys need reverting.
+func TestSettingsValuesOrgScope(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/settings/values", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
+		assert.Empty(t, r.URL.Query().Get("component"), "component must be absent for org-scope")
+		writeJSON(w, types.SettingsValuesResponse{
+			Settings: []types.Setting{
+				{Key: "sonar.exclusions", Values: []string{"**/*.gen.java"}, Inherited: false},
+				{Key: "sonar.coverage.exclusions", Value: "**/*.test.java", Inherited: false},
+			},
+		})
+	})
+	cc := newTestCloud(t, mux)
+
+	settings, err := cc.Settings.Values(context.Background(), "", "myorg")
+	require.NoError(t, err)
+	require.Len(t, settings, 2)
+	assert.Equal(t, "sonar.exclusions", settings[0].Key)
+	assert.Equal(t, []string{"**/*.gen.java"}, settings[0].Values)
+}
+
+// TestSettingsResetOrgScope pins the POST /api/settings/reset shape
+// used by the reset command to revert org-level settings.
+func TestSettingsResetOrgScope(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/settings/reset", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		_ = r.ParseForm()
+		// The SonarQube Web API expects a single comma-joined "keys"
+		// parameter, not repeated keys=K1&keys=K2 values.
+		assert.Equal(t, "sonar.exclusions,sonar.coverage.exclusions", r.FormValue("keys"))
+		assert.Equal(t, "myorg", r.FormValue("organization"))
+		assert.Empty(t, r.Form["component"], "component must be absent at org scope")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.Settings.Reset(context.Background(), "",
+		[]string{"sonar.exclusions", "sonar.coverage.exclusions"}, "myorg")
+	require.NoError(t, err)
+}
+
+// TestSettingsResetEmptyKeys ensures the SDK no-ops on an empty list
+// rather than hitting the API with an invalid request that SonarQube
+// would reject with HTTP 400.
+func TestSettingsResetEmptyKeys(t *testing.T) {
+	mux := http.NewServeMux()
+	called := false
+	mux.HandleFunc("/api/settings/reset", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+
+	err := cc.Settings.Reset(context.Background(), "", nil, "myorg")
+	require.NoError(t, err)
+	assert.False(t, called, "empty keys must short-circuit before hitting the network")
+}
+
 // --- Enterprises ---
 
 func TestEnterprisesList(t *testing.T) {

--- a/lib/sq-api-go/cloud/settings.go
+++ b/lib/sq-api-go/cloud/settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/url"
+	"strings"
 
 	"github.com/sonar-solutions/sq-api-go/types"
 )
@@ -97,6 +98,42 @@ func (s *SettingsClient) SetFieldValues(ctx context.Context, projectKey, setting
 	}
 	addSettingsScope(form, projectKey, organization)
 	return s.postForm(ctx, "api/settings/set", form, nil)
+}
+
+// Values returns settings explicitly set at the given scope. Settings
+// still at their default are omitted by SonarQube Cloud's response.
+// Used by reset to enumerate which org-level settings need reverting.
+func (s *SettingsClient) Values(ctx context.Context, projectKey, organization string) ([]types.Setting, error) {
+	q := url.Values{}
+	if projectKey != "" {
+		q.Set("component", projectKey)
+	} else if organization != "" {
+		q.Set("organization", organization)
+	}
+	path := "api/settings/values"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var resp types.SettingsValuesResponse
+	if err := s.getJSON(ctx, path, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Settings, nil
+}
+
+// Reset reverts the named settings to their default value at the given
+// scope (POST /api/settings/reset). Multiple keys are joined with
+// commas — the SonarQube Web API expects a single "keys" parameter,
+// not repeated keys=K1&keys=K2 form values. Passing an empty keys list
+// is a no-op (the API would reject it with HTTP 400).
+func (s *SettingsClient) Reset(ctx context.Context, projectKey string, keys []string, organization string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	form := url.Values{}
+	form.Set("keys", strings.Join(keys, ","))
+	addSettingsScope(form, projectKey, organization)
+	return s.postForm(ctx, "api/settings/reset", form, nil)
 }
 
 // addSettingsScope adds exactly one of "component" or "organization" to


### PR DESCRIPTION
## Summary

Two correctness fixes for `sonar-migration-tool reset`, both surfaced while testing PR #209.

### 1. deleteProjects no longer attempts to delete the same key dozens of times

reset's `deleteProjects` was reading `getCreatedProjects` output, which in turn iterated `createProjects` (one record per project) and for **each record** called `/api/projects/search?organization=X` — returning the **whole org's** project list every time. The same SonarCloud key ended up in the JSONL once per createProjects entry in its org, so reset issued one delete attempt per duplicate. The first succeeded; the rest returned 404.

Field signature:
```
deleteProjects 4405/4405 - 100%
task summary task=deleteProjects succeeded=77 failed=4328 total=4405
```
i.e. 77 real projects, 4328 phantom 404s.

**Fix:** `getCreatedProjects` now iterates `generateOrganizationMappings` (one record per org) instead of `createProjects` — the search call fires exactly once per organization. Bonus: reset's plan no longer pulls `createProjects` + `generateProjectMappings` into its DAG via this chain, so reset stops re-running createProjects on every invocation (idempotent before, but a complete waste of API calls).

### 2. Org-level settings are now reverted

reset previously only handled entities (projects, profiles, gates, groups, templates). Any setting the migration wrote at org scope via `setGlobalSettings` — `sonar.exclusions`, `sonar.coverage.exclusions`, language settings, etc. — survived reset, leaving the org in a half-reset state.

**Fix:** new `resetGlobalSettings` task. For each mapped SQC org:
1. `GET /api/settings/values?organization=X`
2. Filter to settings reported as `inherited=false`
3. `POST /api/settings/reset?keys=K1,K2,...&organization=X`

The SDK gains two new methods on `cloud.SettingsClient`: `Values` (read) and `Reset` (write, with the single comma-joined `keys` form parameter the SonarQube Web API expects). The migrate task depends only on `generateOrganizationMappings`, so reset's DAG stays clean.

`reset.go` now targets `delete*` tasks **plus a curated set of `reset*` tasks** (currently just `resetGlobalSettings`). The pre-existing `resetDefaultProfiles` / `resetDefaultGates` / `resetPermissionTemplates` remain documented no-ops and are intentionally NOT in this list — their `set*` deps would otherwise pull most of migrate back into reset.

## Test plan
- [x] `go test ./...` green in both `go/` and `lib/sq-api-go/`.
- [x] SDK tests pin Values + Reset request shapes (org scope, comma-joined keys, empty-keys short-circuit).
- [x] `TestGetCreatedProjectsDeduplicatesByOrg` writes 10 createProjects records for one org and asserts a single output chunk (old behavior: 10 chunks).
- [x] `TestRunResetGlobalSettings` confirms only non-inherited keys are reset, with a single per-org Reset call.
- [x] `TestRunResetGlobalSettingsAllInherited` confirms the task is a no-op (no Reset POST) when nothing is customized.
- [x] `TestDeleteTasks` extended with a `resetGlobalSettings` sub-case to guard the registry shape.
- [ ] Live re-run against a throwaway SQC: `reset` should report 77/77 successes (no 404s) and `sonar.exclusions` should be back to default afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
