### PR TITLE
Issue #249 migrate dbcleaner branches as SQC regex (global side)

### DIFF
--- a/go/internal/migrate/dbcleaner_branches.go
+++ b/go/internal/migrate/dbcleaner_branches.go
@@ -1,0 +1,125 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// dbCleanerBranchesSetting is the SQS key that #249 migrates as a regex.
+const dbCleanerBranchesSetting = "sonar.dbcleaner.branchesToKeepWhenInactive"
+
+// sqcBranchRegexSetting is the SQC target key. Same role: list of
+// branches to keep when inactive. SQC accepts a single regex string.
+const sqcBranchRegexSetting = "sonar.branch.longLivedBranches.regex"
+
+// extractDbCleanerBranches peels off the dbcleaner setting from a
+// slice of getServerSettings records. Returns the matching record
+// (or nil if absent) and the remainder. Operates on the same
+// json.RawMessage slice shape that runSetGlobalSettings already uses.
+func extractDbCleanerBranches(values []json.RawMessage) (dbCleaner json.RawMessage, rest []json.RawMessage) {
+	rest = values[:0]
+	for _, raw := range values {
+		if extractField(raw, "key") == dbCleanerBranchesSetting {
+			dbCleaner = raw
+			continue
+		}
+		rest = append(rest, raw)
+	}
+	return dbCleaner, rest
+}
+
+// CombineBranchesAsRegex turns a list of SQS branch patterns / names
+// into the single regex string SonarQube Cloud expects at
+// sonar.branch.longLivedBranches.regex. Empty list → empty string. A
+// single entry passes through verbatim (already a regex on SQS); two
+// or more are wrapped as "(a|b|c)" so any of them matches.
+//
+// Exported so the predict pipeline can preview the exact value the
+// real migrate task will POST.
+func CombineBranchesAsRegex(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	if len(values) == 1 {
+		return values[0]
+	}
+	out := "("
+	for i, v := range values {
+		if i > 0 {
+			out += "|"
+		}
+		out += v
+	}
+	out += ")"
+	return out
+}
+
+// DbCleanerBranchesTransformNote returns the human-readable Detail
+// the report should display for a #249 multi-value transformation.
+// Empty when the source list has a single value (no transformation
+// to document — it's a 1:1 mapping by issue's request).
+func DbCleanerBranchesTransformNote(values []string, regex string) string {
+	if len(values) < 2 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"Combined %d SonarQube Server branch patterns into a single SonarQube Cloud regex %q (target setting: %s).",
+		len(values), regex, sqcBranchRegexSetting)
+}
+
+// applyDbCleanerBranchesGlobal handles #249 part 1: takes the SQS
+// sonar.dbcleaner.branchesToKeepWhenInactive record and writes its
+// regex form to every target SQC org under
+// sonar.branch.longLivedBranches.regex. Emits one outcome per org
+// (status=applied) so the Global Settings section renders the
+// transformation as Perfect (green). When the source list has 2+
+// values the per-org Detail also documents the regex combination.
+func applyDbCleanerBranchesGlobal(ctx context.Context, e *Executor, raw json.RawMessage, orgList []string,
+	w *common.ChunkWriter, mu *sync.Mutex, counter *TaskCounter) {
+
+	if raw == nil {
+		return
+	}
+	values := extractStringArray(raw, "values")
+	if len(values) == 0 {
+		if v := extractField(raw, "value"); v != "" {
+			values = []string{v}
+		}
+	}
+	if len(values) == 0 {
+		return
+	}
+	regex := CombineBranchesAsRegex(values)
+	note := DbCleanerBranchesTransformNote(values, regex)
+
+	rec := globalSettingResult{Key: dbCleanerBranchesSetting, Values: values}
+	for _, org := range orgList {
+		err := e.Cloud.Settings.Set(ctx, "", sqcBranchRegexSetting, regex, org)
+		if err != nil {
+			counter.Fail()
+			logAPIWarn(e.Logger, "setGlobalSettings dbcleaner branches → regex failed", err,
+				"org", org, "target_key", sqcBranchRegexSetting, "value", regex)
+			rec.Outcomes = append(rec.Outcomes, orgOutcome{
+				Org: org, Status: outcomeFailed, Reason: err.Error(),
+				Detail: fmt.Sprintf("Failed to migrate as %s on SonarQube Cloud", sqcBranchRegexSetting),
+			})
+			continue
+		}
+		counter.Success()
+		detail := fmt.Sprintf("Migrated to %s on SonarQube Cloud", sqcBranchRegexSetting)
+		if note != "" {
+			detail = note
+		}
+		rec.Outcomes = append(rec.Outcomes, orgOutcome{
+			Org: org, Status: outcomeApplied, Detail: detail,
+		})
+	}
+	b, _ := json.Marshal(rec)
+	mu.Lock()
+	_ = w.WriteOne(b)
+	mu.Unlock()
+}

--- a/go/internal/migrate/dbcleaner_branches_test.go
+++ b/go/internal/migrate/dbcleaner_branches_test.go
@@ -1,0 +1,63 @@
+package migrate
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestCombineBranchesAsRegex covers #249 behaviour: empty → empty,
+// single value passes through (already a regex on SQS), two or more
+// values wrapped as "(a|b|c)".
+func TestCombineBranchesAsRegex(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{"nil input", nil, ""},
+		{"empty slice", []string{}, ""},
+		{"single value passes through", []string{"main"}, "main"},
+		{"two values wrapped", []string{"main", "develop"}, "(main|develop)"},
+		{"three values wrapped", []string{"main", "develop", "release-.*"}, "(main|develop|release-.*)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CombineBranchesAsRegex(tc.in); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDbCleanerBranchesTransformNote covers when a note should be
+// surfaced in the report: only when 2+ values were combined.
+func TestDbCleanerBranchesTransformNote(t *testing.T) {
+	cases := []struct {
+		name       string
+		in         []string
+		regex      string
+		wantEmpty  bool
+		wantSubstr string
+	}{
+		{"single value emits no note", []string{"main"}, "main", true, ""},
+		{"empty emits no note", nil, "", true, ""},
+		{"two values emits a note mentioning the regex",
+			[]string{"main", "develop"}, "(main|develop)", false, "(main|develop)"},
+		{"two values mentions the target key",
+			[]string{"main", "develop"}, "(main|develop)", false, "sonar.branch.longLivedBranches.regex"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DbCleanerBranchesTransformNote(tc.in, tc.regex)
+			if tc.wantEmpty {
+				if got != "" {
+					t.Errorf("expected empty note, got %q", got)
+				}
+				return
+			}
+			if !strings.Contains(got, tc.wantSubstr) {
+				t.Errorf("note must contain %q, got %q", tc.wantSubstr, got)
+			}
+		})
+	}
+}

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -123,20 +123,11 @@ var sqsOnlySettings = map[string]func(raw json.RawMessage) sqsOnlyDecision{
 		}
 		return sqsOnlyDecision{Note: skipDetailNotOnSQC}
 	},
-	"sonar.dbcleaner.branchesToKeepWhenInactive": func(raw json.RawMessage) sqsOnlyDecision {
-		// Special-cased pending #249: the SQS key is migrated as a
-		// regex into the SQC org-scope setting
-		// sonar.branch.longLivedBranches.regex. Keep the dedicated
-		// transformation note instead of the canonical Skipped
-		// wording so the operator sees the planned behaviour. Will be
-		// revisited when #249 lands the actual transformation.
-		if extractField(raw, "value") == "" && len(extractStringArray(raw, "values")) == 0 {
-			return sqsOnlyDecision{SkipSilently: true}
-		}
-		return sqsOnlyDecision{
-			Note: "Will be adapted as a regex and migrated to the org-scope setting sonar.branch.longLivedBranches.regex.",
-		}
-	},
+	// Note: sonar.dbcleaner.branchesToKeepWhenInactive is intentionally
+	// NOT in this curated map — #249 implements the actual migration
+	// path (combine SQS values into a regex, POST to SQC org-scope
+	// sonar.branch.longLivedBranches.regex), so the per-key handler
+	// in runSetGlobalSettings owns it now.
 
 	"sonar.allowPermissionManagementForProjectAdmins": func(raw json.RawMessage) sqsOnlyDecision {
 		// SQC has no equivalent feature flag; the SQS default is
@@ -448,6 +439,14 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 		customized = append(customized, raw)
 	}
 
+	// Peel off sonar.dbcleaner.branchesToKeepWhenInactive — #249
+	// migrates it as a regex into the SQC org-scope setting
+	// sonar.branch.longLivedBranches.regex, not via the standard
+	// per-org applyOneGlobalSetting path. Handled below after the
+	// parallel loop.
+	var dbCleanerRaw json.RawMessage
+	dbCleanerRaw, customized = extractDbCleanerBranches(customized)
+
 	// SQS exposes platform-enforced exclusion patterns via the
 	// sonar.global.* keys (today: sonar.global.exclusions and
 	// sonar.global.test.exclusions). SQC has no global counterparts,
@@ -531,6 +530,13 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	if err := g.Wait(); err != nil {
 		return err
 	}
+
+	// #249: migrate sonar.dbcleaner.branchesToKeepWhenInactive as a
+	// regex to the SQC org-scope sonar.branch.longLivedBranches.regex
+	// setting. Done outside the parallel loop because the source key
+	// itself does not exist on SQC — the apply-via-list_definitions
+	// path would just mark it Skipped/not-on-sqc.
+	applyDbCleanerBranchesGlobal(ctx, e, dbCleanerRaw, orgList, w, &mu, counter)
 
 	// Section-level notes for SQS-only settings (issue #200).
 	// Written AFTER the parallel loop so they always trail the

--- a/go/internal/predict/global_settings.go
+++ b/go/internal/predict/global_settings.go
@@ -79,6 +79,19 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 		}
 		seenKey[key] = true
 
+		// #249: sonar.dbcleaner.branchesToKeepWhenInactive migrates as
+		// a regex into the SQC org-scope sonar.branch.longLivedBranches
+		// .regex setting. Predict the same Applied outcome here so the
+		// report shows it green.
+		if key == "sonar.dbcleaner.branchesToKeepWhenInactive" {
+			rec := buildPredictedDbCleanerRecord(key, it.Data)
+			b, _ := json.Marshal(rec)
+			if err := w.WriteOne(b); err != nil {
+				return err
+			}
+			continue
+		}
+
 		// Honor the curated silent-skip list (read-only keys like
 		// sonar.core.startTime, plus SQS-only feature flags whose
 		// value matches SQS's default). Real-migrate drops these in
@@ -143,6 +156,52 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 		}
 		if err := w.WriteOne(b); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// buildPredictedDbCleanerRecord builds the predictive Applied outcome
+// for #249: sonar.dbcleaner.branchesToKeepWhenInactive will be
+// migrated as a regex into sonar.branch.longLivedBranches.regex at
+// SQC org scope. Returns one section-level outcome (Org="") since
+// the regex is the same across orgs.
+func buildPredictedDbCleanerRecord(key string, raw json.RawMessage) map[string]any {
+	values := extractStringValues(raw)
+	regex := migrate.CombineBranchesAsRegex(values)
+	detail := fmt.Sprintf("Will be migrated to %s on SonarQube Cloud", "sonar.branch.longLivedBranches.regex")
+	if note := migrate.DbCleanerBranchesTransformNote(values, regex); note != "" {
+		detail = note
+	}
+	return map[string]any{
+		"key":    key,
+		"values": values,
+		"outcomes": []map[string]string{{
+			"org":    "",
+			"status": "applied",
+			"detail": detail,
+		}},
+	}
+}
+
+// extractStringValues pulls a top-level "values" string array out of
+// a JSON object blob, falling back to a single-element list if only
+// the legacy "value" field is set.
+func extractStringValues(raw json.RawMessage) []string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	if v, ok := obj["values"]; ok {
+		var out []string
+		if err := json.Unmarshal(v, &out); err == nil {
+			return out
+		}
+	}
+	if v, ok := obj["value"]; ok {
+		var s string
+		if err := json.Unmarshal(v, &s); err == nil && s != "" {
+			return []string{s}
 		}
 	}
 	return nil

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -630,12 +630,14 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 //   - |scan:<status> — issue #208 era, scan-history import outcome.
 //
 // Both markers are split off and rendered on separate lines after
-// the cloud key. When predictive is true (#240) the cloud key itself
-// is suppressed — the predict pipeline emits a synthetic placeholder
-// ("predict:<task>:<org>:<name>") that carries no useful information.
+// the cloud key. When predictive is true (#240) the SYNTHETIC
+// "predict:<task>:<org>:<name>" placeholder is suppressed — but any
+// other Detail string (e.g. the #249 dbcleaner-branches transformation
+// note) is kept verbatim so genuinely informative content reaches the
+// report.
 func successDetails(item EntityItem, predictive bool) string {
 	cloudKey, scan, ncdFallback := parseProjectDetailMarkers(item.Detail)
-	if predictive {
+	if predictive && strings.HasPrefix(cloudKey, "predict:") {
 		cloudKey = ""
 	}
 	parts := []string{}
@@ -657,11 +659,12 @@ func successDetails(item EntityItem, predictive bool) string {
 // item — each issue rendered on its own line, prefixed by the cloud
 // key if known. The predictive renderer passes predictive=true so the
 // synthetic predict:<task>:<org>:<name> placeholder is suppressed
-// (issue #240; matches the equivalent stripping in successDetails).
+// (issue #240). Non-synthetic Detail strings are kept so genuinely
+// informative content (e.g. transformation notes) still renders.
 func partialDetails(item EntityItem, predictive bool) string {
 	issues := strings.Join(item.Issues, "\n")
 	detail := item.Detail
-	if predictive {
+	if predictive && strings.HasPrefix(detail, "predict:") {
 		detail = ""
 	}
 	if detail != "" && issues != "" {


### PR DESCRIPTION
## Summary

Migrates `sonar.dbcleaner.branchesToKeepWhenInactive` (SQS, multi-valued) to `sonar.branch.longLivedBranches.regex` (SQC org-scope, mono-valued regex) at the **global level**. Project-level migration (branches with `excludedFromPurge=true` → SQC project-scope regex) will follow in a separate PR.

Partially closes #249 (global side only).

### Behaviour

- 1 source value → passes through verbatim.
- 2+ source values → wrapped as `(v1|v2|v3)` regex.
- Real-migrate POSTs to `sonar.branch.longLivedBranches.regex` at every target SQC org via `Settings.Set`.
- Outcome status: **Applied** → row appears as **Perfect (green)** in the Global Settings section.
- Detail for multi-value documents the transformation; single-value shows just a plain "migrated to" line (per the issue's "not necessary to document the details if single value").

### Bonus fix

`successDetails` / `partialDetails` were stripping every Detail string in predictive mode, not just the synthetic `predict:<task>:<org>:<name>` placeholders. The new dbcleaner transformation note was getting wiped on the predictive PDF as a result. Both helpers now strip only Detail strings prefixed with `predict:`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `TestCombineBranchesAsRegex` covers 0 / 1 / 2 / 3+ value cases
- [x] `TestDbCleanerBranchesTransformNote` covers single-value (no note) vs multi-value (note mentions regex + target key)
- [x] Real-world smoke against `./files`: the dbcleaner row appears in the predictive `setGlobalSettings/*.jsonl` as Applied with the multi-value transformation Detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)
