### PR TITLE
Render full QG condition mapping in the PDF report

### DIFF
--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -163,30 +163,23 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 				if mapped && len(targets) == 0 {
 					e.Logger.Warn("addGateConditions: source metric has no SonarQube Cloud equivalent — condition skipped (#143)",
 						"gate", gateName, "metric", metric, "op", op, "error", errorVal)
-					recordGateConditionNote(notesW, gateIDStr, gateName, "dropped", metric, nil)
+					recordGateConditionNote(notesW, gateIDStr, gateName, gateConditionNoteInput{
+						Action:       "dropped",
+						SourceMetric: metric,
+						SourceOp:     op,
+						SourceError:  errorVal,
+					})
 					counter.Fail()
 					continue
 				}
 				if !mapped {
 					targets = []replacementCondition{{Metric: metric}}
-				} else {
-					e.Logger.Info("addGateConditions: source metric remapped to SonarQube Cloud equivalent(s) (#143)",
-						"gate", gateName, "source_metric", metric, "target_metrics", targets)
-					targetMetrics := make([]string, 0, len(targets))
-					for _, repl := range targets {
-						targetMetrics = append(targetMetrics, repl.Metric)
-					}
-					// Suppress the sidecar note (and therefore the
-					// report's "Near Perfect" Issues line + yellow
-					// classification) for remaps that are obvious from
-					// the metric names alone — e.g. software_quality_*
-					// _rating → its same-axis SQC equivalent. Operators
-					// don't need a callout for those.
-					if !isObviousMetricRemap(metric, targetMetrics) {
-						recordGateConditionNote(notesW, gateIDStr, gateName, "remapped", metric, targetMetrics)
-					}
 				}
 
+				// Compute effective target conditions (each target inherits
+				// the source's op/threshold unless the mapping table
+				// overrides them, e.g. composite expansions).
+				targetConds := make([]targetCondition, 0, len(targets))
 				for _, repl := range targets {
 					effOp := repl.Op
 					if effOp == "" {
@@ -196,13 +189,39 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 					if effErr == "" {
 						effErr = errorVal
 					}
-					pending = append(pending, targetCondition{
+					targetConds = append(targetConds, targetCondition{
 						Metric:       repl.Metric,
 						Op:           effOp,
 						Error:        effErr,
 						SourceMetric: metric,
 					})
 				}
+
+				if mapped {
+					e.Logger.Info("addGateConditions: source metric remapped to SonarQube Cloud equivalent(s) (#143)",
+						"gate", gateName, "source_metric", metric, "target_metrics", targets)
+					targetMetrics := make([]string, 0, len(targetConds))
+					for _, tc := range targetConds {
+						targetMetrics = append(targetMetrics, tc.Metric)
+					}
+					// Suppress the sidecar note (and therefore the
+					// report's "Near Perfect" Issues line + yellow
+					// classification) for remaps that are obvious from
+					// the metric names alone — e.g. software_quality_*
+					// _rating → its same-axis SQC equivalent. Operators
+					// don't need a callout for those.
+					if !isObviousMetricRemap(metric, targetMetrics) {
+						recordGateConditionNote(notesW, gateIDStr, gateName, gateConditionNoteInput{
+							Action:       "remapped",
+							SourceMetric: metric,
+							SourceOp:     op,
+							SourceError:  errorVal,
+							Targets:      targetConds,
+						})
+					}
+				}
+
+				pending = append(pending, targetConds...)
 			}
 
 			// Second pass: collapse collisions per #234, then POST.
@@ -228,22 +247,46 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 	return err
 }
 
-// recordGateConditionNote appends a sidecar JSONL entry describing a
-// per-condition mapping decision (a metric remap per #143 or a dropped
-// condition with no SQC equivalent). The summary report reads this file to
-// mark the parent quality gate as Partial.
-func recordGateConditionNote(w *common.ChunkWriter, cloudGateID, gateName, action, sourceMetric string, targetMetrics []string) {
+// gateConditionNoteInput is the per-condition decision payload written to
+// the addGateConditions.notes sidecar JSONL. Carrying source op/threshold
+// and per-target op/threshold lets the report render the full #143-style
+// mapping (e.g. "software_quality_blocker_issues > 0 --> security_rating
+// <= D") rather than just metric names.
+type gateConditionNoteInput struct {
+	Action       string            // "remapped" | "dropped"
+	SourceMetric string            // source SQS metric
+	SourceOp     string            // source condition op (GT, LT, ...)
+	SourceError  string            // source threshold
+	Targets      []targetCondition // target conditions; empty for "dropped"
+}
+
+// recordGateConditionNote appends a sidecar JSONL entry describing one
+// per-condition mapping decision. The summary report reads this file to
+// classify the parent gate (NearPerfect / Partial) and render Issues.
+func recordGateConditionNote(w *common.ChunkWriter, cloudGateID, gateName string, n gateConditionNoteInput) {
 	if w == nil || cloudGateID == "" {
 		return
 	}
 	rec := map[string]any{
 		"cloud_gate_id": cloudGateID,
 		"gate_name":     gateName,
-		"action":        action, // "remapped" | "dropped"
-		"source_metric": sourceMetric,
+		"action":        n.Action,
+		"source": map[string]string{
+			"metric": n.SourceMetric,
+			"op":     n.SourceOp,
+			"error":  n.SourceError,
+		},
 	}
-	if len(targetMetrics) > 0 {
-		rec["target_metrics"] = targetMetrics
+	if len(n.Targets) > 0 {
+		out := make([]map[string]string, 0, len(n.Targets))
+		for _, t := range n.Targets {
+			out = append(out, map[string]string{
+				"metric": t.Metric,
+				"op":     t.Op,
+				"error":  t.Error,
+			})
+		}
+		rec["targets"] = out
 	}
 	b, _ := json.Marshal(rec)
 	_ = w.WriteOne(b)

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -593,17 +593,17 @@ func TestCollectSummaryQualityGateMappingDedupesAcrossSourceOrgs(t *testing.T) {
 	notesDir := filepath.Join(runDir, "addGateConditions.notes")
 	os.MkdirAll(notesDir, 0o755)
 	dup := map[string]any{
-		"cloud_gate_id":  "42",
-		"gate_name":      "Shared QG",
-		"action":         "remapped",
-		"source_metric":  "new_security_rating_with_aica",
-		"target_metrics": []string{"new_security_rating"},
+		"cloud_gate_id": "42",
+		"gate_name":     "Shared QG",
+		"action":        "remapped",
+		"source":        map[string]string{"metric": "new_security_rating_with_aica", "op": "GT", "error": "1"},
+		"targets":       []map[string]string{{"metric": "new_security_rating", "op": "GT", "error": "1"}},
 	}
 	dupDropped := map[string]any{
 		"cloud_gate_id": "42",
 		"gate_name":     "Shared QG",
 		"action":        "dropped",
-		"source_metric": "contains_ai_code",
+		"source":        map[string]string{"metric": "contains_ai_code", "op": "GT", "error": "0"},
 	}
 	f, _ := os.Create(filepath.Join(notesDir, "results.1.jsonl"))
 	for i := 0; i < 3; i++ {
@@ -625,12 +625,14 @@ func TestCollectSummaryQualityGateMappingDedupesAcrossSourceOrgs(t *testing.T) {
 		t.Fatalf("expected 1 Partial gate, got %d", len(gates.Partial))
 	}
 	joined := strings.Join(gates.Partial[0].Issues, "\n")
-	// Each remap/dropped metric should appear exactly once.
-	if got := strings.Count(joined, "new_security_rating_with_aica --> new_security_rating"); got != 1 {
+	// Each remap / dropped condition should appear exactly once, with the
+	// full #143-style "metric <= LETTER" notation on both sides for rating
+	// conditions.
+	if got := strings.Count(joined, "new_security_rating_with_aica <= A --> new_security_rating <= A"); got != 1 {
 		t.Errorf("expected remap line exactly once, got %d occurrences in:\n%s", got, joined)
 	}
-	if got := strings.Count(joined, "contains_ai_code"); got != 1 {
-		t.Errorf("expected dropped metric exactly once, got %d occurrences in:\n%s", got, joined)
+	if got := strings.Count(joined, "contains_ai_code > 0"); got != 1 {
+		t.Errorf("expected dropped condition exactly once, got %d occurrences in:\n%s", got, joined)
 	}
 }
 
@@ -652,17 +654,17 @@ func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
 	os.MkdirAll(notesDir, 0o755)
 	lines := []map[string]any{
 		{
-			"cloud_gate_id":  "42",
-			"gate_name":      "Backend QG",
-			"action":         "remapped",
-			"source_metric":  "new_security_rating_with_aica",
-			"target_metrics": []string{"new_security_rating"},
+			"cloud_gate_id": "42",
+			"gate_name":     "Backend QG",
+			"action":        "remapped",
+			"source":        map[string]string{"metric": "new_security_rating_with_aica", "op": "GT", "error": "1"},
+			"targets":       []map[string]string{{"metric": "new_security_rating", "op": "GT", "error": "1"}},
 		},
 		{
 			"cloud_gate_id": "42",
 			"gate_name":     "Backend QG",
 			"action":        "dropped",
-			"source_metric": "contains_ai_code",
+			"source":        map[string]string{"metric": "contains_ai_code", "op": "GT", "error": "0"},
 		},
 	}
 	f, _ := os.Create(filepath.Join(notesDir, "results.1.jsonl"))
@@ -701,19 +703,19 @@ func TestCollectSummaryQualityGateMetricMappingMovesToPartial(t *testing.T) {
 		t.Errorf("expected Backend QG in Partial, got %q", item.Name)
 	}
 	joined := strings.Join(item.Issues, " | ")
-	if !strings.Contains(joined, "new_security_rating_with_aica --> new_security_rating") {
-		t.Errorf("expected remap detail (with -->) in Issues, got %q", joined)
+	if !strings.Contains(joined, "new_security_rating_with_aica <= A --> new_security_rating <= A") {
+		t.Errorf("expected remap detail (full condition --> full condition) in Issues, got %q", joined)
 	}
-	if !strings.Contains(joined, "contains_ai_code") {
-		t.Errorf("expected dropped metric in Issues, got %q", joined)
+	if !strings.Contains(joined, "contains_ai_code > 0") {
+		t.Errorf("expected dropped condition in Issues, got %q", joined)
 	}
 	if strings.Contains(joined, "#143") {
 		t.Errorf("did not expect #143 reference in user-facing message, got %q", joined)
 	}
-	// Each metric entry should be on its own line within an Issues message.
-	if !strings.Contains(joined, "\nnew_security_rating_with_aica -->") &&
+	// Each condition entry should be on its own line within an Issues message.
+	if !strings.Contains(joined, "\nnew_security_rating_with_aica <=") &&
 		!strings.HasPrefix(item.Issues[0], "Some metrics were mapped") {
-		t.Errorf("expected newline-separated metric list, got %q", joined)
+		t.Errorf("expected newline-separated condition list, got %q", joined)
 	}
 }
 
@@ -735,11 +737,11 @@ func TestCollectSummaryQualityGateRemapOnlyMovesToNearPerfect(t *testing.T) {
 	os.MkdirAll(notesDir, 0o755)
 	lines := []map[string]any{
 		{
-			"cloud_gate_id":  "77",
-			"gate_name":      "Ratings QG",
-			"action":         "remapped",
-			"source_metric":  "new_security_rating_with_aica",
-			"target_metrics": []string{"new_security_rating"},
+			"cloud_gate_id": "77",
+			"gate_name":     "Ratings QG",
+			"action":        "remapped",
+			"source":        map[string]string{"metric": "new_security_rating_with_aica", "op": "GT", "error": "1"},
+			"targets":       []map[string]string{{"metric": "new_security_rating", "op": "GT", "error": "1"}},
 		},
 	}
 	f, _ := os.Create(filepath.Join(notesDir, "results.1.jsonl"))
@@ -772,8 +774,8 @@ func TestCollectSummaryQualityGateRemapOnlyMovesToNearPerfect(t *testing.T) {
 			succeededNames(gates.NearPerfect))
 	}
 	joined := strings.Join(gates.NearPerfect[0].Issues, " | ")
-	if !strings.Contains(joined, "new_security_rating_with_aica --> new_security_rating") {
-		t.Errorf("expected remap detail in NearPerfect Issues, got %q", joined)
+	if !strings.Contains(joined, "new_security_rating_with_aica <= A --> new_security_rating <= A") {
+		t.Errorf("expected full-condition remap detail in NearPerfect Issues, got %q", joined)
 	}
 }
 

--- a/go/internal/report/summary/gate_condition_format.go
+++ b/go/internal/report/summary/gate_condition_format.go
@@ -1,0 +1,81 @@
+package summary
+
+import (
+	"fmt"
+	"strings"
+)
+
+// isRatingMetric reports whether the metric's threshold is the
+// integer-encoded rating value 1..5 (A..E). Quality-gate conditions on
+// rating metrics are expressed on the wire as `GT <numeric>` but the
+// SonarQube documentation in #143 reads them as `metric <= <letter>`.
+// The report renders the documentation form so operators don't have to
+// translate.
+//
+// Detection is suffix-based so it covers the full family — the canonical
+// names (reliability_rating, security_rating, ...), the new_* variants,
+// the software_quality_*_rating MQR-mode aliases, and the AICA suffix
+// variants — without enumerating ~40 metric names.
+func isRatingMetric(metric string) bool {
+	base := metric
+	if s := strings.TrimSuffix(base, "_with_aica"); s != base {
+		base = s
+	} else if s := strings.TrimSuffix(base, "_without_aica"); s != base {
+		base = s
+	}
+	return strings.HasSuffix(base, "_rating")
+}
+
+// ratingLetter converts the numeric threshold the API uses (1..5) to the
+// A..E letter that documentation and the SonarQube UI both use.
+func ratingLetter(errorVal string) (string, bool) {
+	switch errorVal {
+	case "1":
+		return "A", true
+	case "2":
+		return "B", true
+	case "3":
+		return "C", true
+	case "4":
+		return "D", true
+	case "5":
+		return "E", true
+	}
+	return "", false
+}
+
+// formatGateCondition renders one quality-gate condition in the #143
+// notation: `metric <= LETTER` for a rating condition expressed as
+// `GT numeric`, the literal `metric OP value` form otherwise.
+//
+// The function never panics on unknown ops or non-numeric thresholds —
+// it falls back to whatever the input carried so the user still sees
+// something self-descriptive.
+func formatGateCondition(metric, op, errorVal string) string {
+	if isRatingMetric(metric) && op == "GT" {
+		if letter, ok := ratingLetter(errorVal); ok {
+			return fmt.Sprintf("%s <= %s", metric, letter)
+		}
+	}
+	return fmt.Sprintf("%s %s %s", metric, opSymbol(op), errorVal)
+}
+
+// opSymbol maps an API op token to a human-readable symbol. Unknown
+// tokens are returned as-is so the operator at least sees the raw value.
+func opSymbol(op string) string {
+	switch op {
+	case "GT":
+		return ">"
+	case "LT":
+		return "<"
+	case "GTE":
+		return ">="
+	case "LTE":
+		return "<="
+	case "EQ":
+		return "="
+	case "NE":
+		return "!="
+	}
+	return op
+}

--- a/go/internal/report/summary/gate_condition_format_test.go
+++ b/go/internal/report/summary/gate_condition_format_test.go
@@ -1,0 +1,40 @@
+package summary
+
+import "testing"
+
+func TestFormatGateCondition(t *testing.T) {
+	cases := []struct {
+		name   string
+		metric string
+		op     string
+		errVal string
+		want   string
+	}{
+		// Rating metrics with GT — render in #143 letter notation.
+		{"rating GT 1 → <= A", "new_security_rating", "GT", "1", "new_security_rating <= A"},
+		{"rating GT 2 → <= B", "reliability_rating", "GT", "2", "reliability_rating <= B"},
+		{"rating GT 3 → <= C", "security_rating", "GT", "3", "security_rating <= C"},
+		{"rating GT 4 → <= D", "sqale_rating", "GT", "4", "sqale_rating <= D"},
+		{"new rating GT 4 → <= D", "new_maintainability_rating", "GT", "4", "new_maintainability_rating <= D"},
+
+		// Non-rating metric: literal notation regardless of op.
+		{"issue count GT 0 → > 0", "new_software_quality_security_issues", "GT", "0", "new_software_quality_security_issues > 0"},
+		{"coverage LT 80 → < 80", "coverage", "LT", "80", "coverage < 80"},
+		{"duplicated lines GT 2 → > 2", "duplicated_lines_density", "GT", "2", "duplicated_lines_density > 2"},
+
+		// Defensive: rating metric with non-GT op — fall through to literal.
+		{"rating LT 4 (not standard) → literal", "security_rating", "LT", "4", "security_rating < 4"},
+		// Defensive: rating metric with GT but non-numeric threshold.
+		{"rating GT with garbage threshold → literal", "security_rating", "GT", "X", "security_rating > X"},
+		// Defensive: unknown op — pass through verbatim.
+		{"unknown op stays as-is", "coverage", "FOO", "80", "coverage FOO 80"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := formatGateCondition(tc.metric, tc.op, tc.errVal)
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/go/internal/report/summary/gate_notes.go
+++ b/go/internal/report/summary/gate_notes.go
@@ -3,7 +3,6 @@ package summary
 import (
 	"bufio"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -12,16 +11,27 @@ import (
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
 
+// gateConditionRef is one (metric, op, threshold) tuple as recorded in the
+// sidecar JSONL. The migrator emits one for the source side and one per
+// target produced by the metric mapping (composite expansions can have
+// several).
+type gateConditionRef struct {
+	Metric string `json:"metric"`
+	Op     string `json:"op"`
+	Error  string `json:"error"`
+}
+
 // gateMappingNote is a single per-condition decision recorded by
 // addGateConditions in its sidecar JSONL (addGateConditions.notes/). It
 // describes either a metric remap (#143) or a dropped condition that had no
-// SonarQube Cloud equivalent.
+// SonarQube Cloud equivalent. Source + Targets carry the full conditions
+// (not just metric names) so the report can render them in #143 notation.
 type gateMappingNote struct {
-	CloudGateID   string   `json:"cloud_gate_id"`
-	GateName      string   `json:"gate_name"`
-	Action        string   `json:"action"` // "remapped" | "dropped"
-	SourceMetric  string   `json:"source_metric"`
-	TargetMetrics []string `json:"target_metrics,omitempty"`
+	CloudGateID string             `json:"cloud_gate_id"`
+	GateName    string             `json:"gate_name"`
+	Action      string             `json:"action"` // "remapped" | "dropped"
+	Source      gateConditionRef   `json:"source"`
+	Targets     []gateConditionRef `json:"targets,omitempty"`
 }
 
 // gateNoteSummary captures the per-gate outcome of addGateConditions: the
@@ -88,24 +98,30 @@ func collectGateMappingNotes(runDir string) map[string]gateNoteSummary {
 			// more than once when the same SQS source gate is mapped to a
 			// single SQC org from multiple source orgs (gates.csv carries
 			// one row per source-org pairing, all sharing the same cloud
-			// gate id). Deduplicate by (action, source, targets) so the
+			// gate id). Deduplicate by (action, source, target) so the
 			// Details column shows each mapping exactly once.
 			switch note.Action {
 			case "remapped":
-				targets := strings.Join(note.TargetMetrics, ", ")
-				key := note.SourceMetric + "→" + targets
-				if ag.remappedSeen[key] {
-					continue
+				sourceStr := formatGateCondition(note.Source.Metric, note.Source.Op, note.Source.Error)
+				// Composite mappings produce several targets; emit one
+				// "source --> target" line per target so a multi-row
+				// expansion is visually obvious (per #234 follow-up).
+				for _, t := range note.Targets {
+					targetStr := formatGateCondition(t.Metric, t.Op, t.Error)
+					line := sourceStr + " --> " + targetStr
+					if ag.remappedSeen[line] {
+						continue
+					}
+					ag.remappedSeen[line] = true
+					ag.remapped = append(ag.remapped, line)
 				}
-				ag.remappedSeen[key] = true
-				ag.remapped = append(ag.remapped,
-					fmt.Sprintf("%s --> %s", note.SourceMetric, targets))
 			case "dropped":
-				if ag.droppedSeen[note.SourceMetric] {
+				sourceStr := formatGateCondition(note.Source.Metric, note.Source.Op, note.Source.Error)
+				if ag.droppedSeen[sourceStr] {
 					continue
 				}
-				ag.droppedSeen[note.SourceMetric] = true
-				ag.dropped = append(ag.dropped, note.SourceMetric)
+				ag.droppedSeen[sourceStr] = true
+				ag.dropped = append(ag.dropped, sourceStr)
 			}
 		}
 		f.Close()


### PR DESCRIPTION
## Summary

The "Near Perfect" Issues column previously showed only metric names ("new_software_quality_security_issues --> new_security_rating"), which hides the op/threshold transformation #143 actually documents. Each line now carries the full condition on both sides in #143 notation:

```
new_software_quality_security_issues > 0 --> new_security_rating <= A
software_quality_blocker_issues > 0 --> security_rating <= D
software_quality_blocker_issues > 0 --> reliability_rating <= D
```

- The `addGateConditions.notes` sidecar JSONL schema now carries the source `{metric, op, error}` and a `targets[]` array of `{metric, op, error}` instead of bare metric-name lists.
- Composite expansions render as one line per target.
- Rating conditions (`GT` with a 1..5 threshold) render as `metric <= LETTER`; everything else as literal `metric OP value`.
- `isRatingMetric` is suffix-based so it covers canonical names, `new_*`, `software_quality_*_rating`, and the AICA family without an enumerated list.
- Dropped conditions now render the full source condition rather than just the metric name.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] New `TestFormatGateCondition` covers rating + literal + defensive paths
- [x] Existing collect tests updated for the new JSONL schema and full-condition assertions
- [ ] Visual check of a generated PDF against a real migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)