### PR TITLE
Issue #165 dedupe migrated entities in the summary report

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -162,19 +162,40 @@ func collectSection(store *common.DataStore, def sectionDef,
 }
 
 // collectSucceeded reads items from the output (create*) task JSONL.
+//
+// Issue #165 — the create* tasks (createGates, createProfiles, ...)
+// iterate generate*Mappings, which contains one record per
+// (source_org, entity_name) pair. When a single source-side entity
+// exists under N different SonarQube Server orgs that all map to the
+// same SonarCloud org, the create task emits N JSONL records for the
+// SAME cloud entity. Without dedup the report renders the same row
+// N times and the migrated-count is inflated by N-1.
+//
+// We dedupe by the composite (Organization, Detail, Name, Language).
+// Detail carries the cloud-side unique id for every section
+// (cloud_gate_id, cloud_profile_key, etc.) so identical cloud
+// entities collapse to one row; the rest of the composite keeps
+// distinct entities with the same name in different orgs separate.
 func collectSucceeded(store *common.DataStore, def sectionDef) []EntityItem {
 	items, err := store.ReadAll(def.OutputTask)
 	if err != nil {
 		return nil
 	}
 	var result []EntityItem
+	seen := make(map[string]bool, len(items))
 	for _, item := range items {
-		result = append(result, EntityItem{
+		entry := EntityItem{
 			Name:         jsonStr(item, def.NameField),
 			Language:     jsonStr(item, "language"),
 			Organization: jsonStr(item, "sonarcloud_org_key"),
 			Detail:       jsonStr(item, def.DetailField),
-		})
+		}
+		key := entry.Organization + "\x00" + entry.Detail + "\x00" + entry.Name + "\x00" + entry.Language
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		result = append(result, entry)
 	}
 	return result
 }

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -73,6 +73,54 @@ func TestCollectSummaryWithData(t *testing.T) {
 	}
 }
 
+// TestCollectSummaryDedupesDuplicateCreates is a regression for #165.
+// When a single source-side entity exists under multiple SonarQube
+// Server orgs that map to the same SonarCloud org, the create* task
+// writes one JSONL record per source-org pairing — all referring to
+// the same cloud entity. The report previously listed each duplicate
+// as its own row and inflated the migrated-count by N-1.
+func TestCollectSummaryDedupesDuplicateCreates(t *testing.T) {
+	dir := t.TempDir()
+
+	// Same cloud gate, same org, written three times (one per source org).
+	writeTaskJSONL(t, dir, "createGates", []map[string]any{
+		{"name": "3 - Corp base", "sonarcloud_org_key": "fubar", "cloud_gate_id": "42"},
+		{"name": "3 - Corp base", "sonarcloud_org_key": "fubar", "cloud_gate_id": "42"},
+		{"name": "3 - Corp base", "sonarcloud_org_key": "fubar", "cloud_gate_id": "42"},
+		// A different gate in the same org — must remain.
+		{"name": "Custom Gate", "sonarcloud_org_key": "fubar", "cloud_gate_id": "43"},
+		// Same gate name in a different org — must remain (distinct cloud entity).
+		{"name": "3 - Corp base", "sonarcloud_org_key": "other", "cloud_gate_id": "99"},
+	})
+
+	summary, err := CollectSummary(dir, "")
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	gates := findSection(summary, "Quality Gates")
+	if gates == nil {
+		t.Fatal("missing Quality Gates section")
+	}
+	if len(gates.Succeeded) != 3 {
+		var got []string
+		for _, g := range gates.Succeeded {
+			got = append(got, g.Organization+"/"+g.Name+"#"+g.Detail)
+		}
+		t.Fatalf("expected 3 unique rows after dedup, got %d: %v", len(gates.Succeeded), got)
+	}
+	// Find the fubar/3 - Corp base row — must appear exactly once.
+	found := 0
+	for _, g := range gates.Succeeded {
+		if g.Organization == "fubar" && g.Name == "3 - Corp base" {
+			found++
+		}
+	}
+	if found != 1 {
+		t.Errorf("expected exactly one row for fubar/3 - Corp base, got %d", found)
+	}
+}
+
 func TestCollectSummaryWithScanHistory(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Closes #165. The migration PDF was listing the same quality gate multiple times in the same org (e.g. `3 - Corp base` × 3 in `fubar`) and inflating the migrated-count by the duplicates.

### Root cause

When one SonarQube Server entity exists under several source orgs that all map to the same SonarCloud org, the `generate*Mappings` task emits one JSONL record per source-org pair. `createGates` (and every other `create*` task) then create-or-already-exists the same cloud entity for each, writing N identical records to the output store. `collectSucceeded` mapped those 1:1 to PDF rows.

### Fix

Dedupe `collectSucceeded` by the composite of `(Organization, Detail, Name, Language)`. `Detail` carries the cloud-side unique id for every section (`cloud_gate_id`, `cloud_profile_key`, `cloud_template_id`, `cloud_group_id`, `cloud_portfolio_id`, `cloud_project_key`), so identical cloud entities collapse to one row. Distinct entities with the same name in different orgs or languages stay separate. The migrated-count is `len(section.Succeeded)`, so it naturally drops to the correct value.

The fix is scoped to the report layer — redundant API calls during the migration itself are a separate runtime optimisation outside this issue.

## Test plan
- [x] `go test ./...` green.
- [x] New `TestCollectSummaryDedupesDuplicateCreates` seeds the exact scenario from the bug screenshot: three identical `3 - Corp base` rows in `fubar` + a distinct gate in the same org + the same gate name in a DIFFERENT org. Asserts the result has exactly **3** rows (collapsed duplicate + the two distinct entries) and the duplicate appears once.
- [x] The pre-existing `TestCollectSummaryQualityGateMappingDedupesAcrossSourceOrgs` (a related Notes-sidecar dedup) stays green.
- [ ] **Live re-run**: regenerate the report against the same migration state — `3 - Corp base` should appear once in `fubar` and the total should drop by 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
