### PR TITLE
Issue #98 add --project_key selector to extract + migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ sonar-migration-tool extract <URL> <TOKEN> --export_directory ./files/ [--concur
 | `--extract_type` | Type of extract to run |
 | `--export_directory` | Output directory (default: `/app/files/` — override when running natively) |
 | `--include_scan_history` | Extract full issue data, source code, and SCM blame for scan history import |
+| `--project_key` | Comma-separated list of SonarQube project keys to scope the extract to. Empty extracts every project. See [Single-project / selective re-migration](#single-project--selective-re-migration). |
 | `--pem_file_path` | Client certificate PEM file (mTLS) |
 | `--key_file_path` | Client certificate key file (mTLS) |
 | `--cert_password` | Client certificate password (mTLS) |
@@ -185,10 +186,44 @@ sonar-migration-tool migrate <TOKEN> <ENTERPRISE_KEY> --export_directory ./files
 | `--run_id` | Resume a failed migration from the last completed task |
 | `--target_task` | Run a specific migration task (with its dependencies) |
 | `--skip_profiles` | Skip quality profile migration/provisioning |
+| `--project_key` | Comma-separated list of SonarQube project keys to scope the migration to. Empty migrates every project in `projects.csv`. See [Single-project / selective re-migration](#single-project--selective-re-migration). |
 | `--edition` | SonarQube Cloud license edition |
 | `--url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
 | `--concurrency` | Max concurrent requests |
 | `--export_directory` | Directory containing SonarQube exports (default: `/app/files/` — override when running natively) |
+
+---
+
+## Single-project / selective re-migration
+
+The `--project_key` flag on `extract` and `migrate` accepts a **comma-separated list of SonarQube project keys** and scopes the run to just those projects. Empty (the default) processes every project. Two common use cases:
+
+### Test the tool against a single representative project
+
+Before running a full migration against your whole instance, validate the toolchain end-to-end against one project:
+
+```bash
+sonar-migration-tool extract  <URL> <TOKEN>            --project_key okorach-oss_sonar-tools  --export_directory ./files/
+sonar-migration-tool structure                          --export_directory ./files/
+# edit organizations.csv → set sonarcloud_org_key
+sonar-migration-tool mappings                           --export_directory ./files/
+sonar-migration-tool migrate  <CLOUD_TOKEN> <ENT_KEY>  --project_key okorach-oss_sonar-tools  --export_directory ./files/
+```
+
+Only that project is extracted from SQS and pushed to SQC, so the round trip is fast and the SQC org stays clean for repeat tests.
+
+### Re-migrate a few failed projects after a full run
+
+When a full migration succeeded for most projects but failed for a handful, you don't need to re-run the whole pipeline. Re-extract just the failed projects, then re-migrate them:
+
+```bash
+sonar-migration-tool extract  <URL> <TOKEN>            --project_key projA,projB,projC  --export_directory ./files/
+sonar-migration-tool migrate  <CLOUD_TOKEN> <ENT_KEY>  --project_key projA,projB,projC  --export_directory ./files/
+```
+
+`createProjects` is idempotent — projects that already exist on SQC return `already exists` and downstream tasks proceed normally on each one.
+
+Whitespace around each key is trimmed; duplicates collapse; empty tokens are dropped. The flag is also accepted via JSON config as `"project_key": "projA,projB,projC"`.
 
 ---
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -54,7 +54,8 @@ Create a file named `extract-config.json`:
   "key_file_path": null,
   "cert_password": null,
   "target_task": null,
-  "extract_id": null
+  "extract_id": null,
+  "project_key": null
 }
 ```
 
@@ -76,7 +77,8 @@ Create a file named `migrate-config.json`:
   "export_directory": "./files",
   "concurrency": 10,
   "run_id": null,
-  "target_task": null
+  "target_task": null,
+  "project_key": null
 }
 ```
 
@@ -102,6 +104,7 @@ Usage:
 | `cert_password` | string | `null` | Password for client certificate |
 | `target_task` | string | `null` | Target task to complete |
 | `extract_id` | string | `null` | ID of extract to resume |
+| `project_key` | string | `null` | Comma-separated list of SonarQube project keys to scope the extract to. Empty extracts every project the token can see. |
 
 ### Migrate Command Parameters
 
@@ -115,6 +118,7 @@ Usage:
 | `concurrency` | number | `25` | Maximum concurrent requests |
 | `run_id` | string | `null` | ID of run to resume |
 | `target_task` | string | `null` | Specific migration task |
+| `project_key` | string | `null` | Comma-separated list of SonarQube project keys to scope the migration to. Empty migrates every project in `projects.csv`. |
 
 ## Combining Config Files and CLI Arguments
 

--- a/docs/MANUAL-MIGRATION.md
+++ b/docs/MANUAL-MIGRATION.md
@@ -85,6 +85,7 @@ sonar-migration-tool extract http://localhost:9000 YOUR_TOKEN --export_directory
 | `--pem_file_path`   | Path to a PEM client certificate file (mTLS)             | --      |
 | `--key_file_path`   | Path to a private key file (mTLS)                        | --      |
 | `--cert_password`   | Password for the client certificate (mTLS)               | --      |
+| `--project_key`     | Comma-separated list of project keys to scope the extract to. See [Single-Project / Selective Re-Migration](#single-project--selective-re-migration). | --      |
 
 ---
 
@@ -163,6 +164,7 @@ sonar-migration-tool migrate YOUR_CLOUD_TOKEN YOUR_ENTERPRISE_KEY --export_direc
 | `--run_id`          | Resume a previously started migration by its run ID       | --                        |
 | `--target_task`     | Run a specific migration task only                        | --                        |
 | `--skip_profiles`   | Skip migrating quality profiles                           | --                        |
+| `--project_key`     | Comma-separated list of project keys to scope the migration to. See [Single-Project / Selective Re-Migration](#single-project--selective-re-migration). | --                        |
 
 ---
 
@@ -195,6 +197,65 @@ Once the migration is complete:
    # Built binary
    sonar-migration-tool analysis_report <RUN_ID> --export_directory ./files/
    ```
+
+---
+
+## Single-Project / Selective Re-Migration
+
+`extract` and `migrate` both accept a `--project_key` flag whose value is a **comma-separated list of SonarQube project keys**. When set, the run is scoped to just those projects. When omitted, every project is processed (today's default). Two common workflows:
+
+### Test the tool against one project before a full migration
+
+Before running a full migration against every project on your instance, validate the tool end-to-end against a single representative project. Smaller blast radius, faster iteration:
+
+```bash
+# 1. Extract just one project from SonarQube Server.
+sonar-migration-tool extract http://localhost:9000 YOUR_SQS_TOKEN \
+  --project_key okorach-oss_sonar-tools \
+  --export_directory ./files/
+
+# 2. Generate the org-structure CSV and fill in sonarcloud_org_key as usual.
+sonar-migration-tool structure --export_directory ./files/
+#   edit organizations.csv → set sonarcloud_org_key
+
+# 3. Generate entity mappings.
+sonar-migration-tool mappings --export_directory ./files/
+
+# 4. Migrate just that one project to SonarQube Cloud.
+sonar-migration-tool migrate YOUR_CLOUD_TOKEN YOUR_ENTERPRISE_KEY \
+  --project_key okorach-oss_sonar-tools \
+  --export_directory ./files/
+```
+
+Only that project is extracted from SQS and pushed to SQC, so the round trip stays fast and your target organization stays clean for repeat tests. Use `reset` (see "Additional Commands" in the [README](../README.md)) between runs to wipe SQC if you need a fresh baseline.
+
+### Selectively re-migrate a few failed projects after a full run
+
+When a full migration succeeded for most of your projects but failed for a handful, you don't need to re-run the whole pipeline. Re-extract and re-migrate just the offenders by listing them:
+
+```bash
+sonar-migration-tool extract http://localhost:9000 YOUR_SQS_TOKEN \
+  --project_key projA,projB,projC \
+  --export_directory ./files/
+
+sonar-migration-tool migrate YOUR_CLOUD_TOKEN YOUR_ENTERPRISE_KEY \
+  --project_key projA,projB,projC \
+  --export_directory ./files/
+```
+
+`createProjects` is idempotent — a project that already exists on SonarQube Cloud is reported as `already exists` and the downstream tasks (profiles, gates, settings, …) proceed normally against the existing project key.
+
+### Flag semantics
+
+- Whitespace around each key is tolerated and trimmed: `--project_key "projA, projB , projC"` parses cleanly.
+- Empty tokens are dropped: `projA,,projB` parses as `{projA, projB}`.
+- Duplicates collapse silently.
+- The same value can come from a JSON config file as `"project_key": "projA,projB,projC"`.
+- Empty / unset → no filter (today's behaviour: every project).
+
+### What's NOT in scope for `--project_key` (yet)
+
+Issue #98 also asks for fuller per-project data migration — issue status, user comments, custom tags, hotspots, external (third-party) issues, and MQR-mode impacts. The scan-history side of that pipeline (files, SCM backdating, basic issues, scanner-report submission) already runs when you pass `--include_scan_history`, but the metadata sync to SonarCloud's REST API for transitions / comments / tags / hotspots ships in a follow-up PR.
 
 ---
 

--- a/examples/config-extract.example.json
+++ b/examples/config-extract.example.json
@@ -3,5 +3,6 @@
   "token": "YOUR_SONARQUBE_TOKEN_HERE",
   "export_directory": "./files",
   "concurrency": 10,
-  "timeout": 60
+  "timeout": 60,
+  "project_key": ""
 }

--- a/examples/config-migrate.example.json
+++ b/examples/config-migrate.example.json
@@ -3,5 +3,6 @@
   "enterprise_key": "YOUR_ENTERPRISE_KEY",
   "url": "https://sonarcloud.io/",
   "export_directory": "./files",
-  "concurrency": 10
+  "concurrency": 10,
+  "project_key": ""
 }

--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -48,6 +48,7 @@ func init() {
 	f.String("extract_id", "", "ID of an extract to resume in case of failures")
 	f.String("target_task", "", "Target task to complete; all dependent tasks will be included")
 	f.Bool("include_scan_history", false, "Extract full issue data, source code, and SCM blame for scan history migration")
+	f.String("project_key", "", "Comma-separated list of SonarQube project keys to scope the extract to (issue #98). Empty extracts every project the token can see.")
 }
 
 func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfig, error) {
@@ -82,6 +83,7 @@ func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfi
 	overrideString(cmd, "target_task", &cfg.TargetTask)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	overrideInt(cmd, "timeout", &cfg.Timeout)
+	overrideString(cmd, "project_key", &cfg.ProjectKey)
 	if cmd.Flags().Changed("include_scan_history") {
 		cfg.IncludeScanHistory, _ = cmd.Flags().GetBool("include_scan_history")
 	}

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -47,6 +47,7 @@ func init() {
 	f.String("target_task", "", "Name of a specific migration task to complete")
 	f.Bool("skip_profiles", false, "Skip quality profile migration/provisioning in SonarQube Cloud")
 	f.Bool("include_scan_history", false, "Import scan history (issues, metrics) into SonarQube Cloud projects")
+	f.String("project_key", "", "Comma-separated list of SonarQube project keys to scope the migration to (issue #98). Empty migrates every project in projects.csv.")
 	f.Bool("debug", false, "Enable debug-level logging (verbose request payloads, more detail per task)")
 }
 
@@ -78,6 +79,7 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	overrideString(cmd, "run_id", &cfg.RunID)
 	overrideString(cmd, "export_directory", &cfg.ExportDirectory)
 	overrideString(cmd, "target_task", &cfg.TargetTask)
+	overrideString(cmd, "project_key", &cfg.ProjectKey)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	if cmd.Flags().Changed("skip_profiles") {
 		cfg.SkipProfiles, _ = cmd.Flags().GetBool("skip_profiles")

--- a/go/internal/extract/config_file.go
+++ b/go/internal/extract/config_file.go
@@ -32,6 +32,7 @@ type configFileShape struct {
 	ExtractID          string `json:"extract_id"`
 	TargetTask         string `json:"target_task"`
 	IncludeScanHistory bool   `json:"include_scan_history"`
+	ProjectKey         string `json:"project_key"`
 
 	// Shape 2 (command-sectioned).
 	Extract *configFileShape `json:"extract"`
@@ -95,6 +96,7 @@ func (s configFileShape) toExtractConfig() ExtractConfig {
 		cfg.ExtractID = s.ExtractID
 		cfg.TargetTask = s.TargetTask
 		cfg.IncludeScanHistory = s.IncludeScanHistory
+		cfg.ProjectKey = s.ProjectKey
 	}
 	return cfg
 }

--- a/go/internal/extract/extract.go
+++ b/go/internal/extract/extract.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +31,13 @@ type ExtractConfig struct {
 	ExtractID       string
 	TargetTask         string
 	IncludeScanHistory bool
+	// ProjectKey is a comma-separated list of project keys to scope
+	// the extract to (issue #98). Empty = extract every project the
+	// token can see. Use cases: extracting a single representative
+	// project before a full migration, or re-extracting only the
+	// projects that failed in a prior run. Whitespace around each
+	// key is trimmed.
+	ProjectKey string
 }
 
 // Executor is the runtime context passed to every task function.
@@ -44,6 +52,26 @@ type Executor struct {
 
 	mu              sync.Mutex
 	skippedProjects map[string]bool
+
+	// projectKeyFilter, when non-nil, scopes per-project tasks to
+	// the named projects (issue #98). nil = no filter (today's
+	// pre-filter behaviour). Read via IsSkipped — every per-project
+	// task already consults that predicate, so the filter takes
+	// effect everywhere downstream for free.
+	projectKeyFilter map[string]bool
+}
+
+// SetProjectKeyFilter installs a project-key allow-list. Keys not in
+// the set are treated as skipped by IsSkipped, which the per-project
+// extract tasks already check. A nil or empty map disables filtering.
+func (e *Executor) SetProjectKeyFilter(keys map[string]bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	if len(keys) == 0 {
+		e.projectKeyFilter = nil
+		return
+	}
+	e.projectKeyFilter = keys
 }
 
 // RecordSkipped marks a project as skipped due to insufficient privileges.
@@ -56,11 +84,28 @@ func (e *Executor) RecordSkipped(projectKey string) {
 	e.skippedProjects[projectKey] = true
 }
 
-// IsSkipped returns true if the project has been marked as skipped.
+// IsSkipped returns true if the project has been marked as skipped
+// for either of two reasons:
+//
+//   - the project failed an earlier per-project task with a
+//     non-fatal HTTP error (insufficient privileges, missing
+//     branch, etc.) — recorded via RecordSkipped.
+//   - the executor has a project_key allow-list installed
+//     (issue #98) and the project isn't in it.
+//
+// Per-project extract tasks consult this predicate before doing any
+// network work, so installing the allow-list is sufficient to skip
+// every downstream side-effect.
 func (e *Executor) IsSkipped(projectKey string) bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	return e.skippedProjects[projectKey]
+	if e.skippedProjects[projectKey] {
+		return true
+	}
+	if e.projectKeyFilter != nil && !e.projectKeyFilter[projectKey] {
+		return true
+	}
+	return false
 }
 
 // SkippedProjectKeys returns a sorted list of project keys that were skipped.
@@ -107,6 +152,9 @@ func RunExtract(ctx context.Context, cfg ExtractConfig) ([]string, error) {
 	plan = filterCompleted(plan, store)
 
 	executor := newExecutor(raw, store, client.BaseURL(), edition, version, cfg.Concurrency)
+	if filter := parseProjectKeyFilter(cfg.ProjectKey); filter != nil {
+		executor.SetProjectKeyFilter(filter)
+	}
 	if err := executePhases(ctx, executor, plan, registry, store); err != nil {
 		return nil, err
 	}
@@ -216,6 +264,27 @@ func runPhase(ctx context.Context, e *Executor, taskNames []string, registry map
 		})
 	}
 	return g.Wait()
+}
+
+// parseProjectKeyFilter splits the comma-separated --project_key CLI
+// value into a lookup set. Empty input → nil (no filter). Whitespace
+// around each key is trimmed; duplicates collapse naturally.
+func parseProjectKeyFilter(csv string) map[string]bool {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil
+	}
+	out := make(map[string]bool)
+	for _, k := range strings.Split(csv, ",") {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			out[k] = true
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 func (cfg *ExtractConfig) applyDefaults() {

--- a/go/internal/extract/extract_test.go
+++ b/go/internal/extract/extract_test.go
@@ -800,3 +800,79 @@ func TestFetchAndWriteSingleWithResultKey(t *testing.T) {
 		t.Errorf("expected 'Rule Detail', got %q", name)
 	}
 }
+
+// TestParseProjectKeyFilter pins the issue #98 parsing helper.
+// Comma-separated keys are split, whitespace trimmed, empties
+// dropped, and an empty / whitespace-only input returns nil so
+// callers can detect "no filter" by a single nil check.
+func TestParseProjectKeyFilter(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]bool
+	}{
+		{"empty -> nil", "", nil},
+		{"whitespace only -> nil", "   ", nil},
+		{"single key", "projA", map[string]bool{"projA": true}},
+		{"three keys", "projA,projB,projC",
+			map[string]bool{"projA": true, "projB": true, "projC": true}},
+		{"whitespace tolerated", " projA ,\tprojB ,projC ",
+			map[string]bool{"projA": true, "projB": true, "projC": true}},
+		{"empty tokens dropped", "projA,,projB,",
+			map[string]bool{"projA": true, "projB": true}},
+		{"duplicates collapse", "projA,projA,projB",
+			map[string]bool{"projA": true, "projB": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseProjectKeyFilter(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("size mismatch: got %v, want %v", got, tc.want)
+			}
+			for k := range tc.want {
+				if !got[k] {
+					t.Errorf("missing key %q in %v", k, got)
+				}
+			}
+		})
+	}
+}
+
+// TestIsSkippedHonoursProjectKeyFilter pins issue #98's downstream
+// behaviour: when a project_key allow-list is installed via
+// SetProjectKeyFilter, IsSkipped returns true for keys NOT in the
+// set, on top of the existing per-project failure tracking. Every
+// per-project extract task already consults IsSkipped, so this is
+// the single integration point that scopes the whole pipeline.
+func TestIsSkippedHonoursProjectKeyFilter(t *testing.T) {
+	e := &Executor{}
+
+	// Without filter — every key is allowed.
+	if e.IsSkipped("anything") {
+		t.Fatal("no filter, no skip — IsSkipped(\"anything\") must be false")
+	}
+
+	// Install allow-list.
+	e.SetProjectKeyFilter(map[string]bool{"projA": true, "projB": true})
+	if e.IsSkipped("projA") {
+		t.Error("projA is in the allow-list; must not be skipped")
+	}
+	if e.IsSkipped("projB") {
+		t.Error("projB is in the allow-list; must not be skipped")
+	}
+	if !e.IsSkipped("projC") {
+		t.Error("projC is NOT in the allow-list; must be skipped")
+	}
+
+	// Existing per-project skip tracking still works on top of the filter.
+	e.RecordSkipped("projA")
+	if !e.IsSkipped("projA") {
+		t.Error("projA was explicitly RecordSkipped; must be skipped")
+	}
+
+	// Clearing the filter restores pass-through behaviour.
+	e.SetProjectKeyFilter(nil)
+	if e.IsSkipped("projC") {
+		t.Error("filter cleared; projC must no longer be skipped")
+	}
+}

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -26,6 +26,7 @@ type configFileShape struct {
 	TargetTask         string `json:"target_task"`
 	SkipProfiles       bool   `json:"skip_profiles"`
 	IncludeScanHistory bool   `json:"include_scan_history"`
+	ProjectKey         string `json:"project_key"`
 	Debug              bool   `json:"debug"`
 
 	// Shape 2 (command-sectioned).
@@ -89,6 +90,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		cfg.TargetTask = s.TargetTask
 		cfg.SkipProfiles = s.SkipProfiles
 		cfg.IncludeScanHistory = s.IncludeScanHistory
+		cfg.ProjectKey = s.ProjectKey
 		cfg.Debug = s.Debug
 	}
 	return cfg

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -142,6 +142,17 @@ func loadCSVToJSONL(e *Executor, taskName, csvFilename string) error {
 
 	items := make([]json.RawMessage, 0, len(rows))
 	for _, row := range rows {
+		// Project-key allow-list (issue #98) is only applied when
+		// the loader is producing project mappings — filtering
+		// gates / profiles / groups / templates by a project key
+		// would silently drop org-level rows whose `key` column
+		// names a different entity.
+		if csvFilename == "projects.csv" && e.ProjectKeyFilter != nil {
+			key, _ := row["key"].(string)
+			if !e.ProjectKeyFilter[key] {
+				continue
+			}
+		}
 		// Enrich with sonarcloud_org_key from org lookup.
 		if sqKey, ok := row["sonarqube_org_key"].(string); ok && sqKey != "" {
 			if scKey, found := orgLookup[sqKey]; found {

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -405,3 +405,102 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 		})
 	}
 }
+
+// TestParseProjectKeyFilter mirrors the extract-side helper test
+// (issue #98).
+func TestParseProjectKeyFilter(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want map[string]bool
+	}{
+		{"empty -> nil", "", nil},
+		{"single", "projA", map[string]bool{"projA": true}},
+		{"three", "projA,projB,projC",
+			map[string]bool{"projA": true, "projB": true, "projC": true}},
+		{"whitespace tolerated", " projA ,\tprojB ", map[string]bool{"projA": true, "projB": true}},
+		{"duplicates collapse", "projA,projA", map[string]bool{"projA": true}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseProjectKeyFilter(tc.in)
+			if len(got) != len(tc.want) {
+				t.Fatalf("size mismatch: got %v, want %v", got, tc.want)
+			}
+			for k := range tc.want {
+				if !got[k] {
+					t.Errorf("missing key %q in %v", k, got)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadCSVToJSONLProjectKeyFilter is the issue #98 regression
+// for the migrate-side filter: when Executor.ProjectKeyFilter is
+// installed AND the CSV being loaded is projects.csv, rows whose
+// `key` column isn't in the filter are dropped. Other CSVs (gates,
+// profiles, ...) must be unaffected — their `key` columns name
+// different entities.
+func TestLoadCSVToJSONLProjectKeyFilter(t *testing.T) {
+	dir := t.TempDir()
+
+	// projects.csv with three rows; filter to one.
+	projectsCSV := "key,name\nprojA,Project A\nprojB,Project B\nprojC,Project C\n"
+	if err := os.WriteFile(filepath.Join(dir, "projects.csv"), []byte(projectsCSV), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A sibling CSV that names different entities by key. The
+	// filter must NOT touch this one.
+	gatesCSV := "key,name\nprojA,Gate A\nprojB,Gate B\nprojC,Gate C\n"
+	if err := os.WriteFile(filepath.Join(dir, "gates.csv"), []byte(gatesCSV), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	runDir := filepath.Join(dir, "run-01")
+	os.MkdirAll(runDir, 0o755)
+	store := common.NewDataStore(runDir)
+
+	e := &Executor{
+		Store:            store,
+		ExportDir:        dir,
+		ProjectKeyFilter: map[string]bool{"projB": true},
+	}
+
+	// projects.csv → filtered.
+	if err := loadCSVToJSONL(e, "generateProjectMappings", "projects.csv"); err != nil {
+		t.Fatalf("loadCSVToJSONL: %v", err)
+	}
+	projects, _ := store.ReadAll("generateProjectMappings")
+	if len(projects) != 1 {
+		t.Fatalf("expected 1 project after filter, got %d", len(projects))
+	}
+	var row map[string]any
+	json.Unmarshal(projects[0], &row)
+	if row["key"] != "projB" {
+		t.Errorf("expected projB, got %v", row["key"])
+	}
+
+	// gates.csv → NOT filtered (rows whose `key` happens to match a
+	// project key would otherwise be silently dropped).
+	if err := loadCSVToJSONL(e, "generateGateMappings", "gates.csv"); err != nil {
+		t.Fatalf("loadCSVToJSONL gates: %v", err)
+	}
+	gates, _ := store.ReadAll("generateGateMappings")
+	if len(gates) != 3 {
+		t.Errorf("gates.csv must be unaffected by project_key filter; expected 3 rows, got %d", len(gates))
+	}
+
+	// No filter installed → behaves as before.
+	e2 := &Executor{
+		Store:     store,
+		ExportDir: dir,
+	}
+	if err := loadCSVToJSONL(e2, "generateProjectMappings2", "projects.csv"); err != nil {
+		t.Fatalf("loadCSVToJSONL (no filter): %v", err)
+	}
+	unfiltered, _ := store.ReadAll("generateProjectMappings2")
+	if len(unfiltered) != 3 {
+		t.Errorf("no filter → expected 3 rows, got %d", len(unfiltered))
+	}
+}

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -30,6 +30,13 @@ type MigrateConfig struct {
 	SkipProfiles       bool
 	IncludeScanHistory bool
 	Debug              bool // Enable slog.LevelDebug + verbose request payload logs
+	// ProjectKey is a comma-separated list of SQS project keys to
+	// scope the migration to (issue #98). Empty = migrate every
+	// project in projects.csv. Use cases: testing the tool against
+	// a single representative project, or re-migrating a few
+	// projects that failed in a prior run. Whitespace around each
+	// key is trimmed.
+	ProjectKey string
 }
 
 // Executor is the runtime context passed to every migrate task function.
@@ -48,6 +55,13 @@ type Executor struct {
 	Mapping   structure.ExtractMapping
 	Sem       chan struct{}
 	Logger    *slog.Logger
+	// ProjectKeyFilter, when non-nil, scopes per-project migrate
+	// tasks to the named projects (issue #98). Consulted by
+	// loadCSVToJSONL when reading projects.csv, so every downstream
+	// task that iterates project mappings (createProjects,
+	// setProjectProfiles, setProjectGates, …) sees only the
+	// filtered subset.
+	ProjectKeyFilter map[string]bool
 }
 
 // RunMigrate is the main entry point for the migrate command.
@@ -132,20 +146,21 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	plan = filterCompleted(plan, store)
 
 	executor := &Executor{
-		Cloud:     cc,
-		CloudAPI:  apiCC,
-		Raw:       raw,
-		RawAPI:    rawAPI,
-		Extract:   nil, // Will be set per-task based on extract mapping
-		Store:     store,
-		CloudURL:  cloudClient.BaseURL(),
-		APIURL:    apiClient.BaseURL(),
-		EntKey:    cfg.EnterpriseKey,
-		Edition:   edition,
-		ExportDir: cfg.ExportDirectory,
-		Mapping:   mapping,
-		Sem:       make(chan struct{}, cfg.Concurrency),
-		Logger:    logger,
+		Cloud:            cc,
+		CloudAPI:         apiCC,
+		Raw:              raw,
+		RawAPI:           rawAPI,
+		Extract:          nil, // Will be set per-task based on extract mapping
+		Store:            store,
+		CloudURL:         cloudClient.BaseURL(),
+		APIURL:           apiClient.BaseURL(),
+		EntKey:           cfg.EnterpriseKey,
+		Edition:          edition,
+		ExportDir:        cfg.ExportDirectory,
+		Mapping:          mapping,
+		Sem:              make(chan struct{}, cfg.Concurrency),
+		Logger:           logger,
+		ProjectKeyFilter: parseProjectKeyFilter(cfg.ProjectKey),
 	}
 
 	// Execute phases.
@@ -206,6 +221,28 @@ func (cfg *MigrateConfig) applyDefaults() {
 // from previous releases are ignored by the prefix scan (their
 // names don't start with today's ISO date) — they don't collide,
 // just no longer participate in the count.
+// parseProjectKeyFilter splits the comma-separated --project_key
+// MigrateConfig value into a lookup set. Empty input returns nil
+// (no filter). Whitespace around each key is trimmed; duplicates
+// collapse naturally.
+func parseProjectKeyFilter(csv string) map[string]bool {
+	csv = strings.TrimSpace(csv)
+	if csv == "" {
+		return nil
+	}
+	out := make(map[string]bool)
+	for _, k := range strings.Split(csv, ",") {
+		k = strings.TrimSpace(k)
+		if k != "" {
+			out[k] = true
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 func generateRunID(directory string) string {
 	today := time.Now().UTC().Format("2006-01-02")
 	entries, _ := os.ReadDir(directory)


### PR DESCRIPTION
## Summary

Partial close of #98 — unblocks the two user-facing use cases without touching the data-migration pipeline:

> - Testing the migration tool on a single representative project before running a full migration
> - Selectively re-migrate a few projects when a full migration successfully migrated all but a few projects

New flag on both **`extract`** and **`migrate`**:

```
--project_key projA,projB,projC
```

Empty/unset = today's behaviour (every project). Whitespace tolerated, duplicates collapse, empty tokens dropped. Same flag is accepted via the existing JSON config file as `"project_key": "projA,projB,projC"` (all three documented shapes from #176 carry it).

### Where the filter is applied

The pipeline funnels project iteration through two well-defined choke points; filtering there scopes everything downstream for free:

| Command | Choke point | Implementation |
|---|---|---|
| `extract` | `Executor.IsSkipped(key)` | `SetProjectKeyFilter` installs an allow-list; `IsSkipped` returns `true` for keys not in it. Every per-project task already consults `IsSkipped` via `forEachDep`/`forEachProjectBranch` (e.g. `getProjectIssuesFull`, `getProjectSourceCode`, `getProjectSCMData`, `getProjectComponentTree`, …). |
| `migrate` | `loadCSVToJSONL("projects.csv")` | Rows whose `key` isn't in the filter are dropped before `generateProjectMappings`. Only `projects.csv` is filtered — gates/profiles/groups/templates CSVs carry their own (unrelated) entity keys. |

### Out of scope (tracked separately, can land on top of this)

- Issue-metadata sync (status, user comments, custom tags via `/api/issues/do_transition`, `/api/issues/add_comment`, `/api/issues/set_tags`).
- Hotspots (`/api/hotspots/change_status`, `/api/hotspots/add_comment`).
- External issues (third-party scanner protobufs in the scan report).
- MQR-mode impacts (`cleanCodeAttribute` on the issue protobuf).

## Test plan
- [x] `go test ./...` green in both `go/` and `lib/sq-api-go/`.
- [x] **extract**: `TestParseProjectKeyFilter` pins the CSV-parser shape (7 cases). `TestIsSkippedHonoursProjectKeyFilter` covers no filter, allow-list set, explicit `RecordSkipped` on top, filter cleared.
- [x] **migrate**: mirror parser test + `TestLoadCSVToJSONLProjectKeyFilter` — feeds 3-row `projects.csv` + 3-row `gates.csv`, asserts only the named project survives in `generateProjectMappings` and that `gates.csv` is **unaffected** by the filter.
- [ ] **Live single-project smoke**:
      ```
      ./sonar-migration-tool extract --config extract.json --project_key okorach-oss_sonar-tools
      ./sonar-migration-tool migrate --config migrate.json --project_key okorach-oss_sonar-tools
      ```
- [ ] **Live selective re-migration after a partially-failed full migrate**:
      ```
      ./sonar-migration-tool migrate --config migrate.json --project_key projA,projB,projC
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
