### PR TITLE
Issues #232, #234 — fix QG metric mappings, collapse colliding conditions, hide obvious remaps

### DIFF
--- a/go/internal/migrate/gate_conditions_resolver.go
+++ b/go/internal/migrate/gate_conditions_resolver.go
@@ -1,0 +1,90 @@
+package migrate
+
+import "strconv"
+
+// targetCondition is one condition the migrator intends to POST to SQC,
+// after a source condition has been remapped (1:1, composite, or
+// passthrough) through metricMapping. SourceMetric is carried for logging
+// only — the resolver itself works off (Metric, Op, Error).
+type targetCondition struct {
+	Metric       string
+	Op           string
+	Error        string
+	SourceMetric string
+}
+
+// resolveTargetConditions implements #234: when multiple source-side QG
+// conditions end up targeting the same SonarQube Cloud metric (e.g. a
+// software_quality_blocker_issues composite that expands to a rating
+// metric also held by a direct passthrough condition), collapse them to
+// a single most-stringent condition per metric.
+//
+// "Stringent" means "fires the gate for more cases":
+//   - For Op=GT / GTE, the smaller threshold is more stringent.
+//   - For Op=LT / LTE, the larger threshold is more stringent.
+//   - Conditions on the same metric but with incomparable Ops (e.g. GT
+//     vs LT) are left alone — the first one wins, the rest are dropped.
+//     In practice SQC quality-gate conditions on a given metric always
+//     use the same op, so this branch is defensive.
+//
+// Input order is preserved for metrics that don't collide.
+func resolveTargetConditions(conds []targetCondition) []targetCondition {
+	if len(conds) <= 1 {
+		return conds
+	}
+	// Track the first appearance order of each metric so the output is
+	// deterministic regardless of map iteration order.
+	order := make([]string, 0, len(conds))
+	byMetric := make(map[string]targetCondition, len(conds))
+	for _, c := range conds {
+		existing, seen := byMetric[c.Metric]
+		if !seen {
+			order = append(order, c.Metric)
+			byMetric[c.Metric] = c
+			continue
+		}
+		if moreStringent(c, existing) {
+			byMetric[c.Metric] = c
+		}
+	}
+	out := make([]targetCondition, 0, len(order))
+	for _, m := range order {
+		out = append(out, byMetric[m])
+	}
+	return out
+}
+
+// moreStringent reports whether candidate fires the gate for strictly more
+// cases than incumbent, given they target the same metric. Conditions with
+// incomparable Ops are reported as not more stringent so the incumbent
+// stays.
+func moreStringent(candidate, incumbent targetCondition) bool {
+	if candidate.Op != incumbent.Op {
+		return false
+	}
+	c, cOk := parseConditionThreshold(candidate.Error)
+	i, iOk := parseConditionThreshold(incumbent.Error)
+	if !cOk || !iOk {
+		// Non-numeric threshold (rare for SQC QG conditions). Treat as
+		// incomparable.
+		return false
+	}
+	switch candidate.Op {
+	case "GT", "GTE":
+		return c < i
+	case "LT", "LTE":
+		return c > i
+	}
+	return false
+}
+
+func parseConditionThreshold(s string) (float64, bool) {
+	if s == "" {
+		return 0, false
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}

--- a/go/internal/migrate/gate_conditions_resolver_test.go
+++ b/go/internal/migrate/gate_conditions_resolver_test.go
@@ -1,0 +1,110 @@
+package migrate
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestResolveTargetConditions exercises the #234 collision-resolution rules:
+// when multiple source conditions produce target conditions on the same SQC
+// metric, keep one — the most stringent. "More stringent" means "fires the
+// gate for more cases" (lower threshold for GT, higher threshold for LT).
+func TestResolveTargetConditions(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []targetCondition
+		want []targetCondition
+	}{
+		{
+			name: "no collision passes through unchanged",
+			in: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+			},
+			want: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+			},
+		},
+		{
+			// #234 example: blocker_issues expansion (reliability_rating GT 4)
+			// collides with a direct reliability_rating GT 2. The direct
+			// passthrough is more stringent (B < D), so it wins.
+			name: "blocker expansion + direct reliability GT 2 → direct wins",
+			in: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "reliability_rating"},
+			},
+			want: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "reliability_rating"},
+			},
+		},
+		{
+			// #234 example: medium expansion (security_rating GT 2) collides
+			// with direct security_rating GT 3. Expansion is more stringent
+			// (B < C), so it wins.
+			name: "medium expansion + direct security_rating GT 3 → expansion wins",
+			in: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "2", SourceMetric: "software_quality_medium_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "software_quality_medium_issues"},
+				{Metric: "security_rating", Op: "GT", Error: "3", SourceMetric: "security_rating"},
+			},
+			want: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "2", SourceMetric: "software_quality_medium_issues"},
+				{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "software_quality_medium_issues"},
+			},
+		},
+		{
+			// Two direct passthroughs on the same metric — collapse to the
+			// more stringent one (chosen behaviour per #234 follow-up).
+			name: "two direct security_rating conditions collapse to most stringent",
+			in: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "security_rating"},
+				{Metric: "security_rating", Op: "GT", Error: "3", SourceMetric: "security_rating"},
+			},
+			want: []targetCondition{
+				{Metric: "security_rating", Op: "GT", Error: "3", SourceMetric: "security_rating"},
+			},
+		},
+		{
+			// LT semantics: for a coverage condition, higher threshold is
+			// more stringent (catches more low-coverage cases).
+			name: "LT — higher threshold is more stringent",
+			in: []targetCondition{
+				{Metric: "coverage", Op: "LT", Error: "70", SourceMetric: "coverage"},
+				{Metric: "coverage", Op: "LT", Error: "85", SourceMetric: "coverage"},
+			},
+			want: []targetCondition{
+				{Metric: "coverage", Op: "LT", Error: "85", SourceMetric: "coverage"},
+			},
+		},
+		{
+			// Mixed ops on the same metric — incomparable, the first wins.
+			// Defensive: SQC gates don't actually mix GT and LT on the same
+			// metric, but the resolver shouldn't panic if they do.
+			name: "incomparable ops — first wins",
+			in: []targetCondition{
+				{Metric: "weird_metric", Op: "GT", Error: "5", SourceMetric: "src"},
+				{Metric: "weird_metric", Op: "LT", Error: "5", SourceMetric: "src"},
+			},
+			want: []targetCondition{
+				{Metric: "weird_metric", Op: "GT", Error: "5", SourceMetric: "src"},
+			},
+		},
+		{
+			name: "empty input → empty output",
+			in:   nil,
+			want: nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveTargetConditions(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got %+v\nwant %+v", got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/migrate/gate_metric_mapping.go
+++ b/go/internal/migrate/gate_metric_mapping.go
@@ -73,6 +73,7 @@ var metricMapping = map[string][]replacementCondition{
 	"software_quality_maintainability_rating":              keep("sqale_rating"),
 	"software_quality_maintainability_rating_with_aica":    keep("sqale_rating"),
 	"software_quality_maintainability_rating_without_aica": keep("sqale_rating"),
+	"software_quality_reliability_rating":                  keep("reliability_rating"),
 	"software_quality_reliability_rating_with_aica":        keep("reliability_rating"),
 	"software_quality_reliability_rating_without_aica":     keep("reliability_rating"),
 	"software_quality_security_rating":                     keep("security_rating"),
@@ -100,18 +101,24 @@ var metricMapping = map[string][]replacementCondition{
 	"new_software_quality_security_rating_with_aica":    {ratingWorseThan("new_security_rating", "A")},
 	"new_software_quality_security_rating_without_aica": {ratingWorseThan("new_security_rating", "A")},
 
-	// Composite mappings for software_quality_*_issues. The right-hand side
-	// of the issue table is "metricA <= X + metricB <= X".
+	// Composite mappings for software_quality_*_issues — "any issue at
+	// this severity should fail the gate" expands to a pair of rating
+	// conditions on security_rating + reliability_rating at the matching
+	// severity. The earlier revision of #143 used security_review_rating
+	// here, but that metric is the % of security hotspots reviewed —
+	// unrelated to issue counts — so a source gate with a single
+	// software_quality_blocker_issues condition ended up with a spurious
+	// "Security Review Rating worse than D" on SQC (#232).
 	"software_quality_blocker_issues": {
-		ratingWorseThan("security_review_rating", "D"),
+		ratingWorseThan("security_rating", "D"),
 		ratingWorseThan("reliability_rating", "D"),
 	},
 	"software_quality_high_issues": {
-		ratingWorseThan("security_review_rating", "C"),
+		ratingWorseThan("security_rating", "C"),
 		ratingWorseThan("reliability_rating", "C"),
 	},
 	"software_quality_medium_issues": {
-		ratingWorseThan("security_review_rating", "B"),
+		ratingWorseThan("security_rating", "B"),
 		ratingWorseThan("reliability_rating", "B"),
 	},
 	"software_quality_low_issues": {
@@ -123,30 +130,31 @@ var metricMapping = map[string][]replacementCondition{
 		ratingWorseThan("reliability_rating", "A"),
 	},
 
-	// new_software_quality_*_issues — the issue table shows the same
-	// metric repeated twice (e.g. "new_security_review_rating <= D +
-	// new_security_review_rating <= D"). Follow the table literally — if
-	// SQC rejects the duplicate, the second CreateCondition surfaces a
-	// warning in the run log.
+	// new_software_quality_*_issues — same semantics as the overall-code
+	// composites above, applied to the new_* rating metrics. The earlier
+	// revision of #143 listed new_security_review_rating duplicated; that
+	// is the hotspot-review-percentage metric (unrelated to issue counts)
+	// and a duplicate metric on the same gate is rejected by SQC anyway.
+	// Pair new_security_rating with new_reliability_rating instead (#232).
 	"new_software_quality_blocker_issues": {
-		ratingWorseThan("new_security_review_rating", "D"),
-		ratingWorseThan("new_security_review_rating", "D"),
+		ratingWorseThan("new_security_rating", "D"),
+		ratingWorseThan("new_reliability_rating", "D"),
 	},
 	"new_software_quality_high_issues": {
-		ratingWorseThan("new_security_review_rating", "C"),
-		ratingWorseThan("new_security_review_rating", "C"),
+		ratingWorseThan("new_security_rating", "C"),
+		ratingWorseThan("new_reliability_rating", "C"),
 	},
 	"new_software_quality_medium_issues": {
-		ratingWorseThan("new_security_review_rating", "B"),
-		ratingWorseThan("new_security_review_rating", "B"),
+		ratingWorseThan("new_security_rating", "B"),
+		ratingWorseThan("new_reliability_rating", "B"),
 	},
 	"new_software_quality_low_issues": {
-		ratingWorseThan("new_security_review_rating", "A"),
-		ratingWorseThan("new_security_review_rating", "A"),
+		ratingWorseThan("new_security_rating", "A"),
+		ratingWorseThan("new_reliability_rating", "A"),
 	},
 	"new_software_quality_info_issues": {
-		ratingWorseThan("new_security_review_rating", "A"),
-		ratingWorseThan("new_security_review_rating", "A"),
+		ratingWorseThan("new_security_rating", "A"),
+		ratingWorseThan("new_reliability_rating", "A"),
 	},
 
 	// Source metrics with no meaningful SQC equivalent — drop the condition.
@@ -166,7 +174,6 @@ var metricMapping = map[string][]replacementCondition{
 	"software_quality_maintainability_issues":                 {},
 	"software_quality_maintainability_remediation_effort":     {},
 	"software_quality_reliability_issues":                     {},
-	"software_quality_reliability_rating":                     {},
 	"software_quality_reliability_remediation_effort":         {},
 	"software_quality_security_issues":                        {},
 	"software_quality_security_remediation_effort":            {},

--- a/go/internal/migrate/gate_metric_mapping.go
+++ b/go/internal/migrate/gate_metric_mapping.go
@@ -191,3 +191,32 @@ func lookupMetricReplacement(sourceMetric string) (targets []replacementConditio
 	t, ok := metricMapping[sourceMetric]
 	return t, ok
 }
+
+// obviousMetricRemaps lists source→target pairs whose mapping is
+// self-evident from the metric names alone. The migration report
+// suppresses callouts for these so the "Near Perfect" Issues section
+// only carries genuinely useful information; gates whose only remaps
+// are obvious stay in Succeeded (green) rather than NearPerfect (yellow).
+var obviousMetricRemaps = map[string]string{
+	"software_quality_reliability_rating":         "reliability_rating",
+	"software_quality_security_rating":            "security_rating",
+	"software_quality_maintainability_rating":     "sqale_rating",
+	"new_software_quality_reliability_rating":     "new_reliability_rating",
+	"new_software_quality_security_rating":        "new_security_rating",
+	"new_software_quality_maintainability_rating": "new_maintainability_rating",
+}
+
+// isObviousMetricRemap reports whether the source metric maps 1:1 to a
+// target metric that is obvious from the names alone (e.g.
+// software_quality_reliability_rating → reliability_rating). Only single-
+// target mappings qualify — composite expansions are never obvious.
+func isObviousMetricRemap(sourceMetric string, targetMetrics []string) bool {
+	if len(targetMetrics) != 1 {
+		return false
+	}
+	want, ok := obviousMetricRemaps[sourceMetric]
+	if !ok {
+		return false
+	}
+	return targetMetrics[0] == want
+}

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -29,10 +29,10 @@ func TestLookupMetricReplacement(t *testing.T) {
 		{"debt ratio rename",
 			"software_quality_maintainability_debt_ratio", true,
 			[]replacementCondition{{Metric: "sqale_debt_ratio"}}},
-		{"composite — software_quality_blocker_issues with fixed <= D",
+		{"composite — software_quality_blocker_issues → security_rating + reliability_rating worse than D",
 			"software_quality_blocker_issues", true,
 			[]replacementCondition{
-				{Metric: "security_review_rating", Op: "GT", Error: "4"},
+				{Metric: "security_rating", Op: "GT", Error: "4"},
 				{Metric: "reliability_rating", Op: "GT", Error: "4"},
 			}},
 		{"composite — software_quality_low_issues with <= A",
@@ -41,12 +41,15 @@ func TestLookupMetricReplacement(t *testing.T) {
 				{Metric: "security_rating", Op: "GT", Error: "1"},
 				{Metric: "reliability_rating", Op: "GT", Error: "1"},
 			}},
-		{"new_software_quality_blocker_issues — duplicate target per issue table",
+		{"new_software_quality_blocker_issues → new_security_rating + new_reliability_rating worse than D",
 			"new_software_quality_blocker_issues", true,
 			[]replacementCondition{
-				{Metric: "new_security_review_rating", Op: "GT", Error: "4"},
-				{Metric: "new_security_review_rating", Op: "GT", Error: "4"},
+				{Metric: "new_security_rating", Op: "GT", Error: "4"},
+				{Metric: "new_reliability_rating", Op: "GT", Error: "4"},
 			}},
+		{"software_quality_reliability_rating → reliability_rating (#232)",
+			"software_quality_reliability_rating", true,
+			[]replacementCondition{{Metric: "reliability_rating"}}},
 		{"new_software_quality_maintainability_rating → new_maintainability_rating",
 			"new_software_quality_maintainability_rating", true,
 			[]replacementCondition{{Metric: "new_maintainability_rating"}}},
@@ -149,17 +152,17 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 	defer mu.Unlock()
 
 	// Expected: 1 (coverage, LT 80) + 1 (new_security_rating, inherited GT 1)
-	//         + 2 (security_review_rating GT 4, reliability_rating GT 4)
+	//         + 2 (security_rating GT 4, reliability_rating GT 4)
 	//         + 0 (contains_ai_code dropped)
 	if len(recorded) != 4 {
 		t.Fatalf("expected 4 create_condition calls, got %d: %+v", len(recorded), recorded)
 	}
 
 	want := map[string]call{
-		"coverage":               {metric: "coverage", op: "LT", errVal: "80"},
-		"new_security_rating":    {metric: "new_security_rating", op: "GT", errVal: "1"},
-		"security_review_rating": {metric: "security_review_rating", op: "GT", errVal: "4"},
-		"reliability_rating":     {metric: "reliability_rating", op: "GT", errVal: "4"},
+		"coverage":            {metric: "coverage", op: "LT", errVal: "80"},
+		"new_security_rating": {metric: "new_security_rating", op: "GT", errVal: "1"},
+		"security_rating":     {metric: "security_rating", op: "GT", errVal: "4"},
+		"reliability_rating":  {metric: "reliability_rating", op: "GT", errVal: "4"},
 	}
 
 	keys := make([]string, 0, len(recorded))
@@ -167,7 +170,7 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 		keys = append(keys, c.metric)
 	}
 	sort.Strings(keys)
-	wantKeys := []string{"coverage", "new_security_rating", "reliability_rating", "security_review_rating"}
+	wantKeys := []string{"coverage", "new_security_rating", "reliability_rating", "security_rating"}
 	for i := range wantKeys {
 		if keys[i] != wantKeys[i] {
 			t.Fatalf("metrics: got %v, want %v", keys, wantKeys)

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -187,3 +187,138 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 		}
 	}
 }
+
+// TestIsObviousMetricRemap covers the suppression list that keeps the
+// migration report's "Near Perfect" Issues section free of self-evident
+// software_quality_*_rating → *_rating callouts.
+func TestIsObviousMetricRemap(t *testing.T) {
+	cases := []struct {
+		name    string
+		source  string
+		targets []string
+		want    bool
+	}{
+		{"software_quality_reliability_rating → reliability_rating",
+			"software_quality_reliability_rating",
+			[]string{"reliability_rating"}, true},
+		{"software_quality_security_rating → security_rating",
+			"software_quality_security_rating",
+			[]string{"security_rating"}, true},
+		{"software_quality_maintainability_rating → sqale_rating",
+			"software_quality_maintainability_rating",
+			[]string{"sqale_rating"}, true},
+		{"new_software_quality_reliability_rating → new_reliability_rating",
+			"new_software_quality_reliability_rating",
+			[]string{"new_reliability_rating"}, true},
+		{"new_software_quality_security_rating → new_security_rating",
+			"new_software_quality_security_rating",
+			[]string{"new_security_rating"}, true},
+		{"new_software_quality_maintainability_rating → new_maintainability_rating",
+			"new_software_quality_maintainability_rating",
+			[]string{"new_maintainability_rating"}, true},
+		{"aica suffix drop is NOT obvious enough to suppress",
+			"reliability_rating_with_aica",
+			[]string{"reliability_rating"}, false},
+		{"composite expansion is never obvious",
+			"software_quality_blocker_issues",
+			[]string{"security_rating", "reliability_rating"}, false},
+		{"drop (no targets) is not a remap",
+			"contains_ai_code",
+			nil, false},
+		{"unrelated 1:1 mapping (debt ratio) is not in the suppression list",
+			"software_quality_maintainability_debt_ratio",
+			[]string{"sqale_debt_ratio"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isObviousMetricRemap(tc.source, tc.targets); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestAddGateConditionsCollapsesCollisions covers #234: when a composite
+// expansion and a direct passthrough both target the same SQC metric, the
+// migrator must POST a single create_condition for that metric, holding the
+// more-stringent threshold.
+//
+// Source mix:
+//   - software_quality_blocker_issues > 0  →  security_rating GT 4 + reliability_rating GT 4
+//   - reliability_rating worse than B      →  reliability_rating GT 2  (direct, more stringent)
+//   - software_quality_medium_issues > 0   →  security_rating GT 2 + reliability_rating GT 2
+//
+// After collapse:
+//   - security_rating GT 2     (medium beats blocker)
+//   - reliability_rating GT 2  (direct == medium, ties — first wins; same value)
+func TestAddGateConditionsCollapsesCollisions(t *testing.T) {
+	type call struct{ metric, op, errVal string }
+	var (
+		mu       sync.Mutex
+		recorded []call
+	)
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		recorded = append(recorded, call{
+			metric: r.FormValue("metric"),
+			op:     r.FormValue("op"),
+			errVal: r.FormValue("error"),
+		})
+		mu.Unlock()
+		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
+	})
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("getGateConditions")
+	payload := map[string]any{
+		"gate_name":          "Custom",
+		"sonarcloud_org_key": "cloud-org1",
+		"cloud_gate_id":      "42",
+		"was_preexisting":    false,
+		"conditions": []map[string]any{
+			{"metric": "software_quality_blocker_issues", "op": "GT", "error": "0"},
+			{"metric": "reliability_rating", "op": "GT", "error": "2"},
+			{"metric": "software_quality_medium_issues", "op": "GT", "error": "0"},
+		},
+	}
+	b, _ := json.Marshal(payload)
+	w.WriteOne(b)
+
+	if err := runAddGateConditions(context.Background(), e); err != nil {
+		t.Fatalf("runAddGateConditions: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if len(recorded) != 2 {
+		t.Fatalf("expected 2 create_condition calls after collapse, got %d: %+v", len(recorded), recorded)
+	}
+	want := map[string]call{
+		"security_rating":    {metric: "security_rating", op: "GT", errVal: "2"},
+		"reliability_rating": {metric: "reliability_rating", op: "GT", errVal: "2"},
+	}
+	for _, c := range recorded {
+		w := want[c.metric]
+		if w.metric == "" {
+			t.Errorf("unexpected create_condition call: %+v", c)
+			continue
+		}
+		if c.op != w.op || c.errVal != w.errVal {
+			t.Errorf("%s: got op=%q error=%q, want op=%q error=%q",
+				c.metric, c.op, c.errVal, w.op, w.errVal)
+		}
+	}
+}

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -145,6 +145,12 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 			var conditions []map[string]any
 			json.Unmarshal(conditionsRaw, &conditions)
 
+			// First pass: expand every source condition into zero or more
+			// target conditions, recording notes for drops / remaps. The
+			// actual POSTs are deferred so the resolver (#234) can collapse
+			// collisions across multiple source conditions before any HTTP
+			// traffic.
+			var pending []targetCondition
 			for _, cond := range conditions {
 				metric, _ := cond["metric"].(string)
 				op, _ := cond["op"].(string)
@@ -170,7 +176,15 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 					for _, repl := range targets {
 						targetMetrics = append(targetMetrics, repl.Metric)
 					}
-					recordGateConditionNote(notesW, gateIDStr, gateName, "remapped", metric, targetMetrics)
+					// Suppress the sidecar note (and therefore the
+					// report's "Near Perfect" Issues line + yellow
+					// classification) for remaps that are obvious from
+					// the metric names alone — e.g. software_quality_*
+					// _rating → its same-axis SQC equivalent. Operators
+					// don't need a callout for those.
+					if !isObviousMetricRemap(metric, targetMetrics) {
+						recordGateConditionNote(notesW, gateIDStr, gateName, "remapped", metric, targetMetrics)
+					}
 				}
 
 				for _, repl := range targets {
@@ -182,20 +196,30 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 					if effErr == "" {
 						effErr = errorVal
 					}
-					e.Logger.Debug("gate api call: POST /api/qualitygates/create_condition",
-						"gate_id", gateID, "metric", repl.Metric, "op", effOp, "error", effErr, "org", orgKey,
-						"source_metric", metric)
-					_, err := e.Cloud.QualityGates.CreateCondition(ctx, cloud.CreateConditionParams{
-						GateID: gateID, Organization: orgKey,
-						Metric: repl.Metric, Op: effOp, Error: effErr,
+					pending = append(pending, targetCondition{
+						Metric:       repl.Metric,
+						Op:           effOp,
+						Error:        effErr,
+						SourceMetric: metric,
 					})
-					if err != nil {
-						counter.Fail()
-						logAPIWarn(e.Logger, "addGateConditions failed", err,
-							"metric", repl.Metric, "source_metric", metric)
-					} else {
-						counter.Success()
-					}
+				}
+			}
+
+			// Second pass: collapse collisions per #234, then POST.
+			for _, tc := range resolveTargetConditions(pending) {
+				e.Logger.Debug("gate api call: POST /api/qualitygates/create_condition",
+					"gate_id", gateID, "metric", tc.Metric, "op", tc.Op, "error", tc.Error, "org", orgKey,
+					"source_metric", tc.SourceMetric)
+				_, err := e.Cloud.QualityGates.CreateCondition(ctx, cloud.CreateConditionParams{
+					GateID: gateID, Organization: orgKey,
+					Metric: tc.Metric, Op: tc.Op, Error: tc.Error,
+				})
+				if err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "addGateConditions failed", err,
+						"metric", tc.Metric, "source_metric", tc.SourceMetric)
+				} else {
+					counter.Success()
 				}
 			}
 			return nil


### PR DESCRIPTION
## Summary

Three related fixes to Quality Gate migration, all on this branch.

### Closes #232 — incorrect QG metric mappings
- `software_quality_reliability_rating` was incorrectly listed as having no SQC equivalent (drops + bogus report line). It now maps to `reliability_rating`, matching the `_with_aica` / `_without_aica` variants.
- The `software_quality_*_issues` composites used `security_review_rating` (% of hotspots reviewed — unrelated to issue counts), producing a spurious *"Security Review Rating worse than D"* on the migrated gate. Replaced with `security_rating` for blocker/high/medium, paired with `reliability_rating` at matching thresholds.
- Applied the same fix to `new_software_quality_*_issues` (which additionally listed `new_security_review_rating` duplicated as both targets — clearly unintended).

### Closes #234 — collapse colliding QG conditions to the most stringent
When multiple source conditions target the same SQC metric (e.g. a `software_quality_blocker_issues` composite plus a direct `reliability_rating` passthrough), the migrator now POSTs a single `create_condition` holding the more stringent threshold rather than sending both and letting SQC reject the duplicate. `addGateConditions` builds the full target set first, runs it through `resolveTargetConditions`, then POSTs.

### Suppress obvious remaps from the migration report
The "Near Perfect" Issues list no longer surfaces the six self-evident `(new_)?software_quality_*_rating → (new_)?*_rating` remaps. A gate whose only remaps are obvious stays green (Succeeded) instead of being demoted to NearPerfect (yellow).

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] New tests: `TestIsObviousMetricRemap`, `TestResolveTargetConditions`, `TestAddGateConditionsCollapsesCollisions`
- [x] Updated `TestLookupMetricReplacement` and `TestAddGateConditionsAppliesMetricMapping` for the corrected mappings
- [ ] Visual check of a generated PDF against a real migration with `software_quality_*` conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)