### PR TITLE
Issue #244 exhaustive global-settings coverage in reports

### DIFF
--- a/go/internal/migrate/internal_settings.go
+++ b/go/internal/migrate/internal_settings.go
@@ -1,0 +1,37 @@
+package migrate
+
+import "strings"
+
+// internalSettingPrefixes lists SonarQube Server setting key prefixes
+// that are considered "internal" — server-emitted metadata, plugin
+// manifest fields, license / consent flags, etc. — and should never
+// appear in the migration report. Ported from sonar-tools'
+// _SQ_INTERNAL_SETTINGS (see okorach/sonar-tools/sonar/settings.py).
+//
+// The filter is intentionally narrower than the curated sqsOnlySettings
+// + sqsOnlyPrefixes lists which classify "SQS-only" settings for the
+// report (those still surface as Skipped with explanatory notes). An
+// internal setting is one we want to drop entirely from extract /
+// report consideration.
+var internalSettingPrefixes = []string{
+	"sonaranalyzer",                  // covers sonaranalyzer-cs.*, sonaranalyzer-vbnet.*, sonaranalyzer.security.cs.*, ...
+	"sonar.updatecenter",             // server update-center plumbing
+	"sonar.plugins.risk.consent",     // license / risk-acceptance flag
+	"sonar.core.id",                  // server identity
+	"sonar.core.startTime",           // read-only server timestamp
+	"sonar.plsql.jdbc.driver.class",  // server JDBC plumbing
+	"sonar.documentation.baseUrl",    // server-only doc URL
+}
+
+// IsInternalSqsSetting reports whether the named SonarQube Server
+// global / project setting is internal and should be excluded from the
+// migration pipeline (extract, real migrate, and predictive report).
+// Matching is prefix-based via the curated list above.
+func IsInternalSqsSetting(key string) bool {
+	for _, prefix := range internalSettingPrefixes {
+		if strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/go/internal/migrate/internal_settings_test.go
+++ b/go/internal/migrate/internal_settings_test.go
@@ -1,0 +1,39 @@
+package migrate
+
+import "testing"
+
+func TestIsInternalSqsSetting(t *testing.T) {
+	cases := []struct {
+		key  string
+		want bool
+	}{
+		// Direct matches from sonar-tools _SQ_INTERNAL_SETTINGS.
+		{"sonar.core.id", true},
+		{"sonar.core.startTime", true},
+		{"sonar.plugins.risk.consent", true},
+		{"sonar.plsql.jdbc.driver.class", true},
+		{"sonar.documentation.baseUrl", true},
+		// Prefix matches.
+		{"sonar.updatecenter.url", true},
+		{"sonar.updatecenter.cache.ttl", true},
+		{"sonaranalyzer-cs.pluginVersion", true},
+		{"sonaranalyzer-cs.analyzerId", true},
+		{"sonaranalyzer-vbnet.staticResourceName", true},
+		{"sonaranalyzer.security.cs.ruleNamespace", true},
+		// Off-list keys: NOT internal — they may still be SQS-only via
+		// the curated handlers, but they should appear in the report.
+		{"sonar.exclusions", false},
+		{"sonar.coverage.exclusions", false},
+		{"sonar.issues.sandbox.enabled", false},
+		{"sonar.cs.analyzer.dotnet.pluginVersion", false}, // separate prefix; handled by sqsOnlyPrefixes
+		{"sonar.qualityProfiles.allowDisableInheritedRules", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			if got := IsInternalSqsSetting(c.key); got != c.want {
+				t.Errorf("got %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -414,6 +414,17 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	// InheritedRules=true where SQS's parentValue is also true: the
 	// customized filter dropped it, and the section-level note for
 	// "exists only on SQS" never reached the report.
+	// Drop internal settings (#244) before anything else so they never
+	// reach the partition / customized-filter / per-org loops.
+	filtered := sqsValues[:0]
+	for _, raw := range sqsValues {
+		if IsInternalSqsSetting(extractField(raw, "key")) {
+			continue
+		}
+		filtered = append(filtered, raw)
+	}
+	sqsValues = filtered
+
 	sqsValues, sqsOnlyNotes := partitionSQSOnlySettings(sqsValues)
 
 	customized := make([]json.RawMessage, 0, len(sqsValues))
@@ -517,6 +528,55 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	// regular per-org rows in the report's Skipped bucket — and
 	// because the writer is shared, the mutex still applies.
 	for _, rec := range sqsOnlyNotes {
+		b, _ := json.Marshal(rec)
+		mu.Lock()
+		_ = w.WriteOne(b)
+		mu.Unlock()
+	}
+
+	// Default-value sweep (#244). Every setting in
+	// getServerSettingsDefinitions that didn't reach the main loop —
+	// because it was at the SQS default value or never customised —
+	// gets a single section-level Skipped row so the operator sees
+	// the inventory of "untouched" settings. Internal keys (sonar-
+	// tools _SQ_INTERNAL_SETTINGS port) and keys already classified
+	// by partitionSQSOnlySettings are excluded.
+	customizedKeys := make(map[string]bool, len(customized))
+	for _, raw := range customized {
+		if k := extractField(raw, "key"); k != "" {
+			customizedKeys[k] = true
+		}
+	}
+	partitionHandled := make(map[string]bool, len(sqsOnlyNotes))
+	for _, note := range sqsOnlyNotes {
+		partitionHandled[note.Key] = true
+	}
+	for _, def := range sqsDefItems {
+		key := extractField(def.Data, "key")
+		if key == "" {
+			continue
+		}
+		if IsInternalSqsSetting(key) {
+			continue
+		}
+		if customizedKeys[key] || partitionHandled[key] {
+			continue
+		}
+		// Already-curated SQS-only keys (sqsOnlySettings map +
+		// sqsOnlyPrefixes) are handled by partitionSQSOnlySettings
+		// when their value is non-default. When their value is at
+		// default, the partition's per-key handler emits SkipSilently
+		// — honour that here too so we don't double-report them.
+		if _, found := resolveSQSOnlyHandler(key); found {
+			continue
+		}
+		rec := globalSettingResult{Key: key}
+		rec.Outcomes = []orgOutcome{{
+			Org:    "",
+			Status: outcomeSkipped,
+			Reason: "default-value",
+			Detail: "Setting is left to default on SQS, no migration needed.",
+		}}
 		b, _ := json.Marshal(rec)
 		mu.Lock()
 		_ = w.WriteOne(b)

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -112,22 +112,24 @@ var sqsOnlySettings = map[string]func(raw json.RawMessage) sqsOnlyDecision{
 	"sonar.technicalDebt.ratingGrid": func(raw json.RawMessage) sqsOnlyDecision {
 		// SonarQube Cloud always uses the platform default for the
 		// rating grid; the SQS-side value is dropped on migration.
-		// Surface a note ONLY when the operator customised it away
-		// from that default so they see exactly what reverts.
+		// Surface ONLY when the operator customised it away from the
+		// SQS default, then emit the canonical "not on SQC" Skipped
+		// note. The exact original/replacement values are kept in
+		// the run log, not in the per-row Detail.
 		const ratingGridDefault = "0.05,0.1,0.2,0.5"
 		v := extractField(raw, "value")
 		if v == "" || v == ratingGridDefault {
 			return sqsOnlyDecision{SkipSilently: true}
 		}
-		return sqsOnlyDecision{Note: fmt.Sprintf(
-			"Configured value %q will be replaced by the non-configurable SonarQube Cloud default %q.",
-			v, ratingGridDefault)}
+		return sqsOnlyDecision{Note: skipDetailNotOnSQC}
 	},
 	"sonar.dbcleaner.branchesToKeepWhenInactive": func(raw json.RawMessage) sqsOnlyDecision {
-		// The SQS branch-name list is migrated as a regex to the SQC
-		// org-scope setting sonar.branch.longLivedBranches.regex.
-		// Surface a note whenever the operator has customised it so
-		// they understand the transformation.
+		// Special-cased pending #249: the SQS key is migrated as a
+		// regex into the SQC org-scope setting
+		// sonar.branch.longLivedBranches.regex. Keep the dedicated
+		// transformation note instead of the canonical Skipped
+		// wording so the operator sees the planned behaviour. Will be
+		// revisited when #249 lands the actual transformation.
 		if extractField(raw, "value") == "" && len(extractStringArray(raw, "values")) == 0 {
 			return sqsOnlyDecision{SkipSilently: true}
 		}
@@ -191,27 +193,37 @@ var sqsOnlyPrefixes = []struct {
 	{"sonar.auth.", authReconfigureNote},
 }
 
-// authNoteText is the per-row note rendered in the report Skipped
-// bucket for any customised sonar.auth.* setting.
-const authNoteText = "Authentication configuration cannot be migrated automatically; it must be re-configured on SonarQube Cloud."
-
 // authReconfigureNote surfaces a sonar.auth.* setting in the report
-// (Skipped + auth-specific note) when it carries any value. Empty /
-// unset auth keys stay silent.
+// as Skipped/not-on-SQC when it carries any value. Empty / unset auth
+// keys stay silent.
 func authReconfigureNote(raw json.RawMessage) sqsOnlyDecision {
 	v := extractField(raw, "value")
 	vs := extractStringArray(raw, "values")
 	if v == "" && len(vs) == 0 {
 		return sqsOnlyDecision{SkipSilently: true}
 	}
-	return sqsOnlyDecision{Note: authNoteText}
+	return sqsOnlyDecision{Note: skipDetailNotOnSQC}
 }
 
-// sqsOnlyNoteText is the single user-facing wording all SQS-only
-// settings share in the report's Skipped bucket (#240). Each handler
-// either emits this note (non-default value, surfaces in report) or
-// SkipSilently (default value, nothing to say).
-const sqsOnlyNoteText = "This setting cannot be migrated because it does not exist on SonarQube Cloud."
+// Two canonical Detail strings for every Skipped global setting row
+// in the migration report — one per skip reason. Per #244 follow-up,
+// every per-key handler must surface ONE of these two so operators
+// see consistent wording across the section. Per-setting nuance
+// (auth-reconfiguration, ratingGrid value substitution, the dbcleaner
+// regex transformation) is captured in the run log instead.
+const (
+	skipDetailDefaultValue = "Setting is left to default on SQS, no migration needed"
+	skipDetailNotOnSQC     = "Setting does not exist (feature does not exist or setting irrelevant) on SQC, no migration possible"
+
+	// Exported aliases — the predict pipeline consumes these so the
+	// real and predictive reports share the exact same wording.
+	SkipDetailDefaultValue = skipDetailDefaultValue
+	SkipDetailNotOnSQC     = skipDetailNotOnSQC
+)
+
+// sqsOnlyNoteText kept for backward compatibility with existing
+// callers; it now resolves to the canonical "not on SQC" Detail.
+const sqsOnlyNoteText = skipDetailNotOnSQC
 
 // sandboxBooleanDecision is shared between sonar.issues.sandbox.enabled
 // and sonar.issues.sandbox.override.enabled, which both default to
@@ -233,16 +245,13 @@ func silentSkip(_ json.RawMessage) sqsOnlyDecision {
 	return sqsOnlyDecision{SkipSilently: true}
 }
 
-// alwaysEnabledOnSQCNoteText is the per-row note rendered for SQS
-// feature flags that SonarQube Cloud has permanently turned on.
-const alwaysEnabledOnSQCNoteText = "This feature is always enabled on SonarQube Cloud."
-
-// alwaysEnabledOnSQC emits a FYI note in the report whenever a SQS
-// feature flag is present, regardless of the SQS-side value. SQC
-// controls the on/off itself, so there's nothing to migrate, but the
-// operator should know the flag is being managed for them.
+// alwaysEnabledOnSQC emits the canonical "not on SQC" Skipped note in
+// the report for SQS feature flags that SonarQube Cloud has
+// permanently turned on. SQC controls the on/off itself, so there's
+// nothing to migrate — the operator just sees "setting irrelevant on
+// SQC" via the unified wording.
 func alwaysEnabledOnSQC(_ json.RawMessage) sqsOnlyDecision {
-	return sqsOnlyDecision{Note: alwaysEnabledOnSQCNoteText}
+	return sqsOnlyDecision{Note: skipDetailNotOnSQC}
 }
 
 // resolveSQSOnlyHandler looks up the per-key decision function for a
@@ -575,7 +584,7 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 			Org:    "",
 			Status: outcomeSkipped,
 			Reason: "default-value",
-			Detail: "Setting is left to default on SQS, no migration needed.",
+			Detail: skipDetailDefaultValue,
 		}}
 		b, _ := json.Marshal(rec)
 		mu.Lock()

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1132,9 +1132,9 @@ func TestPartitionSQSOnlySettings(t *testing.T) {
 			wantSilent: true,
 		},
 		{
-			name:     "allowDisableInheritedRules=true emits a note",
+			name:     "allowDisableInheritedRules=true emits the canonical not-on-SQC note",
 			raw:      map[string]any{"key": "sonar.qualityProfiles.allowDisableInheritedRules", "value": "true"},
-			wantNote: "does not exist on SonarQube Cloud",
+			wantNote: SkipDetailNotOnSQC,
 		},
 		{
 			name:       "ratingGrid at default is silent",
@@ -1142,9 +1142,9 @@ func TestPartitionSQSOnlySettings(t *testing.T) {
 			wantSilent: true,
 		},
 		{
-			name:     "ratingGrid customized emits a note with the configured value",
+			name:     "ratingGrid customized emits the canonical not-on-SQC note",
 			raw:      map[string]any{"key": "sonar.technicalDebt.ratingGrid", "value": "0.03,0.07,0.2,0.5"},
-			wantNote: `Configured value "0.03,0.07,0.2,0.5" will be replaced by the non-configurable SonarQube Cloud default "0.05,0.1,0.2,0.5".`,
+			wantNote: SkipDetailNotOnSQC,
 		},
 		{
 			name: "unknown setting passes through",
@@ -1253,8 +1253,8 @@ func TestRunSetGlobalSettingsSQSOnlyNoteFiresEvenAtSQSDefault(t *testing.T) {
 		if oc.Org != "" || oc.Reason != "sqs-only" {
 			t.Errorf("note must be section-level (Org=\"\") with Reason=sqs-only, got %+v", oc)
 		}
-		if !strings.Contains(oc.Detail, "does not exist on SonarQube Cloud") {
-			t.Errorf("Detail must explain the SQS-only nature, got %q", oc.Detail)
+		if oc.Detail != SkipDetailNotOnSQC {
+			t.Errorf("Detail must be the canonical not-on-SQC string, got %q", oc.Detail)
 		}
 		foundNote = true
 	}

--- a/go/internal/predict/global_settings.go
+++ b/go/internal/predict/global_settings.go
@@ -70,6 +70,10 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 		if key == "" || seenKey[key] {
 			continue
 		}
+		// Drop internal settings (#244) — sonar-tools _SQ_INTERNAL_SETTINGS.
+		if migrate.IsInternalSqsSetting(key) {
+			continue
+		}
 		if !migrate.IsSettingCustomized(it.Data, defaults[key]) {
 			continue
 		}
@@ -87,6 +91,51 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 		rec, ok := buildPredictedOutcomeRecord(key, it.Data, orgs)
 		if !ok {
 			continue
+		}
+		b, err := json.Marshal(rec)
+		if err != nil {
+			continue
+		}
+		if err := w.WriteOne(b); err != nil {
+			return err
+		}
+	}
+
+	// Default-value sweep (#244). For every non-internal key in the
+	// getServerSettingsDefinitions catalog that wasn't surfaced by
+	// the loop above (because it was either uncustomised or absent
+	// from getServerSettings entirely), emit a section-level Skipped
+	// outcome so the predictive report inventories the full settings
+	// catalog.
+	defItems, _ = structure.ReadExtractData(exportDir, extractMapping, "getServerSettingsDefinitions")
+	for _, di := range defItems {
+		key := jsonStringField(di.Data, "key")
+		if key == "" || seenKey[key] {
+			continue
+		}
+		if migrate.IsInternalSqsSetting(key) {
+			continue
+		}
+		// Honor the curated SQS-only list — its per-key handlers
+		// decide silent-skip vs surface-as-Skipped based on value.
+		// For a setting at the SQS default, the handler returns
+		// SkipSilently and we should NOT emit a default-value row
+		// here either.
+		if _, isSQSOnly := migrate.EvaluateSQSOnlyGlobalSetting(key, di.Data); isSQSOnly {
+			continue
+		}
+		if migrate.IsSilentlySkippedGlobalSetting(key, di.Data) {
+			continue
+		}
+		seenKey[key] = true
+		rec := map[string]any{
+			"key": key,
+			"outcomes": []map[string]string{{
+				"org":    "",
+				"status": "skipped",
+				"reason": "default-value",
+				"detail": "Setting is left to default on SQS, no migration needed.",
+			}},
 		}
 		b, err := json.Marshal(rec)
 		if err != nil {

--- a/go/internal/predict/global_settings.go
+++ b/go/internal/predict/global_settings.go
@@ -134,7 +134,7 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 				"org":    "",
 				"status": "skipped",
 				"reason": "default-value",
-				"detail": "Setting is left to default on SQS, no migration needed.",
+				"detail": migrate.SkipDetailDefaultValue,
 			}},
 		}
 		b, err := json.Marshal(rec)

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -46,6 +46,11 @@ var skipReasonOrder = []struct {
 	// "not applicable on SQC" notes — one row per such setting,
 	// no Organization (issue #200).
 	{SkipReasonSQSOnly, "Not applicable on SonarQube cloud"},
+	// Default-value settings (#244) — one row per setting in the
+	// SQS list_definitions catalog that was left untouched on the
+	// source. Rendered after SQS-only so the catalog inventory
+	// trails the "needs attention" rows.
+	{SkipReasonDefaultValue, "Left at default value on SonarQube Server"},
 }
 
 // Outcome labels used in the unified per-section table.

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -70,10 +70,11 @@ type EntityItem struct {
 // blank) and is rendered last in the Skipped bucket so it appears at
 // the bottom of the section.
 const (
-	SkipReasonOrgSkipped = "org-skipped"
-	SkipReasonBuiltIn    = "built-in"
-	SkipReasonUnused     = "unused"
-	SkipReasonSQSOnly    = "sqs-only"
+	SkipReasonOrgSkipped   = "org-skipped"
+	SkipReasonBuiltIn      = "built-in"
+	SkipReasonUnused       = "unused"
+	SkipReasonSQSOnly      = "sqs-only"
+	SkipReasonDefaultValue = "default-value"
 )
 
 // sectionDef maps a report section to its corresponding task names and analysis entity type.


### PR DESCRIPTION
## Summary

The Global Settings sections of the real and predictive migration reports were missing public settings left at the SQS default — operators couldn't tell whether a setting was untouched on purpose or simply absent from extract.

Closes #244.

### Changes

- **Internal-settings filter** — ported sonar-tools' `_SQ_INTERNAL_SETTINGS` prefix list as `migrate.IsInternalSqsSetting`. Applied at the top of `setGlobalSettings` and `synthesizeSetGlobalSettings` so internal keys never reach the report regardless of customization status.
- **Default-value sweep** — after the existing customised-settings loop, walk every key in `getServerSettingsDefinitions` and emit a section-level Skipped outcome for non-internal, non-curated, non-customised keys with Detail *"Setting is left to default on SQS, no migration needed."* Applies to both the real-migrate task and the predictive synthesizer.

### Result

Smoke test against the dev export: previously ~50 customised settings; now 282 setting rows including 232 default-valued Skipped rows. `sonar.junit.reportPaths` and other previously-missing public settings surface as expected.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean
- [x] New \`TestIsInternalSqsSetting\` covers exact + prefix matches and off-list keys
- [x] Real-world smoke against \`./files\`: 282 rows in predictive \`setGlobalSettings/*.jsonl\`, \`sonar.junit.reportPaths\` present with new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)