### PR TITLE
Issue #247 default export directory to ./migration-files

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd go
 go run . <command> [args]
 ```
 
-> **Note:** The default `--export_directory` is `/app/files/` (for Docker). When running natively, always pass `--export_directory` to point to a local directory (e.g., `./files/`).
+> **Note:** The default `--export_directory` is `./migration-files` (created in the current working directory). You can override it with the `--export_directory` flag or the `export_directory` field in the JSON config file. Every command prints `See sonar-migration-tool output results in <directory>` when it finishes so you always know where to look.
 
 ---
 
@@ -93,7 +93,7 @@ sonar-migration-tool gui --export_directory ./files/
 
 | Flag | Description |
 |------|-------------|
-| `--export_directory` | Output directory (default: `/app/files/`) |
+| `--export_directory` | Output directory (default: `./migration-files`) |
 | `--addr` | Address to bind HTTP server (default: `localhost:0` — auto-assigns port) |
 | `--no-browser` | Don't automatically open the browser |
 
@@ -137,7 +137,7 @@ sonar-migration-tool extract <URL> <TOKEN> --export_directory ./files/ [--concur
 | `--concurrency` | Max concurrent requests (default: server-detected) |
 | `--timeout` | Request timeout in seconds |
 | `--extract_type` | Type of extract to run |
-| `--export_directory` | Output directory (default: `/app/files/` — override when running natively) |
+| `--export_directory` | Output directory (default: `./migration-files`) |
 | `--include_scan_history` | Extract full issue data, source code, and SCM blame for scan history import |
 | `--pem_file_path` | Client certificate PEM file (mTLS) |
 | `--key_file_path` | Client certificate key file (mTLS) |
@@ -188,7 +188,7 @@ sonar-migration-tool migrate <TOKEN> <ENTERPRISE_KEY> --export_directory ./files
 | `--edition` | SonarQube Cloud license edition |
 | `--url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
 | `--concurrency` | Max concurrent requests |
-| `--export_directory` | Directory containing SonarQube exports (default: `/app/files/` — override when running natively) |
+| `--export_directory` | Directory containing SonarQube exports (default: `./migration-files`) |
 
 ---
 

--- a/go/cmd/analysis_report.go
+++ b/go/cmd/analysis_report.go
@@ -17,7 +17,7 @@ var analysisReportCmd = &cobra.Command{
 }
 
 func init() {
-	analysisReportCmd.Flags().String("export_directory", "/app/files/", "Root directory containing all SonarQube exports")
+	analysisReportCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory containing all SonarQube exports")
 }
 
 func runAnalysisReport(cmd *cobra.Command, args []string) error {
@@ -38,6 +38,7 @@ func runAnalysisReport(cmd *cobra.Command, args []string) error {
 	success, failure := countOutcomes(rows)
 	fmt.Printf("Analysis Report: %d total, %d success, %d failure\n", len(rows), success, failure)
 	fmt.Printf("CSV written to: %s/final_analysis_report.csv\n", runDir)
+	printExportDirNotice(exportDir)
 	return nil
 }
 

--- a/go/cmd/defaults.go
+++ b/go/cmd/defaults.go
@@ -1,0 +1,20 @@
+package cmd
+
+import "fmt"
+
+// DefaultExportDirectory is the implicit value of --export_directory
+// when the operator passes neither a flag nor a config-file value
+// (issue #247). Relative path so the tool creates the directory in
+// whatever cwd the operator invoked it from.
+const DefaultExportDirectory = "./migration-files"
+
+// printExportDirNotice writes a uniform "See sonar-migration-tool
+// output results in <dir>" line so every command tells the operator
+// where to look — whether the directory was defaulted, supplied via
+// --export_directory, or read from the config file.
+func printExportDirNotice(dir string) {
+	if dir == "" {
+		return
+	}
+	fmt.Printf("See sonar-migration-tool output results in %s\n", dir)
+}

--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -31,6 +31,7 @@ var extractCmd = &cobra.Command{
 				fmt.Fprintf(os.Stderr, "  - %s\n", key)
 			}
 		}
+		printExportDirNotice(cfg.ExportDirectory)
 		return nil
 	},
 }
@@ -41,7 +42,7 @@ func init() {
 	f.String("pem_file_path", "", "Path to client certificate pem file")
 	f.String("key_file_path", "", "Path to client certificate key file")
 	f.String("cert_password", "", "Password for client certificate")
-	f.String("export_directory", "/app/files/", "Root directory to output the export")
+	f.String("export_directory", DefaultExportDirectory, "Root directory to output the export")
 	f.String("extract_type", "", "Type of extract to run")
 	f.Int("concurrency", 0, "Maximum number of concurrent requests")
 	f.Int("timeout", 0, "Number of seconds before a request will timeout")
@@ -84,6 +85,12 @@ func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfi
 	overrideInt(cmd, "timeout", &cfg.Timeout)
 	if cmd.Flags().Changed("include_scan_history") {
 		cfg.IncludeScanHistory, _ = cmd.Flags().GetBool("include_scan_history")
+	}
+
+	// Default the export directory when neither config nor flag supplied
+	// one (issue #247).
+	if cfg.ExportDirectory == "" {
+		cfg.ExportDirectory = DefaultExportDirectory
 	}
 
 	return cfg, nil

--- a/go/cmd/gui.go
+++ b/go/cmd/gui.go
@@ -22,7 +22,7 @@ var guiCmd = &cobra.Command{
 }
 
 func init() {
-	guiCmd.Flags().String("export_directory", "/app/files/", "Root directory to output the export")
+	guiCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory to output the export")
 	guiCmd.Flags().String("addr", "localhost:0", "Address to bind the HTTP server (default: random port)")
 	guiCmd.Flags().Bool("no-browser", false, "Do not open the browser automatically")
 }

--- a/go/cmd/mappings.go
+++ b/go/cmd/mappings.go
@@ -11,10 +11,14 @@ var mappingsCmd = &cobra.Command{
 	Long:  "Maps groups, permission templates, quality profiles, quality gates, and portfolios to relevant organizations. Outputs CSVs for each entity type.",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		exportDir, _ := cmd.Flags().GetString("export_directory")
-		return structure.RunMappings(exportDir)
+		if err := structure.RunMappings(exportDir); err != nil {
+			return err
+		}
+		printExportDirNotice(exportDir)
+		return nil
 	},
 }
 
 func init() {
-	mappingsCmd.Flags().String("export_directory", "/app/files/", "Root directory containing all SonarQube exports")
+	mappingsCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory containing all SonarQube exports")
 }

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -32,6 +32,7 @@ organization keys to organizations.csv.`,
 		if pdfPath, pdfErr := summary.GeneratePDFReport(runDir, cfg.ExportDirectory, cfg.ExportDirectory); pdfErr == nil {
 			fmt.Printf("PDF summary report: %s\n", pdfPath)
 		}
+		printExportDirNotice(cfg.ExportDirectory)
 		return nil
 	},
 }
@@ -87,6 +88,12 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	}
 	if cmd.Flags().Changed("debug") {
 		cfg.Debug, _ = cmd.Flags().GetBool("debug")
+	}
+
+	// Default the export directory when neither config nor flag supplied
+	// one (issue #247).
+	if cfg.ExportDirectory == "" {
+		cfg.ExportDirectory = DefaultExportDirectory
 	}
 
 	return cfg, nil

--- a/go/cmd/predictive_report.go
+++ b/go/cmd/predictive_report.go
@@ -42,6 +42,7 @@ func runPredictiveReport(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	fmt.Printf("Predictive PDF report: %s\n", pdfPath)
+	printExportDirNotice(exportDir)
 	return nil
 }
 
@@ -67,8 +68,10 @@ func resolvePredictiveReportExportDir(cmd *cobra.Command) (string, error) {
 		}
 	}
 
+	// Default the export directory when neither config nor flag supplied
+	// one (issue #247).
 	if exportDir == "" {
-		return "", fmt.Errorf("--export_directory is required (either as a CLI flag or via --config)")
+		exportDir = DefaultExportDirectory
 	}
 	return exportDir, nil
 }

--- a/go/cmd/predictive_report_test.go
+++ b/go/cmd/predictive_report_test.go
@@ -68,12 +68,16 @@ func TestPredictiveReport_FlagOverridesConfigFile(t *testing.T) {
 	}
 }
 
-// Without --config and without --export_directory, the command should
-// surface a clear error instead of silently picking an empty dir.
-func TestPredictiveReport_RequiresExportDir(t *testing.T) {
+// Without --config and without --export_directory, the command falls
+// back to the implicit default "./migration-files" (issue #247).
+func TestPredictiveReport_DefaultsExportDir(t *testing.T) {
 	cmd := newPredictiveReportTestCmd()
-	if _, err := resolvePredictiveReportExportDir(cmd); err == nil {
-		t.Error("expected error when neither --export_directory nor --config supplied")
+	got, err := resolvePredictiveReportExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolvePredictiveReportExportDir: %v", err)
+	}
+	if got != DefaultExportDirectory {
+		t.Errorf("got %q, want %q", got, DefaultExportDirectory)
 	}
 }
 

--- a/go/cmd/report.go
+++ b/go/cmd/report.go
@@ -20,7 +20,7 @@ var reportCmd = &cobra.Command{
 
 func init() {
 	f := reportCmd.Flags()
-	f.String("export_directory", "/app/files/", "Root directory containing all SonarQube exports")
+	f.String("export_directory", DefaultExportDirectory, "Root directory containing all SonarQube exports")
 	f.String("report_type", "migration", "Type of report to generate")
 	f.String("filename", "", "Filename for the report")
 }
@@ -57,5 +57,6 @@ func runReport(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Report written to: %s\n", outPath)
+	printExportDirNotice(exportDir)
 	return nil
 }

--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -22,7 +22,11 @@ var resetCmd = &cobra.Command{
 		}
 
 		fmt.Println("WARNING: This will delete everything in every organization within the enterprise.")
-		return migrate.RunReset(cmd.Context(), cfg)
+		if err := migrate.RunReset(cmd.Context(), cfg); err != nil {
+			return err
+		}
+		printExportDirNotice(cfg.ExportDirectory)
+		return nil
 	},
 }
 
@@ -32,7 +36,7 @@ func init() {
 	f.String("edition", "enterprise", "SonarQube Cloud license edition")
 	f.String("url", "https://sonarcloud.io/", "URL of SonarQube Cloud")
 	f.Int("concurrency", 25, "Maximum number of concurrent requests")
-	f.String("export_directory", "/app/files/", "Directory to place all interim files")
+	f.String("export_directory", DefaultExportDirectory, "Directory to place all interim files")
 	f.Bool("debug", false, "Enable debug-level logging (verbose request payloads, more detail per task)")
 }
 
@@ -63,6 +67,12 @@ func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, e
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	if cmd.Flags().Changed("debug") {
 		cfg.Debug, _ = cmd.Flags().GetBool("debug")
+	}
+
+	// Default the export directory when neither config nor flag supplied
+	// one (issue #247).
+	if cfg.ExportDirectory == "" {
+		cfg.ExportDirectory = DefaultExportDirectory
 	}
 
 	return cfg, nil

--- a/go/cmd/structure.go
+++ b/go/cmd/structure.go
@@ -22,15 +22,23 @@ var structureCmd = &cobra.Command{
 				return err
 			}
 			if len(orgs) == 1 {
-				return structure.RunStructure(exportDir, orgs[0].Key)
+				if err := structure.RunStructure(exportDir, orgs[0].Key); err != nil {
+					return err
+				}
+				printExportDirNotice(exportDir)
+				return nil
 			}
 		}
 
-		return structure.RunStructure(exportDir)
+		if err := structure.RunStructure(exportDir); err != nil {
+			return err
+		}
+		printExportDirNotice(exportDir)
+		return nil
 	},
 }
 
 func init() {
-	structureCmd.Flags().String("export_directory", "/app/files/", "Root directory containing all SonarQube exports")
+	structureCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory containing all SonarQube exports")
 	structureCmd.Flags().String("config", "", "Path to JSON configuration file (pre-populates sonarcloud_org_key when one org is defined)")
 }

--- a/go/cmd/wizard.go
+++ b/go/cmd/wizard.go
@@ -18,7 +18,7 @@ var wizardCmd = &cobra.Command{
 }
 
 func init() {
-	wizardCmd.Flags().String("export_directory", "/app/files/", "Root directory to output the export")
+	wizardCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory to output the export")
 }
 
 func runWizard(cmd *cobra.Command, args []string) error {
@@ -34,6 +34,9 @@ func runWizard(cmd *cobra.Command, args []string) error {
 		fmt.Println("\nWizard interrupted. Your progress has been saved.")
 		fmt.Println("Run the wizard again to resume from where you left off.")
 		return nil
+	}
+	if err == nil {
+		printExportDirNotice(exportDir)
 	}
 	return err
 }


### PR DESCRIPTION
## Summary

Every command now defaults `--export_directory` to `./migration-files` when neither the flag nor the JSON config provides a value. Previously the default was `/app/files/`, which only made sense inside the Docker image.

Closes #247.

- Shared `DefaultExportDirectory = "./migration-files"` constant.
- Applied to every Cobra flag default (extract, structure, mappings, report, predictive-report, analysis_report, reset, wizard, gui).
- Post-config fallback in `buildExtractConfig`, `buildMigrateConfig`, `buildResetConfig`, and `resolvePredictiveReportExportDir` so the config-vs-flag merge paths default correctly too.
- Every command prints `See sonar-migration-tool output results in <directory>` on successful completion. GUI is the exception — interactive server, no "complete" event.
- Explicit `--export_directory` / `export_directory` config field still wins over the default.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `TestPredictiveReport_DefaultsExportDir` covers the new fallback
- [x] Existing CLI config tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)