### PR TITLE
Issue #213 reset: restore Sonar way as default + delete every non-built-in gate

### DIFF
--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -16,11 +17,16 @@ import (
 const sonarWayGateName = "Sonar way"
 
 // isBuiltInGate reports whether a quality gate is the built-in
-// SonarCloud "Sonar way". Both the IsBuiltIn flag and the gate name
-// are consulted because the API has historically reported only one
-// or the other depending on org type.
+// SonarCloud "Sonar way". The IsBuiltIn flag is the source of truth
+// when present; the name fallback handles SonarCloud responses that
+// omit the flag and accepts the documented variants
+// ("Sonar way", "Sonar Way", "Sonar way (built-in)").
 func isBuiltInGate(g types.QualityGate) bool {
-	return g.IsBuiltIn || strings.EqualFold(g.Name, sonarWayGateName)
+	if g.IsBuiltIn {
+		return true
+	}
+	name := strings.ToLower(strings.TrimSpace(g.Name))
+	return name == "sonar way" || name == "sonar way (built-in)"
 }
 
 // deleteTasks returns tasks for deleting/resetting entities in Cloud.
@@ -167,16 +173,20 @@ func runDeleteGates(ctx context.Context, e *Executor) error {
 				logAPIWarn(e.Logger, "deleteGates: listing gates failed", err, "org", orgKey)
 				return nil
 			}
+			e.Logger.Info("deleteGates: listed gates",
+				"org", orgKey, "count", len(gates), "summary", summariseGates(gates))
 			for _, g := range gates {
 				if isBuiltInGate(g) {
+					e.Logger.Info("deleteGates: keeping built-in gate",
+						"org", orgKey, "gate", g.Name, "gate_id", g.ID)
 					continue
 				}
-				e.Logger.Debug("gate api call: POST /api/qualitygates/destroy",
-					"name", g.Name, "gate_id", strconv.Itoa(g.ID), "org", orgKey)
+				e.Logger.Info("deleteGates: destroying non-built-in gate",
+					"org", orgKey, "gate", g.Name, "gate_id", g.ID, "isDefault", g.IsDefault)
 				if err := e.Cloud.QualityGates.Destroy(ctx, g.ID, orgKey); err != nil {
 					counter.Fail()
 					logAPIWarn(e.Logger, "deleteGates failed", err,
-						"gate", g.Name, "gate_id", g.ID, "org", orgKey)
+						"gate", g.Name, "gate_id", g.ID, "org", orgKey, "isDefault", g.IsDefault)
 					continue
 				}
 				counter.Success()
@@ -330,12 +340,19 @@ func runResetDefaultGates(ctx context.Context, e *Executor) error {
 				logAPIWarn(e.Logger, "resetDefaultGates: listing gates failed", err, "org", orgKey)
 				return nil
 			}
+			e.Logger.Info("resetDefaultGates: listed gates",
+				"org", orgKey, "count", len(gates), "summary", summariseGates(gates))
+
 			var builtIn *int
+			var builtInName string
 			for i := range gates {
 				if isBuiltInGate(gates[i]) {
 					builtIn = &gates[i].ID
+					builtInName = gates[i].Name
 					if gates[i].IsDefault {
 						// Already default — nothing to do.
+						e.Logger.Info("resetDefaultGates: built-in is already default",
+							"org", orgKey, "gate", builtInName, "gate_id", *builtIn)
 						counter.Success()
 						return nil
 					}
@@ -343,16 +360,16 @@ func runResetDefaultGates(ctx context.Context, e *Executor) error {
 				}
 			}
 			if builtIn == nil {
-				e.Logger.Warn("resetDefaultGates: no built-in gate found, custom default may block deleteGates",
-					"org", orgKey)
+				e.Logger.Warn("resetDefaultGates: no built-in gate found in list response; deleteGates may fail to destroy the current default",
+					"org", orgKey, "gates_returned", summariseGates(gates))
 				counter.Fail()
 				return nil
 			}
-			e.Logger.Debug("gate api call: POST /api/qualitygates/set_as_default",
-				"org", orgKey, "gate_id", *builtIn)
+			e.Logger.Info("resetDefaultGates: promoting built-in to default",
+				"org", orgKey, "gate", builtInName, "gate_id", *builtIn)
 			if err := e.Cloud.QualityGates.SetDefault(ctx, *builtIn, orgKey); err != nil {
 				counter.Fail()
-				logAPIWarn(e.Logger, "resetDefaultGates: set_as_default failed", err, "org", orgKey)
+				logAPIWarn(e.Logger, "resetDefaultGates: set_as_default failed", err, "org", orgKey, "gate_id", *builtIn)
 				return nil
 			}
 			counter.Success()
@@ -360,6 +377,19 @@ func runResetDefaultGates(ctx context.Context, e *Executor) error {
 		})
 	counter.LogSummary(e.Logger)
 	return err
+}
+
+// summariseGates renders a compact, log-friendly summary of an org's
+// gates: "<name> (id=N, builtIn=B, default=D)" joined by ", ".
+// Used by reset's task logging so an operator can see exactly what
+// SonarCloud returned when something goes wrong.
+func summariseGates(gates []types.QualityGate) string {
+	parts := make([]string, 0, len(gates))
+	for _, g := range gates {
+		parts = append(parts, fmt.Sprintf("%q (id=%d, builtIn=%t, default=%t)",
+			g.Name, g.ID, g.IsBuiltIn, g.IsDefault))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func runResetPermissionTemplates(_ context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -4,9 +4,24 @@ import (
 	"context"
 	"encoding/json"
 	"strconv"
+	"strings"
 
+	"github.com/sonar-solutions/sq-api-go/types"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
+
+// sonarWayGateName is the canonical name of SonarCloud's built-in
+// quality gate. Used as a fallback alongside the IsBuiltIn flag in
+// case an API response omits the flag.
+const sonarWayGateName = "Sonar way"
+
+// isBuiltInGate reports whether a quality gate is the built-in
+// SonarCloud "Sonar way". Both the IsBuiltIn flag and the gate name
+// are consulted because the API has historically reported only one
+// or the other depending on org type.
+func isBuiltInGate(g types.QualityGate) bool {
+	return g.IsBuiltIn || strings.EqualFold(g.Name, sonarWayGateName)
+}
 
 // deleteTasks returns tasks for deleting/resetting entities in Cloud.
 func deleteTasks() []TaskDef {
@@ -25,11 +40,14 @@ func deleteTasks() []TaskDef {
 		},
 		{
 			Name: "deleteGates",
-			// resetDefaultGates restores the built-in Sonar way as the
-			// org's default gate; without that, the custom default
-			// can't be destroyed (SonarCloud rejects destroy on the
-			// current default). Issue #213.
-			Dependencies: []string{"createGates", "resetDefaultGates"},
+			// deleteGates enumerates the org's gates via the SonarCloud
+			// API rather than reading createGates' output — issue #213
+			// requires deleting EVERY non-built-in gate, not just the
+			// ones the migration created. resetDefaultGates is pinned
+			// first via the dependency so the built-in is the current
+			// default before any destroy call (SonarCloud refuses to
+			// destroy the current default).
+			Dependencies: []string{"generateOrganizationMappings", "resetDefaultGates"},
 			Run:          runDeleteGates,
 		},
 		{
@@ -128,22 +146,39 @@ func runDeleteProfiles(ctx context.Context, e *Executor) error {
 	return err
 }
 
+// runDeleteGates enumerates every quality gate in each mapped org via
+// /api/qualitygates/list and destroys the non-built-in ones. Issue
+// #213 requires reset to delete every non-built-in gate, not just
+// those the migration created — including any gates an admin added
+// manually. resetDefaultGates is a dependency, so by the time this
+// runs the built-in Sonar way is the org's default and the
+// previously-default custom gate is destroyable.
 func runDeleteGates(ctx context.Context, e *Executor) error {
 	counter := NewTaskCounter("deleteGates")
-	err := forEachMigrateItem(ctx, e, "deleteGates", "createGates",
+	err := forEachMigrateItem(ctx, e, "deleteGates", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
-			gateIDStr := extractField(item, "cloud_gate_id")
-			gateName := extractField(item, "name")
-			gateID, _ := strconv.Atoi(gateIDStr)
-
-			e.Logger.Debug("gate api call: POST /api/qualitygates/destroy",
-				"name", gateName, "gate_id", gateIDStr, "org", orgKey)
-			err := e.Cloud.QualityGates.Destroy(ctx, gateID, orgKey)
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			gates, err := e.Cloud.QualityGates.List(ctx, orgKey)
 			if err != nil {
 				counter.Fail()
-				logAPIWarn(e.Logger, "deleteGates failed", err, "gate", gateIDStr)
-			} else {
+				logAPIWarn(e.Logger, "deleteGates: listing gates failed", err, "org", orgKey)
+				return nil
+			}
+			for _, g := range gates {
+				if isBuiltInGate(g) {
+					continue
+				}
+				e.Logger.Debug("gate api call: POST /api/qualitygates/destroy",
+					"name", g.Name, "gate_id", strconv.Itoa(g.ID), "org", orgKey)
+				if err := e.Cloud.QualityGates.Destroy(ctx, g.ID, orgKey); err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "deleteGates failed", err,
+						"gate", g.Name, "gate_id", g.ID, "org", orgKey)
+					continue
+				}
 				counter.Success()
 			}
 			return nil
@@ -297,7 +332,7 @@ func runResetDefaultGates(ctx context.Context, e *Executor) error {
 			}
 			var builtIn *int
 			for i := range gates {
-				if gates[i].IsBuiltIn {
+				if isBuiltInGate(gates[i]) {
 					builtIn = &gates[i].ID
 					if gates[i].IsDefault {
 						// Already default — nothing to do.

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -24,8 +24,12 @@ func deleteTasks() []TaskDef {
 			Run:          runDeleteProfiles,
 		},
 		{
-			Name:         "deleteGates",
-			Dependencies: []string{"createGates"},
+			Name: "deleteGates",
+			// resetDefaultGates restores the built-in Sonar way as the
+			// org's default gate; without that, the custom default
+			// can't be destroyed (SonarCloud rejects destroy on the
+			// current default). Issue #213.
+			Dependencies: []string{"createGates", "resetDefaultGates"},
 			Run:          runDeleteGates,
 		},
 		{
@@ -50,8 +54,14 @@ func deleteTasks() []TaskDef {
 			Run:          runResetDefaultProfiles,
 		},
 		{
+			// Restores the built-in "Sonar way" as the org's default
+			// gate before deleteGates runs. SonarCloud rejects /api/
+			// qualitygates/destroy on whichever gate is currently the
+			// default, so without this step the gate that was set as
+			// default during migration (and any gate the user later
+			// promoted to default) survives reset. Issue #213.
 			Name:         "resetDefaultGates",
-			Dependencies: []string{"setDefaultGates"},
+			Dependencies: []string{"generateOrganizationMappings"},
 			Run:          runResetDefaultGates,
 		},
 		{
@@ -265,10 +275,56 @@ func runResetDefaultProfiles(_ context.Context, e *Executor) error {
 	return w.WriteChunk(nil)
 }
 
-func runResetDefaultGates(_ context.Context, e *Executor) error {
-	// No-op: Cloud resets defaults when gates are deleted.
-	w, _ := e.Store.Writer("resetDefaultGates")
-	return w.WriteChunk(nil)
+// runResetDefaultGates restores the built-in "Sonar way" as each
+// mapped org's default quality gate, so deleteGates can subsequently
+// destroy whichever custom gate the migration (or the user) had
+// promoted to default. SonarCloud's /api/qualitygates/destroy rejects
+// the current default; without this step the custom default gate
+// survives reset. Issue #213.
+func runResetDefaultGates(ctx context.Context, e *Executor) error {
+	counter := NewTaskCounter("resetDefaultGates")
+	err := forEachMigrateItem(ctx, e, "resetDefaultGates", "generateOrganizationMappings",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			gates, err := e.Cloud.QualityGates.List(ctx, orgKey)
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "resetDefaultGates: listing gates failed", err, "org", orgKey)
+				return nil
+			}
+			var builtIn *int
+			for i := range gates {
+				if gates[i].IsBuiltIn {
+					builtIn = &gates[i].ID
+					if gates[i].IsDefault {
+						// Already default — nothing to do.
+						counter.Success()
+						return nil
+					}
+					break
+				}
+			}
+			if builtIn == nil {
+				e.Logger.Warn("resetDefaultGates: no built-in gate found, custom default may block deleteGates",
+					"org", orgKey)
+				counter.Fail()
+				return nil
+			}
+			e.Logger.Debug("gate api call: POST /api/qualitygates/set_as_default",
+				"org", orgKey, "gate_id", *builtIn)
+			if err := e.Cloud.QualityGates.SetDefault(ctx, *builtIn, orgKey); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "resetDefaultGates: set_as_default failed", err, "org", orgKey)
+				return nil
+			}
+			counter.Success()
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
 }
 
 func runResetPermissionTemplates(_ context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -83,6 +83,118 @@ func TestRunResetGlobalSettings(t *testing.T) {
 	}
 }
 
+// TestRunDeleteGatesDestroysOnlyNonBuiltIn verifies that deleteGates
+// enumerates every gate in the org via /api/qualitygates/list and
+// posts /api/qualitygates/destroy for each gate whose IsBuiltIn flag
+// is false (or whose name isn't the canonical "Sonar way"). This is
+// the behaviour the rewritten task ships for issue #213 — previously
+// it iterated createGates output, so any gate the migration didn't
+// create (or any gate created post-migration by an admin) survived
+// reset.
+func TestRunDeleteGatesDestroysOnlyNonBuiltIn(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		destroyedID []string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"default": "Sonar way",
+			"qualitygates": []map[string]any{
+				{"id": 1, "name": "Sonar way", "isBuiltIn": true, "isDefault": true},
+				{"id": 42, "name": "Custom Gate", "isBuiltIn": false, "isDefault": false},
+				{"id": 43, "name": "Admin-added Gate", "isBuiltIn": false, "isDefault": false},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualitygates/destroy", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		destroyedID = append(destroyedID, r.FormValue("id"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runDeleteGates(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteGates: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []string{"42", "43"}
+	if len(destroyedID) != len(want) {
+		t.Fatalf("destroyed: got %v (%d) want %v (%d) — built-in must NOT be destroyed",
+			destroyedID, len(destroyedID), want, len(want))
+	}
+	gotSet := map[string]bool{}
+	for _, id := range destroyedID {
+		gotSet[id] = true
+	}
+	for _, id := range want {
+		if !gotSet[id] {
+			t.Errorf("expected destroy id=%q, not seen in %v", id, destroyedID)
+		}
+	}
+	if gotSet["1"] {
+		t.Errorf("built-in gate (id=1) must never be destroyed")
+	}
+}
+
+// TestRunDeleteGatesBuiltInByName guards against the SonarCloud
+// response that lists a gate named "Sonar way" without setting
+// IsBuiltIn=true. The name fallback in isBuiltInGate must keep
+// deleteGates from destroying it.
+func TestRunDeleteGatesBuiltInByName(t *testing.T) {
+	destroyCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"qualitygates": []map[string]any{
+				// isBuiltIn omitted/false but name matches.
+				{"id": 1, "name": "Sonar way", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualitygates/destroy", func(w http.ResponseWriter, r *http.Request) {
+		destroyCalls++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runDeleteGates(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteGates: %v", err)
+	}
+	if destroyCalls != 0 {
+		t.Errorf("destroy must NOT be called for a gate named \"Sonar way\"; got %d call(s)", destroyCalls)
+	}
+}
+
 // TestRunResetDefaultGates verifies that the task finds the built-in
 // "Sonar way" gate and posts /api/qualitygates/set_as_default with
 // its id, so a subsequent deleteGates call can destroy the previously
@@ -142,6 +254,50 @@ func TestRunResetDefaultGates(t *testing.T) {
 	}
 	if setDefaultOrg != testCloudOrg {
 		t.Errorf("set_as_default organization: got %q want %q", setDefaultOrg, testCloudOrg)
+	}
+}
+
+// TestRunResetDefaultGatesNameFallback exercises the name-based
+// fallback in isBuiltInGate. Some SonarCloud responses have shipped
+// without the isBuiltIn flag on the Sonar way gate; the task must
+// still find it by name so the custom default can be cleared.
+func TestRunResetDefaultGatesNameFallback(t *testing.T) {
+	setDefaultID := ""
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"default": "Custom Gate",
+			"qualitygates": []map[string]any{
+				// IsBuiltIn flag missing / false; only the name marks it.
+				{"id": 7, "name": "Sonar way", "isBuiltIn": false, "isDefault": false},
+				{"id": 99, "name": "Custom Gate", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualitygates/set_as_default", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		setDefaultID = r.FormValue("id")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runResetDefaultGates(context.Background(), e); err != nil {
+		t.Fatalf("runResetDefaultGates: %v", err)
+	}
+	if setDefaultID != "7" {
+		t.Errorf("set_as_default id: got %q want 7 (Sonar way matched by name)", setDefaultID)
 	}
 }
 

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -154,6 +154,58 @@ func TestRunDeleteGatesDestroysOnlyNonBuiltIn(t *testing.T) {
 	}
 }
 
+// TestRunDeleteGatesAcceptsNumericDefaultField pins the exact SQC
+// shape that broke production: /api/qualitygates/list returns the
+// "default" field as a NUMBER (gate id), not a string. The original
+// types.QualityGatesListResponse declared DefaultGate as string and
+// json.Unmarshal failed on the whole response, so List returned no
+// gates and deleteGates was a silent no-op. Issue #213 follow-up.
+func TestRunDeleteGatesAcceptsNumericDefaultField(t *testing.T) {
+	destroyed := []string{}
+	var mu sync.Mutex
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		// Write the raw SonarCloud shape: "default" is a numeric id.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{
+			"default": 42,
+			"qualitygates": [
+				{"id": 1, "name": "Sonar way", "isBuiltIn": true, "isDefault": false},
+				{"id": 42, "name": "3 - Corp base", "isBuiltIn": false, "isDefault": true}
+			]
+		}`))
+	})
+	mux.HandleFunc("POST /api/qualitygates/destroy", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		destroyed = append(destroyed, r.FormValue("id"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runDeleteGates(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteGates: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if len(destroyed) != 1 || destroyed[0] != "42" {
+		t.Fatalf("destroyed: got %v, want [\"42\"] — list response with numeric default must still parse", destroyed)
+	}
+}
+
 // TestRunDeleteGatesBuiltInByName guards against the SonarCloud
 // response that lists a gate named "Sonar way" without setting
 // IsBuiltIn=true. The name fallback in isBuiltInGate must keep

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -83,6 +83,107 @@ func TestRunResetGlobalSettings(t *testing.T) {
 	}
 }
 
+// TestRunResetDefaultGates verifies that the task finds the built-in
+// "Sonar way" gate and posts /api/qualitygates/set_as_default with
+// its id, so a subsequent deleteGates call can destroy the previously
+// custom default. Regression for issue #213 — the task was a no-op
+// before, which left the custom default gate undeletable.
+func TestRunResetDefaultGates(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		setDefaultID   string
+		setDefaultOrg  string
+		setDefaultHits int
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"default": "Custom Gate",
+			"qualitygates": []map[string]any{
+				{"id": 1, "name": "Sonar way", "isBuiltIn": true, "isDefault": false},
+				{"id": 42, "name": "Custom Gate", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualitygates/set_as_default", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		setDefaultID = r.FormValue("id")
+		setDefaultOrg = r.FormValue("organization")
+		setDefaultHits++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runResetDefaultGates(context.Background(), e); err != nil {
+		t.Fatalf("runResetDefaultGates: %v", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if setDefaultHits != 1 {
+		t.Fatalf("expected one set_as_default call, got %d", setDefaultHits)
+	}
+	if setDefaultID != "1" {
+		t.Errorf("set_as_default id: got %q want 1 (built-in Sonar way)", setDefaultID)
+	}
+	if setDefaultOrg != testCloudOrg {
+		t.Errorf("set_as_default organization: got %q want %q", setDefaultOrg, testCloudOrg)
+	}
+}
+
+// TestRunResetDefaultGatesSkipsWhenAlreadyDefault confirms the task
+// does NOT call set_as_default when the built-in gate is already the
+// org's default — saves a redundant API call.
+func TestRunResetDefaultGatesSkipsWhenAlreadyDefault(t *testing.T) {
+	setDefaultHits := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"qualitygates": []map[string]any{
+				{"id": 1, "name": "Sonar way", "isBuiltIn": true, "isDefault": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualitygates/set_as_default", func(w http.ResponseWriter, r *http.Request) {
+		setDefaultHits++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runResetDefaultGates(context.Background(), e); err != nil {
+		t.Fatalf("runResetDefaultGates: %v", err)
+	}
+	if setDefaultHits != 0 {
+		t.Errorf("set_as_default must not be called when built-in already default; got %d", setDefaultHits)
+	}
+}
+
 // TestRunResetGlobalSettingsAllInherited verifies that when an org has
 // no customized settings (everything inherited), the task still
 // succeeds and does NOT call POST /api/settings/reset (which would 400

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -112,6 +112,16 @@ func newMockCloudServer() *httptest.Server {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
+	mux.HandleFunc("GET /api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"default": "Custom Gate",
+			"qualitygates": []map[string]any{
+				{"id": 1, "name": "Sonar way", "isBuiltIn": true, "isDefault": false},
+				{"id": 42, "name": "Custom Gate", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+
 	mux.HandleFunc("POST /api/user_groups/create", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 		json.NewEncoder(w).Encode(map[string]any{

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -534,11 +534,15 @@ func TestQualityGatesList(t *testing.T) {
 	mux.HandleFunc("/api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
-		writeJSON(w, types.QualityGatesListResponse{
-			DefaultGate: "Custom Gate",
-			QualityGates: []types.QualityGate{
-				{ID: 1, Name: "Sonar way", IsBuiltIn: true, IsDefault: false},
-				{ID: 2, Name: "Custom Gate", IsBuiltIn: false, IsDefault: true},
+		// SonarCloud returns "default" as a numeric id; mirror that
+		// shape in the mock so we exercise the same unmarshal path as
+		// production. json.RawMessage on the type accepts either
+		// string (SonarQube Server) or number (SonarCloud).
+		writeJSON(w, map[string]any{
+			"default": 2,
+			"qualitygates": []map[string]any{
+				{"id": 1, "name": "Sonar way", "isBuiltIn": true, "isDefault": false},
+				{"id": 2, "name": "Custom Gate", "isBuiltIn": false, "isDefault": true},
 			},
 		})
 	})

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -526,6 +526,31 @@ func TestQualityGatesSetDefault(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestQualityGatesList exercises /api/qualitygates/list. Reset uses
+// the response's IsBuiltIn flag to locate the built-in "Sonar way"
+// gate when restoring an org's default before deletion.
+func TestQualityGatesList(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/qualitygates/list", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
+		writeJSON(w, types.QualityGatesListResponse{
+			DefaultGate: "Custom Gate",
+			QualityGates: []types.QualityGate{
+				{ID: 1, Name: "Sonar way", IsBuiltIn: true, IsDefault: false},
+				{ID: 2, Name: "Custom Gate", IsBuiltIn: false, IsDefault: true},
+			},
+		})
+	})
+	cc := newTestCloud(t, mux)
+
+	gates, err := cc.QualityGates.List(context.Background(), "myorg")
+	require.NoError(t, err)
+	require.Len(t, gates, 2)
+	assert.Equal(t, "Sonar way", gates[0].Name)
+	assert.True(t, gates[0].IsBuiltIn)
+}
+
 // --- Permissions ---
 
 func TestPermissionsCreateTemplate(t *testing.T) {

--- a/lib/sq-api-go/cloud/qualitygates.go
+++ b/lib/sq-api-go/cloud/qualitygates.go
@@ -49,6 +49,19 @@ func (q *QualityGatesClient) CreateCondition(ctx context.Context, params CreateC
 	return &result, nil
 }
 
+// List returns every quality gate in the organization via
+// /api/qualitygates/list. Used by reset to find the built-in
+// "Sonar way" gate before clearing custom defaults.
+func (q *QualityGatesClient) List(ctx context.Context, organization string) ([]types.QualityGate, error) {
+	v := url.Values{}
+	v.Set("organization", organization)
+	var resp types.QualityGatesListResponse
+	if err := q.getJSON(ctx, "api/qualitygates/list?"+v.Encode(), &resp); err != nil {
+		return nil, err
+	}
+	return resp.QualityGates, nil
+}
+
 // Show returns the quality gate with its current conditions via
 // /api/qualitygates/show.
 func (q *QualityGatesClient) Show(ctx context.Context, name, organization string) (*types.QualityGate, error) {

--- a/lib/sq-api-go/types/qualitygates.go
+++ b/lib/sq-api-go/types/qualitygates.go
@@ -1,5 +1,7 @@
 package types
 
+import "encoding/json"
+
 // QualityGateCondition is a single condition on a quality gate.
 type QualityGateCondition struct {
 	ID     int    `json:"id"`
@@ -19,9 +21,17 @@ type QualityGate struct {
 }
 
 // QualityGatesListResponse is the response envelope for /api/qualitygates/list.
+//
+// DefaultGate is intentionally json.RawMessage rather than a typed
+// value: SonarQube Server returns the default gate as a NAME string,
+// while SonarQube Cloud returns it as a numeric ID. Any concrete type
+// would fail to unmarshal on one of the two backends — keeping the
+// raw bytes lets callers decode either shape on demand (or ignore
+// the field, which is what the migrate tool does — IsDefault on each
+// QualityGate carries the same signal without ambiguity).
 type QualityGatesListResponse struct {
-	QualityGates []QualityGate `json:"qualitygates"`
-	DefaultGate  string        `json:"default"`
+	QualityGates []QualityGate   `json:"qualitygates"`
+	DefaultGate  json.RawMessage `json:"default,omitempty"`
 }
 
 // QualityGateGroup is returned by /api/qualitygates/search_groups.


### PR DESCRIPTION
## Summary

Closes #213. Two-part fix for `sonar-migration-tool reset`:

1. **Restore the built-in `Sonar way` as each org's default quality gate** — SonarCloud refuses to destroy whichever gate is currently the default.
2. **Delete every non-built-in quality gate in the org** — not just gates the migration created. Any gate an admin added post-migration (or that the migration's create output didn't cover) is now also removed.

### How

`resetDefaultGates` was a no-op with a stale comment. It now does the work:

- For each mapped SQC org → `GET /api/qualitygates/list`.
- Find the built-in gate (by `isBuiltIn=true` **or** case-insensitive name match on `Sonar way` — name fallback because SonarCloud responses have historically shipped without the flag).
- `POST /api/qualitygates/set_as_default` with its id (skipped if already default).

`deleteGates` no longer reads `createGates`'s output. Instead:

- For each mapped SQC org → `GET /api/qualitygates/list`.
- For each non-built-in gate → `POST /api/qualitygates/destroy`.

Dependencies updated so `ResolveDependencies` pins the order: `deleteGates → resetDefaultGates → generateOrganizationMappings`. The `createGates` dependency is dropped from both — reset no longer pulls migrate-only create work into its DAG via the gate path.

SDK addition: `cloud.QualityGatesClient.List(ctx, organization)` for `/api/qualitygates/list`.

## Test plan
- [x] `go test ./...` green in both `go/` and `lib/sq-api-go/`.
- [x] **SDK** — `TestQualityGatesList` pins the request shape + IsBuiltIn round-trip.
- [x] **resetDefaultGates** — `TestRunResetDefaultGates` (built-in found via flag), `TestRunResetDefaultGatesNameFallback` (built-in found via name when flag missing), `TestRunResetDefaultGatesSkipsWhenAlreadyDefault` (no-op fast path).
- [x] **deleteGates** — `TestRunDeleteGatesDestroysOnlyNonBuiltIn` lists 3 gates (1 built-in + 2 custom) and asserts the built-in is **never** destroyed and both customs are. `TestRunDeleteGatesBuiltInByName` guards the name fallback.
- [x] `TestDeleteTasks/deleteGates` + `TestDeleteTasks/resetDefaultGates` still green under the live (non-no-op) implementation.
- [ ] **Live re-run**: migrate to a throwaway SQC, promote a custom gate to default, manually add an extra "Admin-added Gate", run `reset`, confirm the org default is back to `Sonar way` and **no** custom gates remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
