### PR TITLE
Issue #227 distinguish Near Perfect (yellow) vs Partial (orange) QG status

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -226,6 +226,7 @@ func collectSection(store *common.DataStore, def sectionDef,
 	skipped := collectSkipped(store, def)
 	failed := collectFailed(failuresByType, def)
 	partial := collectPartial(def, configFailures, succeeded)
+	var nearPerfect []EntityItem
 
 	// Augment skipped with built-in / unused items derived from extract data.
 	if def.ExtractTask != "" && extractMapping != nil {
@@ -250,21 +251,23 @@ func collectSection(store *common.DataStore, def sectionDef,
 		}
 	}
 
-	// Quality gates whose conditions were remapped (#143) or dropped
-	// because no SQC equivalent exists are reported as Partial. The
-	// per-condition decisions are written by addGateConditions to a
-	// sidecar JSONL.
+	// Quality gates whose conditions had to be remapped to close
+	// SonarQube Cloud equivalents (#143) are NearPerfect (yellow, #227).
+	// Gates with any dropped condition — no SQC equivalent — are Partial
+	// (orange, #227). The per-condition decisions are written by
+	// addGateConditions to a sidecar JSONL.
 	if def.Name == "Quality Gates" {
 		notes := collectGateMappingNotes(store.BaseDir())
-		succeeded, partial = applyGateMappingNotes(succeeded, partial, notes)
+		succeeded, nearPerfect, partial = applyGateMappingNotes(succeeded, nearPerfect, partial, notes)
 	}
 
 	return Section{
-		Name:      def.Name,
-		Succeeded: succeeded,
-		Partial:   partial,
-		Failed:    failed,
-		Skipped:   skipped,
+		Name:        def.Name,
+		Succeeded:   succeeded,
+		NearPerfect: nearPerfect,
+		Partial:     partial,
+		Failed:      failed,
+		Skipped:     skipped,
 	}
 }
 

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -683,11 +683,15 @@ func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
 		t.Fatal("missing Quality Gates section")
 	}
 
-	// Backend QG should be moved to Partial; Frontend QG should remain
-	// in Succeeded untouched.
+	// Backend QG has a dropped condition, so orange dominates: it lands
+	// in Partial, not NearPerfect. Frontend QG stays in Succeeded.
 	if len(gates.Succeeded) != 1 || gates.Succeeded[0].Name != "Frontend QG" {
 		t.Errorf("expected Frontend QG to remain in Succeeded, got %+v",
 			succeededNames(gates.Succeeded))
+	}
+	if len(gates.NearPerfect) != 0 {
+		t.Errorf("expected 0 NearPerfect gates (Backend QG has a drop), got %+v",
+			succeededNames(gates.NearPerfect))
 	}
 	if len(gates.Partial) != 1 {
 		t.Fatalf("expected 1 Partial gate, got %d", len(gates.Partial))
@@ -710,6 +714,66 @@ func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
 	if !strings.Contains(joined, "\nnew_security_rating_with_aica -->") &&
 		!strings.HasPrefix(item.Issues[0], "Some metrics were mapped") {
 		t.Errorf("expected newline-separated metric list, got %q", joined)
+	}
+}
+
+// TestCollectSummaryQualityGateRemapOnlyMovesToNearPerfect covers the #227
+// yellow criterion: a quality gate whose conditions were all close-equivalent
+// remaps (#143) and had no dropped conditions lands in NearPerfect, not
+// Partial.
+func TestCollectSummaryQualityGateRemapOnlyMovesToNearPerfect(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	writeTaskJSONL(t, runDir, "createGates", []map[string]any{
+		{"name": "Ratings QG", "sonarcloud_org_key": "org1", "cloud_gate_id": "77"},
+	})
+
+	notesDir := filepath.Join(runDir, "addGateConditions.notes")
+	os.MkdirAll(notesDir, 0o755)
+	lines := []map[string]any{
+		{
+			"cloud_gate_id":  "77",
+			"gate_name":      "Ratings QG",
+			"action":         "remapped",
+			"source_metric":  "new_security_rating_with_aica",
+			"target_metrics": []string{"new_security_rating"},
+		},
+	}
+	f, _ := os.Create(filepath.Join(notesDir, "results.1.jsonl"))
+	for _, line := range lines {
+		b, _ := json.Marshal(line)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	f.Close()
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	gates := findSection(summary, "Quality Gates")
+	if gates == nil {
+		t.Fatal("missing Quality Gates section")
+	}
+
+	if len(gates.Succeeded) != 0 {
+		t.Errorf("expected gate to leave Succeeded, got %+v",
+			succeededNames(gates.Succeeded))
+	}
+	if len(gates.Partial) != 0 {
+		t.Errorf("expected 0 Partial gates (no drop), got %+v",
+			succeededNames(gates.Partial))
+	}
+	if len(gates.NearPerfect) != 1 || gates.NearPerfect[0].Name != "Ratings QG" {
+		t.Fatalf("expected Ratings QG in NearPerfect, got %+v",
+			succeededNames(gates.NearPerfect))
+	}
+	joined := strings.Join(gates.NearPerfect[0].Issues, " | ")
+	if !strings.Contains(joined, "new_security_rating_with_aica --> new_security_rating") {
+		t.Errorf("expected remap detail in NearPerfect Issues, got %q", joined)
 	}
 }
 

--- a/go/internal/report/summary/gate_notes.go
+++ b/go/internal/report/summary/gate_notes.go
@@ -24,11 +24,19 @@ type gateMappingNote struct {
 	TargetMetrics []string `json:"target_metrics,omitempty"`
 }
 
+// gateNoteSummary captures the per-gate outcome of addGateConditions: the
+// human-readable Issues lines the report renders, plus a flag indicating
+// whether any source condition had to be dropped for lack of a SonarQube
+// Cloud equivalent. Dropped conditions are the #227 orange criterion;
+// remap-only gates qualify as #227 yellow (near-perfect).
+type gateNoteSummary struct {
+	Issues     []string
+	HasDropped bool
+}
+
 // collectGateMappingNotes reads the addGateConditions.notes sidecar and
-// returns one human-readable Partial-migration message per cloud gate
-// affected. The key is the cloud_gate_id; values are the strings the
-// summary report appends to the gate's Issues list.
-func collectGateMappingNotes(runDir string) map[string][]string {
+// returns the per-gate outcome keyed by cloud_gate_id.
+func collectGateMappingNotes(runDir string) map[string]gateNoteSummary {
 	dir := filepath.Join(runDir, "addGateConditions.notes")
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -103,7 +111,7 @@ func collectGateMappingNotes(runDir string) map[string][]string {
 		f.Close()
 	}
 
-	out := make(map[string][]string, len(byGate))
+	out := make(map[string]gateNoteSummary, len(byGate))
 	for gateID, ag := range byGate {
 		var msgs []string
 		if len(ag.remapped) > 0 {
@@ -119,18 +127,27 @@ func collectGateMappingNotes(runDir string) map[string][]string {
 					strings.Join(ag.dropped, "\n"))
 		}
 		if len(msgs) > 0 {
-			out[gateID] = msgs
+			out[gateID] = gateNoteSummary{
+				Issues:     msgs,
+				HasDropped: len(ag.dropped) > 0,
+			}
 		}
 	}
 	return out
 }
 
-// applyGateMappingNotes moves any Succeeded quality gate whose cloud gate id
-// appears in notes into the Partial bucket, attaching the human-readable
-// issue strings. Gates already in Partial get their Issues list extended.
-func applyGateMappingNotes(succeeded, partial []EntityItem, notes map[string][]string) ([]EntityItem, []EntityItem) {
+// applyGateMappingNotes routes Succeeded quality gates with addGateConditions
+// notes into either NearPerfect (yellow, #227) or Partial (orange, #227):
+//
+//   - A gate whose only notes are "remapped" (close-equivalent metric
+//     substitution per #143) lands in NearPerfect.
+//   - A gate with at least one "dropped" condition — i.e. a source metric
+//     with no SonarQube Cloud equivalent — lands in Partial.
+//   - A gate already in Partial (e.g. set_as_default failed) keeps that
+//     classification and absorbs the note Issues; orange dominates yellow.
+func applyGateMappingNotes(succeeded, nearPerfect, partial []EntityItem, notes map[string]gateNoteSummary) ([]EntityItem, []EntityItem, []EntityItem) {
 	if len(notes) == 0 || (len(succeeded) == 0 && len(partial) == 0) {
-		return succeeded, partial
+		return succeeded, nearPerfect, partial
 	}
 
 	// Index existing Partial entries by cloud_gate_id so we can extend
@@ -144,33 +161,37 @@ func applyGateMappingNotes(succeeded, partial []EntityItem, notes map[string][]s
 
 	keep := succeeded[:0:0]
 	for _, item := range succeeded {
-		issues, ok := notes[item.Detail]
+		note, ok := notes[item.Detail]
 		if !ok {
 			keep = append(keep, item)
 			continue
 		}
-		// Move to Partial.
 		moved := EntityItem{
 			Name:         item.Name,
 			Language:     item.Language,
 			Organization: item.Organization,
 			Detail:       item.Detail,
-			Issues:       append([]string(nil), issues...),
+			Issues:       append([]string(nil), note.Issues...),
 		}
-		partial = append(partial, moved)
+		if note.HasDropped {
+			partial = append(partial, moved)
+		} else {
+			nearPerfect = append(nearPerfect, moved)
+		}
 	}
 
-	// Append notes for gates already in Partial (e.g., from another
-	// upstream source).
-	for gateID, issues := range notes {
+	// Append notes for gates already in Partial (e.g., set_as_default
+	// failed in collectPartial). Orange dominates yellow, so we never
+	// move them out — just extend Issues.
+	for gateID, note := range notes {
 		idx, ok := partialIdx[gateID]
 		if !ok {
 			continue
 		}
-		partial[idx].Issues = append(partial[idx].Issues, issues...)
+		partial[idx].Issues = append(partial[idx].Issues, note.Issues...)
 	}
 
-	return keep, partial
+	return keep, nearPerfect, partial
 }
 
 // gateMappingDataStore is an interface satisfied by *common.DataStore so the

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -26,8 +26,9 @@ var (
 	colorWhite     = [3]int{255, 255, 255}
 	colorBlack     = [3]int{0, 0, 0}
 	colorGreen     = [3]int{34, 139, 34}
+	colorYellow    = [3]int{180, 150, 0} // near-perfect (issue #224 yellow status)
 	colorRed       = [3]int{200, 0, 0}
-	colorAmber     = [3]int{200, 110, 0}
+	colorAmber     = [3]int{200, 110, 0} // partial migration (issue #224 orange status)
 	colorDarkGray  = [3]int{90, 90, 90}
 )
 
@@ -48,10 +49,11 @@ var skipReasonOrder = []struct {
 
 // Outcome labels used in the unified per-section table.
 const (
-	outcomeSuccess = "Success"
-	outcomePartial = "Partial"
-	outcomeFailed  = "Failed"
-	outcomeSkipped = "Skipped"
+	outcomeSuccess     = "Success"
+	outcomeNearPerfect = "Near Perfect"
+	outcomePartial     = "Partial"
+	outcomeFailed      = "Failed"
+	outcomeSkipped     = "Skipped"
 )
 
 // RenderPDF builds a PDF document from the migration summary and returns the bytes.
@@ -149,9 +151,17 @@ func renderTitlePage(pdf *fpdf.Fpdf, summary *MigrationSummary) {
 	renderExecutiveSummary(pdf, summary.Sections)
 }
 
+// renderExecutiveSummary renders the six-column summary table at the top of
+// the report: Objects | Perfect | Near Perfect | Partial | Failed | Skipped.
+// The five status buckets follow the green/yellow/orange/red/grey taxonomy
+// defined in issues #224 and #227; colours are conveyed by the count cells.
 func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
-	headers := []string{"Section", "Succeeded", "Partial", "Failed", "Skipped", "Total"}
-	widths := []float64{50, 25, 25, 25, 25, 25}
+	headers := []string{"Objects", "Perfect", "Near Perfect", "Partial", "Failed", "Skipped"}
+	const (
+		objectsWidth = 45.0
+		countWidth   = 30.0
+	)
+	widths := []float64{objectsWidth, countWidth, countWidth, countWidth, countWidth, countWidth}
 
 	setFillColor(pdf, colorDarkBlue)
 	pdf.SetTextColor(255, 255, 255)
@@ -166,13 +176,18 @@ func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
 	pdf.Ln(-1)
 
 	pdf.SetFont(pdfFontFamily, "", 10)
-	var totalS, totalP, totalF, totalSk int
+	var totalPerfect, totalYellow, totalOrange, totalRed, totalGrey int
 	for i, sec := range sections {
-		s, p, f, sk := len(sec.Succeeded), len(sec.Partial), len(sec.Failed), len(sec.Skipped)
-		totalS += s
-		totalP += p
-		totalF += f
-		totalSk += sk
+		perfect := len(sec.Succeeded)
+		yellow := len(sec.NearPerfect)
+		orange := len(sec.Partial)
+		red := len(sec.Failed)
+		grey := len(sec.Skipped)
+		totalPerfect += perfect
+		totalYellow += yellow
+		totalOrange += orange
+		totalRed += red
+		totalGrey += grey
 
 		if i%2 == 0 {
 			setFillColor(pdf, colorLightGray)
@@ -181,25 +196,24 @@ func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section) {
 		}
 		setColor(pdf, colorBlack)
 		pdf.CellFormat(widths[0], 7, sec.Name, "1", 0, "L", true, 0, "")
-		renderCountCell(pdf, widths[1], s, colorGreen)
-		renderCountCell(pdf, widths[2], p, colorAmber)
-		renderCountCell(pdf, widths[3], f, colorRed)
-		renderCountCell(pdf, widths[4], sk, colorDarkGray)
-		setColor(pdf, colorBlack)
-		pdf.CellFormat(widths[5], 7, itoa(s+p+f+sk), "1", 0, "C", true, 0, "")
+		renderCountCell(pdf, widths[1], perfect, colorGreen)
+		renderCountCell(pdf, widths[2], yellow, colorYellow)
+		renderCountCell(pdf, widths[3], orange, colorAmber)
+		renderCountCell(pdf, widths[4], red, colorRed)
+		renderCountCell(pdf, widths[5], grey, colorDarkGray)
 		pdf.Ln(-1)
 	}
 
-	// Totals row
+	// Totals row.
 	setFillColor(pdf, colorDarkBlue)
 	pdf.SetTextColor(255, 255, 255)
 	pdf.SetFont(pdfFontFamily, "B", 10)
 	pdf.CellFormat(widths[0], 8, "Total", "1", 0, "L", true, 0, "")
-	pdf.CellFormat(widths[1], 8, itoa(totalS), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[2], 8, itoa(totalP), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[3], 8, itoa(totalF), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[4], 8, itoa(totalSk), "1", 0, "C", true, 0, "")
-	pdf.CellFormat(widths[5], 8, itoa(totalS+totalP+totalF+totalSk), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[1], 8, itoa(totalPerfect), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[2], 8, itoa(totalYellow), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[3], 8, itoa(totalOrange), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[4], 8, itoa(totalRed), "1", 0, "C", true, 0, "")
+	pdf.CellFormat(widths[5], 8, itoa(totalGrey), "1", 0, "C", true, 0, "")
 	pdf.Ln(-1)
 }
 
@@ -213,7 +227,7 @@ func renderCountCell(pdf *fpdf.Fpdf, w float64, count int, color [3]int) {
 }
 
 func renderSection(pdf *fpdf.Fpdf, section Section) {
-	total := len(section.Succeeded) + len(section.Partial) + len(section.Failed) + len(section.Skipped)
+	total := len(section.Succeeded) + len(section.NearPerfect) + len(section.Partial) + len(section.Failed) + len(section.Skipped)
 	if total == 0 {
 		return
 	}
@@ -464,8 +478,10 @@ type fpdfCell interface {
 	CellFormat(w, h float64, txtStr, borderStr string, ln int, alignStr string, fill bool, link int, linkStr string)
 }
 
-// buildUnifiedRows flattens the section's four buckets into ordered rows:
-// Succeeded → Partial → Failed → Skipped (skipped grouped by reason order).
+// buildUnifiedRows flattens the section's buckets into ordered rows:
+// Succeeded → NearPerfect → Partial → Failed → Skipped (skipped grouped by
+// reason order). Order mirrors the green → yellow → orange → red → grey
+// taxonomy from issues #224 and #227.
 func buildUnifiedRows(section Section) []unifiedRow {
 	var rows []unifiedRow
 
@@ -477,6 +493,20 @@ func buildUnifiedRows(section Section) []unifiedRow {
 			outcome:  outcomeSuccess,
 			color:    colorGreen,
 			details:  successDetails(item),
+		})
+	}
+	for _, item := range section.NearPerfect {
+		name := item.Name
+		if name == "" {
+			name = "(unknown)"
+		}
+		rows = append(rows, unifiedRow{
+			name:     name,
+			language: item.Language,
+			org:      item.Organization,
+			outcome:  outcomeNearPerfect,
+			color:    colorYellow,
+			details:  partialDetails(item),
 		})
 	}
 	for _, item := range section.Partial {
@@ -589,6 +619,9 @@ var sectionsWithoutSkipped = map[string]bool{
 func sectionCountSummary(section Section) string {
 	parts := []string{
 		fmt.Sprintf("%d succeeded", len(section.Succeeded)),
+	}
+	if len(section.NearPerfect) > 0 {
+		parts = append(parts, fmt.Sprintf("%d near perfect", len(section.NearPerfect)))
 	}
 	if len(section.Partial) > 0 {
 		parts = append(parts, fmt.Sprintf("%d partial", len(section.Partial)))

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -18,12 +18,23 @@ type MigrationSummary struct {
 }
 
 // Section represents a category of migrated entities (e.g., Projects, Quality Gates).
+//
+// The four success/non-success buckets correspond to the five-status taxonomy
+// from issues #224 and #227:
+//   - Succeeded   → green  (perfect-fidelity migration)
+//   - NearPerfect → yellow (migrated with a known close-equivalent substitution,
+//                   e.g. a metric mapping from #143)
+//   - Partial     → orange (created on SQC but a follow-up configuration step
+//                   was incomplete, or a feature was dropped)
+//   - Failed      → red    (create call itself failed)
+//   - Skipped     → grey   (deliberately skipped by configuration)
 type Section struct {
-	Name      string
-	Succeeded []EntityItem
-	Partial   []EntityItem // created on SQC but follow-up configuration was incomplete
-	Failed    []EntityItem
-	Skipped   []EntityItem
+	Name        string
+	Succeeded   []EntityItem
+	NearPerfect []EntityItem
+	Partial     []EntityItem
+	Failed      []EntityItem
+	Skipped     []EntityItem
 }
 
 // EntityItem represents a single entity in the report.


### PR DESCRIPTION
## Summary
- Restructure the migration report summary table to the five-status taxonomy from #224 / #227: **Objects | Perfect | Near Perfect | Partial | Failed | Skipped**. Objects column is wider; the five count columns are uniform.
- Add a `Section.NearPerfect` bucket to model the yellow status, and surface near-perfect rows in the per-section Quality Gates table (yellow outcome cell, same metric-mapping detail block as Partial).
- Route Quality Gates whose conditions were remapped to a close SonarQube Cloud equivalent (#143) into **NearPerfect**. Gates that lost a condition (no SQC equivalent) or hit a follow-up config failure (e.g. `set_as_default`) remain in **Partial** — orange dominates yellow.

Closes #227

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] New test `TestCollectSummaryQualityGateRemapOnlyMovesToNearPerfect` covers the yellow path
- [x] Existing `TestCollectSummaryQualityGateMetricMappingMovesToPartial` hardened to assert NearPerfect stays empty when a dropped condition is present
- [ ] Visual check of a generated PDF against a run that has both remap-only and dropped-condition gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)