### PR TITLE
Issue #246 accept --config on predictive-report

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,15 +223,20 @@ go run . predictive-report --export_directory ./files/
 
 # Built binary
 sonar-migration-tool predictive-report --export_directory ./files/
+
+# Or read export_directory from the same JSON config used by extract / migrate (#246)
+sonar-migration-tool predictive-report --config extract-config.json
 ```
 
-Output: `<export_directory>/predictive_migration_summary.pdf`. Two
-classes of outcomes from a real migrate run are excluded because they
-cannot be predicted ahead of time:
+Output: `<export_directory>/predictive_migration_summary.pdf`. The
+`--config` flag accepts the same configuration file shape as `extract`
+or `migrate` — only the `export_directory` field is read. An explicit
+`--export_directory` flag overrides whatever the config file carries.
 
-- SonarQube Cloud API errors or rate limiting.
-- Global settings — discovery of SQC-supported settings is dynamic, so
-  the Global Settings section is omitted from the predictive report.
+The Global Settings section is included with the SQS-only settings
+predicted to be Skipped (Setting Key column, sorted alphabetically).
+SonarQube Cloud API errors or rate-limiting cannot be predicted ahead
+of time, so they have no row in the Failed bucket.
 
 **Reset** — deletes all content in every org in the enterprise:
 ```bash

--- a/go/cmd/predictive_report.go
+++ b/go/cmd/predictive_report.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/predict"
 	"github.com/spf13/cobra"
 )
@@ -17,21 +18,57 @@ run cannot be predicted and are omitted (#235):
   - SonarQube Cloud API errors / rate limiting.
   - Global settings (SQC-support detection is dynamic).
 
+The export directory can be supplied directly via --export_directory or
+read from the same JSON config file the extract / migrate commands use
+via --config (issue #246).
+
 The PDF is written to <export_directory>/predictive_migration_summary.pdf.`,
 	RunE: runPredictiveReport,
 }
 
 func init() {
 	f := predictiveReportCmd.Flags()
-	f.String("export_directory", "/app/files/", "Root directory containing extract data and the mapping CSVs")
+	f.String("config", "", "Path to JSON configuration file (same shape as extract --config); export_directory is read from it")
+	f.String("export_directory", "", "Root directory containing extract data and the mapping CSVs")
 }
 
 func runPredictiveReport(cmd *cobra.Command, args []string) error {
-	exportDir, _ := cmd.Flags().GetString("export_directory")
+	exportDir, err := resolvePredictiveReportExportDir(cmd)
+	if err != nil {
+		return err
+	}
 	pdfPath, err := predict.GeneratePredictiveReport(exportDir)
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Predictive PDF report: %s\n", pdfPath)
 	return nil
+}
+
+// resolvePredictiveReportExportDir decides where to read the migration
+// data from, applying the same config-vs-flag precedence the extract
+// and migrate commands use:
+//
+//   - --config <path> loads export_directory from the JSON file (#246).
+//   - --export_directory always wins when explicitly set on the CLI.
+//   - Empty result → returns an error so the caller surfaces a clear
+//     message.
+func resolvePredictiveReportExportDir(cmd *cobra.Command) (string, error) {
+	exportDir, _ := cmd.Flags().GetString("export_directory")
+	configFile, _ := cmd.Flags().GetString("config")
+
+	if configFile != "" {
+		cfg, err := extract.LoadExtractConfigFile(configFile)
+		if err != nil {
+			return "", fmt.Errorf("loading config %s: %w", configFile, err)
+		}
+		if !cmd.Flags().Changed("export_directory") {
+			exportDir = cfg.ExportDirectory
+		}
+	}
+
+	if exportDir == "" {
+		return "", fmt.Errorf("--export_directory is required (either as a CLI flag or via --config)")
+	}
+	return exportDir, nil
 }

--- a/go/cmd/predictive_report_test.go
+++ b/go/cmd/predictive_report_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newPredictiveReportTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "predictive-report"}
+	f := cmd.Flags()
+	f.String("config", "", "")
+	f.String("export_directory", "", "")
+	return cmd
+}
+
+func writePredictiveConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "predict-cfg-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// Issue #246: --config should populate export_directory from the JSON.
+func TestPredictiveReport_ConfigFileSuppliesExportDirectory(t *testing.T) {
+	path := writePredictiveConfigFile(t, `{
+		"url": "https://sqs.example.com",
+		"token": "ignored",
+		"export_directory": "/cfg/files"
+	}`)
+
+	cmd := newPredictiveReportTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	got, err := resolvePredictiveReportExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolvePredictiveReportExportDir: %v", err)
+	}
+	if got != "/cfg/files" {
+		t.Errorf("ExportDirectory: got %q, want /cfg/files", got)
+	}
+}
+
+// Issue #246: --export_directory on the CLI takes precedence over the
+// value in --config — same precedence the extract / migrate commands use.
+func TestPredictiveReport_FlagOverridesConfigFile(t *testing.T) {
+	path := writePredictiveConfigFile(t, `{
+		"export_directory": "/cfg/files"
+	}`)
+
+	cmd := newPredictiveReportTestCmd()
+	_ = cmd.Flags().Set("config", path)
+	_ = cmd.Flags().Set("export_directory", "/cli/files")
+
+	got, err := resolvePredictiveReportExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolvePredictiveReportExportDir: %v", err)
+	}
+	if got != "/cli/files" {
+		t.Errorf("ExportDirectory: CLI flag should win, got %q", got)
+	}
+}
+
+// Without --config and without --export_directory, the command should
+// surface a clear error instead of silently picking an empty dir.
+func TestPredictiveReport_RequiresExportDir(t *testing.T) {
+	cmd := newPredictiveReportTestCmd()
+	if _, err := resolvePredictiveReportExportDir(cmd); err == nil {
+		t.Error("expected error when neither --export_directory nor --config supplied")
+	}
+}
+
+// Pointing --config at a non-existent file should produce a wrapped
+// error so the operator can act on it.
+func TestPredictiveReport_MissingConfigFileError(t *testing.T) {
+	cmd := newPredictiveReportTestCmd()
+	_ = cmd.Flags().Set("config", "/path/that/does/not/exist.json")
+
+	if _, err := resolvePredictiveReportExportDir(cmd); err == nil {
+		t.Error("expected error when --config points at a missing file")
+	}
+}


### PR DESCRIPTION
## Summary

`predictive-report` now accepts a `--config <path>` flag that points at the same JSON config file `extract` and `migrate` use. The `export_directory` field is read from the file when `--export_directory` is not explicitly passed on the CLI. An explicit `--export_directory` flag still wins, matching the precedence the other commands use.

Closes #246.

## Test plan

- [x] \`go build ./...\` clean
- [x] New \`cmd/predictive_report_test.go\` covers config-only, flag-overrides-config, missing-config error, and the require-export-dir error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)