### PR TITLE
Issue #214 reset: restore Sonar way per-language + delete all non-built-in quality profiles

### DIFF
--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -25,8 +25,25 @@ func isBuiltInGate(g types.QualityGate) bool {
 	if g.IsBuiltIn {
 		return true
 	}
-	name := strings.ToLower(strings.TrimSpace(g.Name))
-	return name == "sonar way" || name == "sonar way (built-in)"
+	return matchesSonarWayName(g.Name)
+}
+
+// isBuiltInProfile is the profile analogue of isBuiltInGate. SonarCloud
+// reports built-in language profiles with IsBuiltIn=true; the name
+// fallback covers responses that omit the flag.
+func isBuiltInProfile(p types.QualityProfile) bool {
+	if p.IsBuiltIn {
+		return true
+	}
+	return matchesSonarWayName(p.Name)
+}
+
+// matchesSonarWayName performs the case-insensitive, trimmed match
+// against the canonical built-in name variants. Centralised so the
+// gate and profile helpers stay in sync.
+func matchesSonarWayName(name string) bool {
+	n := strings.ToLower(strings.TrimSpace(name))
+	return n == "sonar way" || n == "sonar way (built-in)"
 }
 
 // deleteTasks returns tasks for deleting/resetting entities in Cloud.
@@ -40,8 +57,15 @@ func deleteTasks() []TaskDef {
 			Run:          runDeleteProjects,
 		},
 		{
-			Name:         "deleteProfiles",
-			Dependencies: []string{"createProfiles"},
+			Name: "deleteProfiles",
+			// deleteProfiles enumerates the org's profiles via the
+			// SonarCloud API rather than reading createProfiles'
+			// output — issue #214 requires deleting EVERY non-built-in
+			// profile, not just those the migration created.
+			// resetDefaultProfiles is pinned first so the built-in is
+			// the per-language default before any delete call (SQC
+			// refuses to delete a language's current default profile).
+			Dependencies: []string{"generateOrganizationMappings", "resetDefaultProfiles"},
 			Run:          runDeleteProfiles,
 		},
 		{
@@ -73,8 +97,14 @@ func deleteTasks() []TaskDef {
 			Run:          runDeletePortfolios,
 		},
 		{
+			// Restores the built-in "Sonar way" as each language's
+			// default profile before deleteProfiles runs. SonarCloud
+			// rejects /api/qualityprofiles/delete on whichever profile
+			// is the current per-language default, so without this
+			// step the profile that migration (or an admin) promoted
+			// to default survives reset. Issue #214.
 			Name:         "resetDefaultProfiles",
-			Dependencies: []string{"setDefaultProfiles"},
+			Dependencies: []string{"generateOrganizationMappings"},
 			Run:          runResetDefaultProfiles,
 		},
 		{
@@ -128,22 +158,43 @@ func runDeleteProjects(ctx context.Context, e *Executor) error {
 	return err
 }
 
+// runDeleteProfiles enumerates every quality profile in each mapped
+// org via /api/qualityprofiles/search and deletes the non-built-in
+// ones. Issue #214 requires reset to delete EVERY non-built-in
+// profile, not just those the migration created — including profiles
+// an admin added manually. resetDefaultProfiles is a dependency, so
+// by the time this runs the built-in is the per-language default and
+// the previously-default custom profile is deletable.
 func runDeleteProfiles(ctx context.Context, e *Executor) error {
 	counter := NewTaskCounter("deleteProfiles")
-	err := forEachMigrateItemFiltered(ctx, e, "deleteProfiles", "createProfiles",
-		func(item json.RawMessage) bool {
-			return !extractBool(item, "is_default")
-		},
+	err := forEachMigrateItem(ctx, e, "deleteProfiles", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
-			name := extractField(item, "name")
-			lang := extractField(item, "language")
-
-			err := e.Cloud.QualityProfiles.Delete(ctx, lang, name, orgKey)
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			profiles, err := e.Cloud.QualityProfiles.Search(ctx, orgKey)
 			if err != nil {
 				counter.Fail()
-				logAPIWarn(e.Logger, "deleteProfiles failed", err, "name", name)
-			} else {
+				logAPIWarn(e.Logger, "deleteProfiles: listing profiles failed", err, "org", orgKey)
+				return nil
+			}
+			e.Logger.Info("deleteProfiles: listed profiles",
+				"org", orgKey, "count", len(profiles), "summary", summariseProfiles(profiles))
+			for _, p := range profiles {
+				if isBuiltInProfile(p) {
+					e.Logger.Info("deleteProfiles: keeping built-in profile",
+						"org", orgKey, "profile", p.Name, "language", p.Language)
+					continue
+				}
+				e.Logger.Info("deleteProfiles: deleting non-built-in profile",
+					"org", orgKey, "profile", p.Name, "language", p.Language, "isDefault", p.IsDefault)
+				if err := e.Cloud.QualityProfiles.Delete(ctx, p.Language, p.Name, orgKey); err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "deleteProfiles failed", err,
+						"profile", p.Name, "language", p.Language, "org", orgKey, "isDefault", p.IsDefault)
+					continue
+				}
 				counter.Success()
 			}
 			return nil
@@ -314,10 +365,87 @@ func runResetGlobalSettings(ctx context.Context, e *Executor) error {
 	return err
 }
 
-func runResetDefaultProfiles(_ context.Context, e *Executor) error {
-	// No-op: Cloud resets defaults when profiles are deleted.
-	w, _ := e.Store.Writer("resetDefaultProfiles")
-	return w.WriteChunk(nil)
+// runResetDefaultProfiles restores the built-in "Sonar way" profile
+// as each language's default in every mapped org, so deleteProfiles
+// can subsequently delete the previously-default custom profile.
+// SonarCloud rejects /api/qualityprofiles/delete on whichever profile
+// is the current default for a language; without this step the
+// migration-promoted custom default profile survives reset.
+// Issue #214.
+//
+// Defaults are per-language. The task groups the org's profiles by
+// language, finds the built-in for each language that has a
+// non-built-in default, and posts /api/qualityprofiles/set_default
+// for that language + built-in profile name.
+func runResetDefaultProfiles(ctx context.Context, e *Executor) error {
+	counter := NewTaskCounter("resetDefaultProfiles")
+	err := forEachMigrateItem(ctx, e, "resetDefaultProfiles", "generateOrganizationMappings",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			profiles, err := e.Cloud.QualityProfiles.Search(ctx, orgKey)
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "resetDefaultProfiles: listing profiles failed", err, "org", orgKey)
+				return nil
+			}
+			e.Logger.Info("resetDefaultProfiles: listed profiles",
+				"org", orgKey, "count", len(profiles), "summary", summariseProfiles(profiles))
+
+			// Languages whose current default is non-built-in.
+			needsRestore := make(map[string]bool)
+			// Built-in profile per language (first one wins).
+			builtInByLang := make(map[string]types.QualityProfile)
+			for _, p := range profiles {
+				if p.Language == "" {
+					continue
+				}
+				if isBuiltInProfile(p) {
+					if _, seen := builtInByLang[p.Language]; !seen {
+						builtInByLang[p.Language] = p
+					}
+				}
+				if p.IsDefault && !isBuiltInProfile(p) {
+					needsRestore[p.Language] = true
+				}
+			}
+
+			for lang := range needsRestore {
+				bi, ok := builtInByLang[lang]
+				if !ok {
+					e.Logger.Warn("resetDefaultProfiles: no built-in profile found for language; deleteProfiles may fail to delete the current default",
+						"org", orgKey, "language", lang)
+					counter.Fail()
+					continue
+				}
+				e.Logger.Info("resetDefaultProfiles: promoting built-in to default",
+					"org", orgKey, "language", lang, "profile", bi.Name)
+				if err := e.Cloud.QualityProfiles.SetDefault(ctx, lang, bi.Name, orgKey); err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "resetDefaultProfiles: set_default failed", err,
+						"org", orgKey, "language", lang, "profile", bi.Name)
+					continue
+				}
+				counter.Success()
+			}
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
+}
+
+// summariseProfiles renders a compact, log-friendly summary of an
+// org's profiles. Mirrors summariseGates so operators get the same
+// shape across the gate and profile reset paths.
+func summariseProfiles(profiles []types.QualityProfile) string {
+	parts := make([]string, 0, len(profiles))
+	for _, p := range profiles {
+		parts = append(parts, fmt.Sprintf("%q [%s] (builtIn=%t, default=%t)",
+			p.Name, p.Language, p.IsBuiltIn, p.IsDefault))
+	}
+	return strings.Join(parts, ", ")
 }
 
 // runResetDefaultGates restores the built-in "Sonar way" as each

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -392,6 +392,157 @@ func TestRunResetDefaultGatesSkipsWhenAlreadyDefault(t *testing.T) {
 	}
 }
 
+// TestRunResetDefaultProfilesPerLanguage verifies the task lists the
+// org's profiles via /api/qualityprofiles/search, identifies every
+// language whose current default is non-built-in, and posts
+// /api/qualityprofiles/set_default with the built-in for that
+// language. Defaults are per-language on SonarCloud, so the task
+// must dispatch one set_default call per language that needs
+// restoring. Issue #214.
+func TestRunResetDefaultProfilesPerLanguage(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		setDefault  []map[string]string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				// Java — built-in present, custom is current default. Needs restore.
+				{"key": "j1", "name": "Sonar way", "language": "java", "isBuiltIn": true, "isDefault": false},
+				{"key": "j2", "name": "Custom Java", "language": "java", "isBuiltIn": false, "isDefault": true},
+				// Python — built-in already default. No-op for this language.
+				{"key": "p1", "name": "Sonar way", "language": "py", "isBuiltIn": true, "isDefault": true},
+				{"key": "p2", "name": "Custom Py", "language": "py", "isBuiltIn": false, "isDefault": false},
+				// JS — built-in present, custom is current default. Needs restore.
+				{"key": "js1", "name": "Sonar way", "language": "js", "isBuiltIn": true, "isDefault": false},
+				{"key": "js2", "name": "Custom JS", "language": "js", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualityprofiles/set_default", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		setDefault = append(setDefault, map[string]string{
+			"language":       r.FormValue("language"),
+			"qualityProfile": r.FormValue("qualityProfile"),
+			"organization":   r.FormValue("organization"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runResetDefaultProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runResetDefaultProfiles: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(setDefault) != 2 {
+		t.Fatalf("expected 2 set_default calls (java + js), got %d: %v", len(setDefault), setDefault)
+	}
+	// Build a language -> profile map to assert without depending on call order.
+	got := map[string]string{}
+	for _, call := range setDefault {
+		got[call["language"]] = call["qualityProfile"]
+		if call["organization"] != testCloudOrg {
+			t.Errorf("set_default organization: got %q want %q", call["organization"], testCloudOrg)
+		}
+	}
+	if got["java"] != "Sonar way" {
+		t.Errorf("java default: got %q want \"Sonar way\"", got["java"])
+	}
+	if got["js"] != "Sonar way" {
+		t.Errorf("js default: got %q want \"Sonar way\"", got["js"])
+	}
+	if _, restored := got["py"]; restored {
+		t.Errorf("py must NOT be restored: built-in is already default")
+	}
+}
+
+// TestRunDeleteProfilesDeletesOnlyNonBuiltIn confirms the rewritten
+// deleteProfiles enumerates via search and deletes every non-built-in
+// profile (regardless of whether the migration created it), and
+// never touches a built-in. Issue #214.
+func TestRunDeleteProfilesDeletesOnlyNonBuiltIn(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		deleted  []map[string]string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				{"key": "k1", "name": "Sonar way", "language": "java", "isBuiltIn": true, "isDefault": true},
+				{"key": "k2", "name": "Custom Java", "language": "java", "isBuiltIn": false, "isDefault": false},
+				{"key": "k3", "name": "Admin Java", "language": "java", "isBuiltIn": false, "isDefault": false},
+				{"key": "k4", "name": "Sonar way", "language": "py", "isBuiltIn": true, "isDefault": true},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/qualityprofiles/delete", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deleted = append(deleted, map[string]string{
+			"language":       r.FormValue("language"),
+			"qualityProfile": r.FormValue("qualityProfile"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runDeleteProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteProfiles: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletes (Custom Java + Admin Java), got %d: %v", len(deleted), deleted)
+	}
+	deletedNames := map[string]bool{}
+	for _, d := range deleted {
+		deletedNames[d["qualityProfile"]] = true
+		if d["language"] != "java" {
+			t.Errorf("unexpected language %q in delete: %v", d["language"], d)
+		}
+	}
+	if !deletedNames["Custom Java"] || !deletedNames["Admin Java"] {
+		t.Errorf("expected Custom Java + Admin Java both deleted, got %v", deletedNames)
+	}
+	if deletedNames["Sonar way"] {
+		t.Error("built-in \"Sonar way\" must never be deleted")
+	}
+}
+
 // TestRunResetGlobalSettingsAllInherited verifies that when an org has
 // no customized settings (everything inherited), the task still
 // succeeds and does NOT call POST /api/settings/reset (which would 400

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -82,6 +82,15 @@ func newMockCloudServer() *httptest.Server {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
+	mux.HandleFunc("GET /api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"profiles": []map[string]any{
+				{"key": "p1", "name": "Sonar way", "language": "java", "isBuiltIn": true, "isDefault": false},
+				{"key": "p2", "name": "Custom Java", "language": "java", "isBuiltIn": false, "isDefault": true},
+			},
+		})
+	})
+
 	mux.HandleFunc("POST /api/qualitygates/create", func(w http.ResponseWriter, r *http.Request) {
 		r.ParseForm()
 		json.NewEncoder(w).Encode(map[string]any{

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -339,6 +339,32 @@ func TestQualityProfilesDelete(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestQualityProfilesSearch exercises GET /api/qualityprofiles/search.
+// Reset enumerates profiles per-language via the IsBuiltIn flag in
+// the response and promotes the built-in to default before any
+// deletion attempt.
+func TestQualityProfilesSearch(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/qualityprofiles/search", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "myorg", r.URL.Query().Get("organization"))
+		writeJSON(w, types.QualityProfilesSearchResponse{
+			Profiles: []types.QualityProfile{
+				{Key: "k1", Name: "Sonar way", Language: "java", IsBuiltIn: true, IsDefault: false},
+				{Key: "k2", Name: "Custom Java", Language: "java", IsBuiltIn: false, IsDefault: true},
+			},
+		})
+	})
+	cc := newTestCloud(t, mux)
+
+	profiles, err := cc.QualityProfiles.Search(context.Background(), "myorg")
+	require.NoError(t, err)
+	require.Len(t, profiles, 2)
+	assert.Equal(t, "Sonar way", profiles[0].Name)
+	assert.True(t, profiles[0].IsBuiltIn)
+	assert.Equal(t, "java", profiles[0].Language)
+}
+
 func TestQualityProfilesSetDefault(t *testing.T) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/qualityprofiles/set_default", func(w http.ResponseWriter, r *http.Request) {

--- a/lib/sq-api-go/cloud/qualityprofiles.go
+++ b/lib/sq-api-go/cloud/qualityprofiles.go
@@ -17,6 +17,21 @@ type CreateProfileParams struct {
 	Organization string
 }
 
+// Search returns every quality profile in the organization via
+// /api/qualityprofiles/search. Used by reset to enumerate profiles
+// per-language so the built-in can be promoted to default before
+// any deletion attempt (SonarCloud refuses to delete the current
+// default profile for a language).
+func (q *QualityProfilesClient) Search(ctx context.Context, organization string) ([]types.QualityProfile, error) {
+	v := url.Values{}
+	v.Set("organization", organization)
+	var resp types.QualityProfilesSearchResponse
+	if err := q.getJSON(ctx, "api/qualityprofiles/search?"+v.Encode(), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Profiles, nil
+}
+
 // Create creates a new quality profile via /api/qualityprofiles/create.
 func (q *QualityProfilesClient) Create(ctx context.Context, params CreateProfileParams) (*types.QualityProfile, error) {
 	form := url.Values{}


### PR DESCRIPTION
## Summary

Closes #214. Companion fix to #213, applied to **quality profiles**:

1. **Restore the built-in `Sonar way` as each language's default profile** in every mapped org — SonarCloud refuses to delete whichever profile is currently the default for a language.
2. **Delete every non-built-in profile in the org**, regardless of whether the migration created it.

`resetDefaultProfiles` was a no-op with a stale comment. It now does the work.

### How

`resetDefaultProfiles` (rewritten):
- For each mapped SQC org → `GET /api/qualityprofiles/search`.
- Group profiles by language. For each language with a non-built-in default, find the built-in profile for that language and `POST /api/qualityprofiles/set_default`.
- Idempotent: languages whose built-in is already default produce no API call.

`deleteProfiles` (rewritten):
- For each mapped SQC org → `GET /api/qualityprofiles/search`.
- For each non-built-in profile → `POST /api/qualityprofiles/delete`.

Dependencies updated: `deleteProfiles → resetDefaultProfiles → generateOrganizationMappings`. The `createProfiles` dependency is dropped — issue #214 requires deletion of EVERY non-built-in profile, including ones an admin added post-migration. The previous filter-by-is_default-from-createProfiles approach silently skipped them.

SDK addition: `cloud.QualityProfilesClient.Search(ctx, organization)` for `/api/qualityprofiles/search`.

Shared with #213: `isBuiltInProfile` / `matchesSonarWayName` centralise the detection (IsBuiltIn flag with case-insensitive name fallback).

## Test plan
- [x] `go test ./...` green in both `go/` and `lib/sq-api-go/`.
- [x] **SDK** — `TestQualityProfilesSearch` pins the request shape + IsBuiltIn round-trip.
- [x] **resetDefaultProfiles** — `TestRunResetDefaultProfilesPerLanguage` seeds 3 languages (java needs restore, py is already built-in, js needs restore) and asserts `set_default` fires exactly twice, with `profile="Sonar way"`, once for each language that needs it.
- [x] **deleteProfiles** — `TestRunDeleteProfilesDeletesOnlyNonBuiltIn` seeds 4 profiles across 2 languages and asserts only the two non-built-in Java profiles are deleted; built-ins are kept.
- [x] `TestDeleteTasks/{resetDefaultProfiles,deleteProfiles}` still green under the live implementation.
- [ ] **Live re-run**: migrate to a throwaway SQC, promote a custom Java profile to default, add an extra "Admin Java" profile, run `reset`, confirm the java default is back to `Sonar way` and no custom profiles remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
