### PR TITLE
Issue #160 drive setProjectProfiles from explicit assignments only

### DIFF
--- a/go/internal/extract/tasks_profiles.go
+++ b/go/internal/extract/tasks_profiles.go
@@ -42,6 +42,48 @@ func profileTasks() []TaskDef {
 			Run: perProfilePaginated("getProfileGroups", "api/qualityprofiles/search_groups", "groups")},
 		{Name: "getProfileUsers", Editions: AllEditions, Dependencies: []string{"getProfiles"},
 			Run: perProfilePaginated("getProfileUsers", "api/qualityprofiles/search_users", "users")},
+		{
+			// getProfileProjects lists the projects EXPLICITLY assigned
+			// to each non-built-in quality profile (selected=selected).
+			// Used by migrate's setProjectProfiles as the source of truth
+			// for project→profile assignments. The qualityProfiles array
+			// returned by api/navigation/component (in getProjectDetails)
+			// reports the profile used at the LAST ANALYSIS, which can
+			// drift from the current explicit assignment if a project
+			// was unassigned after its last analysis — bug observed in
+			// issue #160 where a profile showed projectCount=1 on SQS
+			// but the navigation/component data fingered 2 projects,
+			// leaving the second project incorrectly attached to the
+			// custom profile on SQC after migration.
+			Name:         "getProfileProjects",
+			Editions:     AllEditions,
+			Dependencies: []string{"getProfiles"},
+			Run: func(ctx context.Context, e *Executor) error {
+				return forEachDepFiltered(ctx, e, "getProfileProjects", "getProfiles", notBuiltIn,
+					func(ctx context.Context, item json.RawMessage, w *ChunkWriter) error {
+						name := extractField(item, "name")
+						lang := extractField(item, "language")
+						profileKey := extractField(item, "key")
+						items, err := e.Raw.GetPaginated(ctx, PaginatedOpts{
+							Path: "api/qualityprofiles/projects", ResultKey: "results",
+							Params: url.Values{
+								"qualityProfile": {name},
+								"language":       {lang},
+								"selected":       {"selected"},
+							},
+						})
+						if err != nil {
+							return err
+						}
+						return w.WriteChunk(enrichAll(items, map[string]any{
+							"profileKey":  profileKey,
+							"profileName": name,
+							"language":    lang,
+							"serverUrl":   e.ServerURL,
+						}))
+					})
+			},
+		},
 	}
 }
 

--- a/go/internal/extract/tasks_profiles.go
+++ b/go/internal/extract/tasks_profiles.go
@@ -64,14 +64,18 @@ func profileTasks() []TaskDef {
 						name := extractField(item, "name")
 						lang := extractField(item, "language")
 						profileKey := extractField(item, "key")
-						items, err := e.Raw.GetPaginated(ctx, PaginatedOpts{
-							Path: "api/qualityprofiles/projects", ResultKey: "results",
-							Params: url.Values{
-								"qualityProfile": {name},
-								"language":       {lang},
-								"selected":       {"selected"},
-							},
-						})
+						// /api/qualityprofiles/projects is keyed by the
+					// profile UUID, NOT by qualityProfile+language like
+					// search_groups / search_users. Using the wrong
+					// parameter shape produces an empty result set, which
+					// is what was happening when this fix first shipped.
+					items, err := e.Raw.GetPaginated(ctx, PaginatedOpts{
+						Path: "api/qualityprofiles/projects", ResultKey: "results",
+						Params: url.Values{
+							"key":      {profileKey},
+							"selected": {"selected"},
+						},
+					})
 						if err != nil {
 							return err
 						}

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -82,6 +82,26 @@ func associateTasks() []TaskDef {
 	}
 }
 
+// runSetProjectProfiles drives quality-profile assignments on SonarCloud
+// from the getProfileProjects extract — the definitive list of
+// explicit project↔profile bindings on SonarQube Server.
+//
+// Earlier versions of this task iterated createProjects' embedded
+// profiles array, which was populated from api/navigation/component.
+// That endpoint reports the profile used at the LAST ANALYSIS, not
+// the current explicit binding, so a project that once used a custom
+// profile and was later unassigned still appeared bound to it. The
+// migrate task then re-applied the stale binding on SQC and the
+// custom profile ended up listed for more projects on SQC than on
+// SQS (issue #160).
+//
+// The new flow drives off getProfileProjects, which queries
+// /api/qualityprofiles/projects?selected=selected per non-built-in
+// profile — exactly the projects with an active explicit assignment.
+// Each record carries the SQS project key + profile name/language;
+// we resolve the cloud project key via createProjects output and
+// confirm the profile was migrated via createProfiles output before
+// dispatching POST /api/qualityprofiles/add_project.
 func runSetProjectProfiles(ctx context.Context, e *Executor) error {
 	// Build profile lookup: orgKey+language+name -> true.
 	profiles, _ := e.Store.ReadAll("createProfiles")
@@ -93,30 +113,55 @@ func runSetProjectProfiles(ctx context.Context, e *Executor) error {
 		profileLookup[orgKey+lang+name] = true
 	}
 
-	counter := NewTaskCounter("setProjectProfiles")
-	err := forEachMigrateItem(ctx, e, "setProjectProfiles", "createProjects",
-		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
-			orgKey := extractField(item, "sonarcloud_org_key")
-			projectKey := extractField(item, "cloud_project_key")
-			profilesArr := extractProfilesList(item)
+	// Build project lookup: serverURL+sqsProjectKey ->
+	// (cloudProjectKey, sonarcloudOrgKey). createProjects rows carry
+	// both, so a single pass is enough.
+	type projTarget struct {
+		cloudKey string
+		orgKey   string
+	}
+	projects, _ := e.Store.ReadAll("createProjects")
+	projectLookup := make(map[string]projTarget, len(projects))
+	for _, p := range projects {
+		server := extractField(p, "server_url")
+		srcKey := extractField(p, "key")
+		cloudKey := extractField(p, "cloud_project_key")
+		orgKey := extractField(p, "sonarcloud_org_key")
+		if srcKey == "" || cloudKey == "" {
+			continue
+		}
+		projectLookup[server+srcKey] = projTarget{cloudKey: cloudKey, orgKey: orgKey}
+	}
 
-			for _, p := range profilesArr {
-				lang := getString(p, "language")
-				name := getString(p, "name")
-				if unsupportedLanguages[lang] || getBool(p, "deleted") {
-					continue
-				}
-				if !profileLookup[orgKey+lang+name] {
-					continue
-				}
-				e.Logger.Debug("project api call: POST /api/qualityprofiles/add_project",
-					"project", projectKey, "language", lang, "profile", name, "org", orgKey)
-				if err := e.Cloud.QualityProfiles.AddProject(ctx, lang, name, projectKey, orgKey); err != nil {
-					counter.Fail()
-					logAPIWarn(e.Logger, "setProjectProfiles failed", err, "project", projectKey)
-				} else {
-					counter.Success()
-				}
+	counter := NewTaskCounter("setProjectProfiles")
+	err := forEachExtractItem(ctx, e, "setProjectProfiles", "getProfileProjects",
+		func(ctx context.Context, ext structure.ExtractItem, w *common.ChunkWriter) error {
+			server := extractField(ext.Data, "serverUrl")
+			lang := extractField(ext.Data, "language")
+			name := extractField(ext.Data, "profileName")
+			srcProjectKey := extractField(ext.Data, "key")
+			if unsupportedLanguages[lang] || srcProjectKey == "" {
+				return nil
+			}
+			target, ok := projectLookup[server+srcProjectKey]
+			if !ok {
+				// Project wasn't migrated (e.g., skipped org). Nothing
+				// to assign on SQC.
+				return nil
+			}
+			if !profileLookup[target.orgKey+lang+name] {
+				// Profile wasn't migrated (built-in, or org skipped).
+				// SQC's own default applies; no AddProject needed.
+				return nil
+			}
+			e.Logger.Debug("project api call: POST /api/qualityprofiles/add_project",
+				"project", target.cloudKey, "language", lang, "profile", name, "org", target.orgKey)
+			if err := e.Cloud.QualityProfiles.AddProject(ctx, lang, name, target.cloudKey, target.orgKey); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setProjectProfiles failed", err,
+					"project", target.cloudKey, "language", lang, "profile", name)
+			} else {
+				counter.Success()
 			}
 			return nil
 		})

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"sync"
 	"testing"
 )
@@ -206,6 +207,109 @@ func TestSetProjectProfiles(t *testing.T) {
 	err := reg["setProjectProfiles"].Run(context.Background(), e)
 	if err != nil {
 		t.Fatalf("setProjectProfiles: %v", err)
+	}
+}
+
+// TestSetProjectProfilesUsesExplicitAssignmentsOnly is a regression
+// for issue #160. The old implementation drove off the
+// qualityProfiles array embedded in createProjects (sourced from
+// api/navigation/component) which reports the profile used in the
+// LAST ANALYSIS — historical data that can list a project as bound
+// to a custom profile even after the explicit binding has been
+// removed. The fix drives off getProfileProjects, which queries
+// /api/qualityprofiles/projects?selected=selected — exactly the
+// explicitly-assigned projects.
+//
+// This test seeds two projects (projA + projB), both in the same
+// org. The getProfileProjects extract data lists ONLY projA as
+// assigned to "Custom Python" — projB has no explicit assignment.
+// Even if a stale navigation/component capture had listed projB as
+// using "Custom Python", the new code path must not call
+// AddProject for projB.
+func TestSetProjectProfilesUsesExplicitAssignmentsOnly(t *testing.T) {
+	type addProjectCall struct {
+		language, profile, project, org string
+	}
+	var (
+		mu    sync.Mutex
+		calls []addProjectCall
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/qualityprofiles/add_project", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		calls = append(calls, addProjectCall{
+			language: r.FormValue("language"),
+			profile:  r.FormValue("qualityProfile"),
+			project:  r.FormValue("project"),
+			org:      r.FormValue("organization"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	// Replace the default getProfileProjects with our scenario: only
+	// projA is explicitly assigned to "Custom Python".
+	writeJSONL(filepath.Join(dir, "extract-01", "getProfileProjects"), []map[string]any{
+		{"key": "projA", "name": "Project A", "selected": true,
+			"profileKey": "py-custom", "profileName": "Custom Python", "language": "py",
+			"serverUrl": testServerURL},
+	})
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// Both projects exist and are migrated. createProjects rows carry
+	// the SQS key + cloud key + org.
+	w, _ := e.Store.Writer("createProjects")
+	for _, src := range []string{"projA", "projB"} {
+		b, _ := json.Marshal(map[string]any{
+			"server_url":         testServerURL,
+			"key":                src,
+			"cloud_project_key":  testCloudOrg + "_" + src,
+			"sonarcloud_org_key": testCloudOrg,
+		})
+		w.WriteOne(b)
+	}
+
+	// "Custom Python" is migrated.
+	w, _ = e.Store.Writer("createProfiles")
+	b, _ := json.Marshal(map[string]any{
+		"name":               "Custom Python",
+		"language":           "py",
+		"sonarcloud_org_key": testCloudOrg,
+		"cloud_profile_key":  "py-custom-cloud",
+		"source_profile_key": "py-custom",
+	})
+	w.WriteOne(b)
+
+	if err := runSetProjectProfiles(context.Background(), e); err != nil {
+		t.Fatalf("runSetProjectProfiles: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(calls) != 1 {
+		t.Fatalf("expected exactly 1 AddProject call (projA), got %d: %+v", len(calls), calls)
+	}
+	got := calls[0]
+	wantProject := testCloudOrg + "_projA"
+	if got.project != wantProject {
+		t.Errorf("AddProject project: got %q want %q", got.project, wantProject)
+	}
+	if got.profile != "Custom Python" || got.language != "py" {
+		t.Errorf("AddProject profile/lang: got %s/%s want \"Custom Python\"/\"py\"", got.profile, got.language)
+	}
+	for _, c := range calls {
+		if c.project == testCloudOrg+"_projB" {
+			t.Errorf("projB must NOT receive AddProject — no explicit assignment in getProfileProjects")
+		}
 	}
 }
 

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -458,6 +458,15 @@ func setupExtractData(dir string) {
 		{"profileKey": "prof1", "name": testSonarUsers, "serverUrl": testServerURL},
 	})
 
+	// Profile↔project explicit assignments (issue #160 — definitive
+	// source of project profile bindings, replacing the stale
+	// navigation/component qualityProfiles array).
+	writeJSONL(filepath.Join(extractDir, "getProfileProjects"), []map[string]any{
+		{"key": "proj1", "name": "Project 1", "selected": true,
+			"profileKey": "prof1", "profileName": "Custom", "language": "java",
+			"serverUrl": testServerURL},
+	})
+
 	// Portfolio projects (empty for non-enterprise tests).
 	writeJSONL(filepath.Join(extractDir, "getPortfolioProjects"), nil)
 }


### PR DESCRIPTION
## Summary

Closes #160. A custom Python QP showed `projectCount=1` on SonarQube Server but ended up bound to 2 projects on SonarQube Cloud after migration. After tracing through your `files.old2` extract:

| Project | SQS extract source: `api/navigation/component` | SQS source-of-truth: `api/qualityprofiles/projects?key=…&selected=selected` | What the OLD migrate did | What it should do |
|---|---|---|---|---|
| `okorach-oss_sonar-tools` | "Olivier Way" | ✅ assigned | AddProject ✅ | AddProject ✅ |
| `file-issue` | "Olivier Way" (stale — historical analysis) | ❌ not assigned | AddProject ❌ | nothing ✅ |

`api/navigation/component`'s `qualityProfiles` array is **the profile used at the last analysis**, not the current explicit binding. Once `file-issue`'s explicit binding to "Olivier Way" was removed but the project wasn't re-analyzed, navigation/component kept reporting "Olivier Way". The old `setProjectProfiles` had no way to know it was stale.

### Fix

Drive assignments off a **definitive** source.

- New extract task **`getProfileProjects`** — for each non-built-in profile, calls `/api/qualityprofiles/projects?key=K&selected=selected`, which returns exactly the projects with an active explicit binding.
- **`runSetProjectProfiles`** now iterates that extract data (one record per profile×project explicit assignment), resolves the cloud project key via `createProjects`, confirms the profile was migrated via `createProfiles`, and dispatches `POST /api/qualityprofiles/add_project` for that pair.
- The embedded `qualityProfiles` array on each createProjects record is no longer consulted for dispatch (it stays for downstream diagnostics).

### Upgrade note

Users **must re-extract from SQS** to populate `getProfileProjects`. Older extract directories will lack the data and `setProjectProfiles` will be a no-op (not a failure). I'll mention this in the release notes when this lands.

## Test plan
- [x] `go test ./...` green.
- [x] **`TestSetProjectProfilesUsesExplicitAssignmentsOnly`** reproduces the bug scenario: two projects in the same migrated org, only one explicitly assigned to a custom Python profile per `getProfileProjects`. Asserts exactly **one** `AddProject` call is made, and the un-assigned project never receives one.
- [x] The existing `TestSetProjectProfiles` smoke test still passes via a seeded `getProfileProjects` sample in `setupExtractData`.
- [ ] **Live re-run**: re-extract `files.old2`, re-migrate; "Olivier Way" should end up with `projectCount=1` on SQC, only `okorach-oss_sonar-tools` listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
