### PR TITLE
Issue #158 extract --config reads snake_case keys

### DIFF
--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -54,16 +53,15 @@ func init() {
 func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfig, error) {
 	var cfg extract.ExtractConfig
 
-	// Load config file if specified.
+	// Load config file if specified. Supports flat, command-sectioned,
+	// and side-sectioned shapes — issue #158.
 	configFile, _ := cmd.Flags().GetString("config")
 	if configFile != "" {
-		data, err := os.ReadFile(configFile)
+		loaded, err := extract.LoadExtractConfigFile(configFile)
 		if err != nil {
-			return cfg, fmt.Errorf("reading config file: %w", err)
+			return cfg, err
 		}
-		if err := json.Unmarshal(data, &cfg); err != nil {
-			return cfg, fmt.Errorf("parsing config file: %w", err)
-		}
+		cfg = loaded
 	}
 
 	// CLI args override config file.

--- a/go/internal/extract/config_file.go
+++ b/go/internal/extract/config_file.go
@@ -1,0 +1,110 @@
+package extract
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// configFileShape is the union of the three documented config-file
+// formats for the extract command (issue #158):
+//
+//   - examples/config-extract.example.json — flat top-level keys
+//   - examples/config.example.json         — "extract" sub-object
+//   - examples/migration-config.example.json — "sonarqube" + "settings"
+//     sub-objects (the SonarCloud-side blocks are ignored by extract)
+//
+// Detection at parse time:
+//   - sonarqube present -> shape 3 (side-sectioned)
+//   - extract present   -> shape 2 (command-sectioned)
+//   - else              -> shape 1 (flat)
+type configFileShape struct {
+	// Shape 1 (flat) fields. Reused inside Shape 2's "extract" object.
+	URL                string `json:"url"`
+	Token              string `json:"token"`
+	ExportDirectory    string `json:"export_directory"`
+	ExtractType        string `json:"extract_type"`
+	PEMFilePath        string `json:"pem_file_path"`
+	KeyFilePath        string `json:"key_file_path"`
+	CertPassword       string `json:"cert_password"`
+	Concurrency        int    `json:"concurrency"`
+	Timeout            int    `json:"timeout"`
+	ExtractID          string `json:"extract_id"`
+	TargetTask         string `json:"target_task"`
+	IncludeScanHistory bool   `json:"include_scan_history"`
+
+	// Shape 2 (command-sectioned).
+	Extract *configFileShape `json:"extract"`
+
+	// Shape 3 (side-sectioned). The SonarCloud side of
+	// migration-config.example.json is ignored — extract only consumes
+	// the SonarQube-side credentials and shared settings block.
+	SonarQube *sonarQubeBlock `json:"sonarqube"`
+	Settings  *settingsBlock  `json:"settings"`
+}
+
+type sonarQubeBlock struct {
+	URL   string `json:"url"`
+	Token string `json:"token"`
+}
+
+type settingsBlock struct {
+	ExportDirectory string `json:"export_directory"`
+	Concurrency     int    `json:"concurrency"`
+	Timeout         int    `json:"timeout"`
+}
+
+func parseConfigFile(path string) (configFileShape, error) {
+	var shape configFileShape
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return shape, fmt.Errorf("reading config file: %w", err)
+	}
+	if len(data) == 0 {
+		return shape, fmt.Errorf("config file %s is empty", path)
+	}
+	if err := json.Unmarshal(data, &shape); err != nil {
+		return shape, fmt.Errorf("parsing config file: %w", err)
+	}
+	return shape, nil
+}
+
+func (s configFileShape) toExtractConfig() ExtractConfig {
+	var cfg ExtractConfig
+	switch {
+	case s.SonarQube != nil:
+		cfg.URL = s.SonarQube.URL
+		cfg.Token = s.SonarQube.Token
+		if s.Settings != nil {
+			cfg.ExportDirectory = s.Settings.ExportDirectory
+			cfg.Concurrency = s.Settings.Concurrency
+			cfg.Timeout = s.Settings.Timeout
+		}
+	case s.Extract != nil:
+		return s.Extract.toExtractConfig()
+	default:
+		cfg.URL = s.URL
+		cfg.Token = s.Token
+		cfg.ExportDirectory = s.ExportDirectory
+		cfg.ExtractType = s.ExtractType
+		cfg.PEMFilePath = s.PEMFilePath
+		cfg.KeyFilePath = s.KeyFilePath
+		cfg.CertPassword = s.CertPassword
+		cfg.Concurrency = s.Concurrency
+		cfg.Timeout = s.Timeout
+		cfg.ExtractID = s.ExtractID
+		cfg.TargetTask = s.TargetTask
+		cfg.IncludeScanHistory = s.IncludeScanHistory
+	}
+	return cfg
+}
+
+// LoadExtractConfigFile parses a JSON config file in any of the three
+// documented shapes and returns the populated ExtractConfig.
+func LoadExtractConfigFile(path string) (ExtractConfig, error) {
+	shape, err := parseConfigFile(path)
+	if err != nil {
+		return ExtractConfig{}, err
+	}
+	return shape.toExtractConfig(), nil
+}

--- a/go/internal/extract/config_file_test.go
+++ b/go/internal/extract/config_file_test.go
@@ -1,0 +1,149 @@
+package extract
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const examplesDir = "../../../examples"
+
+func TestLoadExtractConfigFileShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		file string
+		want ExtractConfig
+	}{
+		{
+			name: "shape 1 - flat",
+			file: "config-extract.example.json",
+			want: ExtractConfig{
+				URL:             "http://localhost:9000",
+				Token:           "YOUR_SONARQUBE_TOKEN_HERE",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+				Timeout:         60,
+			},
+		},
+		{
+			name: "shape 2 - command-sectioned",
+			file: "config.example.json",
+			want: ExtractConfig{
+				URL:             "http://localhost:9000",
+				Token:           "YOUR_SONARQUBE_TOKEN_HERE",
+				ExportDirectory: "./files",
+				ExtractType:     "all",
+				Concurrency:     10,
+				Timeout:         60,
+			},
+		},
+		{
+			name: "shape 3 - side-sectioned",
+			file: "migration-config.example.json",
+			want: ExtractConfig{
+				URL:             "http://localhost:9000",
+				Token:           "YOUR_SONARQUBE_ADMIN_TOKEN_HERE",
+				ExportDirectory: "./files",
+				Concurrency:     10,
+				Timeout:         60,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := LoadExtractConfigFile(filepath.Join(examplesDir, tc.file))
+			if err != nil {
+				t.Fatalf("LoadExtractConfigFile(%s): %v", tc.file, err)
+			}
+			if got != tc.want {
+				t.Errorf("ExtractConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadExtractConfigFileSnakeCaseFields(t *testing.T) {
+	// Regression for issue #158: every snake_case field in the flat
+	// shape must round-trip into the corresponding CamelCase struct
+	// field. Before the fix, json.Unmarshal silently dropped these
+	// because ExtractConfig had no json: tags, so users had to type
+	// "exportDirectory" / "extractType" / etc. instead of the
+	// documented snake_case keys.
+	f, err := os.CreateTemp(t.TempDir(), "extract-cfg-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString(`{
+		"url": "http://sq.example.com:9000",
+		"token": "tok",
+		"export_directory": "/data/files",
+		"extract_type": "all",
+		"pem_file_path": "/certs/client.pem",
+		"key_file_path": "/certs/client.key",
+		"cert_password": "secret",
+		"concurrency": 25,
+		"timeout": 90,
+		"extract_id": "resume-me",
+		"target_task": "getRules",
+		"include_scan_history": true
+	}`)
+	f.Close()
+
+	got, err := LoadExtractConfigFile(f.Name())
+	if err != nil {
+		t.Fatalf("LoadExtractConfigFile: %v", err)
+	}
+
+	want := ExtractConfig{
+		URL:                "http://sq.example.com:9000",
+		Token:              "tok",
+		ExportDirectory:    "/data/files",
+		ExtractType:        "all",
+		PEMFilePath:        "/certs/client.pem",
+		KeyFilePath:        "/certs/client.key",
+		CertPassword:       "secret",
+		Concurrency:        25,
+		Timeout:            90,
+		ExtractID:          "resume-me",
+		TargetTask:         "getRules",
+		IncludeScanHistory: true,
+	}
+	if got != want {
+		t.Errorf("snake_case round-trip mismatch\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+func TestLoadExtractConfigFileErrors(t *testing.T) {
+	t.Run("missing file", func(t *testing.T) {
+		_, err := LoadExtractConfigFile("/nonexistent/path/does-not-exist.json")
+		if err == nil {
+			t.Fatal("expected error for missing file, got nil")
+		}
+	})
+
+	t.Run("malformed JSON", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "bad-*.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = f.WriteString("{not valid")
+		f.Close()
+		_, err = LoadExtractConfigFile(f.Name())
+		if err == nil {
+			t.Fatal("expected error for malformed JSON, got nil")
+		}
+	})
+
+	t.Run("empty file", func(t *testing.T) {
+		f, err := os.CreateTemp(t.TempDir(), "empty-*.json")
+		if err != nil {
+			t.Fatal(err)
+		}
+		f.Close()
+		_, err = LoadExtractConfigFile(f.Name())
+		if err == nil {
+			t.Fatal("expected error for empty file, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #158. `extract --config` was silently dropping every snake_case key in the documented example files because `ExtractConfig` had no `json:` tags — the same latent bug PR #209 fixed for `migrate --config`. Users following the README hit:

```
./sonar-migration-tool extract --config extract-config.json
Error: creating extract dir: mkdir /app: read-only file system
```

because `export_directory` never reached `cfg.ExportDirectory` and the tool fell back to `/app/files/`. Same story for `extract_type`, `pem_file_path`, `key_file_path`, `cert_password`, `extract_id`, `target_task`, `include_scan_history`.

### Fix

New `LoadExtractConfigFile` (mirroring `LoadMigrateConfigFile` from #209). Parses with explicit `json:` tags and supports all three documented config shapes:

| Shape | Example | Detection |
|---|---|---|
| Flat | `config-extract.example.json` | default |
| Command-sectioned | `config.example.json` | top-level `extract: {...}` |
| Side-sectioned | `migration-config.example.json` | top-level `sonarqube` + `settings` |

For shape 3 the SonarCloud-side blocks are ignored — extract only reads `sonarqube.url` / `sonarqube.token` and the shared `settings` block.

`buildExtractConfig` now routes through the new loader; positional args + CLI flags still override config-file values with the same precedence as before.

## Test plan
- [x] `go test ./...` green.
- [x] `TestLoadExtractConfigFileShapes` pins each documented example file → expected `ExtractConfig`.
- [x] `TestLoadExtractConfigFileSnakeCaseFields` exercises every snake_case key that previously dropped to its zero value (URL, token, export_directory, extract_type, PEM/key/cert paths, concurrency, timeout, extract_id, target_task, include_scan_history).
- [x] `TestLoadExtractConfigFileErrors` covers missing-file, malformed JSON, empty-file cases.
- [ ] Live smoke: `./sonar-migration-tool extract --config examples/config-extract.example.json` writes to `./files` (not `/app/files/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
