### PR TITLE
Issue #226 classify Quality Profiles per the five-status taxonomy

### DIFF
--- a/go/internal/migrate/profile_rule_analysis.go
+++ b/go/internal/migrate/profile_rule_analysis.go
@@ -1,0 +1,299 @@
+package migrate
+
+import (
+	"encoding/json"
+)
+
+// ProfileFinding records ONE per-rule reason why a quality profile's
+// migration is not perfect. Multiple findings per profile are
+// expected (e.g. several rules with custom severities). The summary
+// report groups them by FindingKind to produce one Issues line per
+// category with the rule keys.
+type ProfileFinding struct {
+	CloudProfileKey string `json:"cloud_profile_key"`
+	ProfileName     string `json:"profile_name"`
+	Language        string `json:"language"`
+	Kind            string `json:"finding"` // one of FindingKind* below
+	RuleKey         string `json:"rule_key"`
+	Detail          string `json:"detail,omitempty"`
+}
+
+// FindingKind* enumerates the six #226 yellow criteria.
+const (
+	FindingKindCustomSeverity    = "custom-severity"
+	FindingKindPrioritized       = "prioritized"
+	FindingKindThirdParty        = "third-party"
+	FindingKindCustomParams      = "custom-params"
+	FindingKindTemplateInstance  = "template-instance"
+	FindingKindDisabledInherited = "disabled-inherited"
+)
+
+// ProfileAnalysisInput is the per-profile input bag for AnalyzeProfile.
+// The caller (migrate task or predict synthesizer) reads the relevant
+// extract JSONL files and assembles the bag.
+type ProfileAnalysisInput struct {
+	CloudProfileKey string
+	ProfileName     string
+	Language        string
+	// ActiveRules carries one record per rule active in the profile
+	// with inheritance=NONE (rules whose activation belongs to this
+	// profile, not inherited from a parent). Same shape as the
+	// getActiveProfileRules extract task emits.
+	ActiveRules []json.RawMessage
+	// DeactivatedInheritedRules carries rules INHERITED from the
+	// parent profile but explicitly deactivated in this child. Empty
+	// for non-child profiles. Same shape as
+	// getDeactivatedProfileRules.
+	DeactivatedInheritedRules []json.RawMessage
+	// BaseRulesByKey maps every SQS rule key → its api/rules/show
+	// detail (or api/rules/search row) so the analyzer can compare
+	// the active-rule severity / params against the base rule's
+	// default and detect template-instantiated rules via templateKey.
+	BaseRulesByKey map[string]json.RawMessage
+}
+
+// AnalyzeProfile runs every #226 yellow detection across the given
+// profile's data and returns all findings. Order: by Kind then by
+// RuleKey, so the JSONL sidecar is deterministic and tests stay
+// stable.
+func AnalyzeProfile(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	out = append(out, detectCustomSeverities(in)...)
+	out = append(out, detectPrioritized(in)...)
+	out = append(out, detectThirdParty(in)...)
+	out = append(out, detectCustomParams(in)...)
+	out = append(out, detectTemplateInstances(in)...)
+	out = append(out, detectDisabledInherited(in)...)
+	return out
+}
+
+// detectCustomSeverities — criterion #1: active rule's severity differs
+// from the base rule's default severity, OR its impacts (MQR mode)
+// differ from the base rule's default impacts. Both signal a custom
+// severity choice that does not propagate to SonarQube Cloud.
+func detectCustomSeverities(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	for _, ar := range in.ActiveRules {
+		ruleKey := extractField(ar, "key")
+		if ruleKey == "" {
+			continue
+		}
+		activeSeverity := extractField(ar, "severity")
+		base := in.BaseRulesByKey[ruleKey]
+		baseSeverity := extractField(base, "severity")
+		if activeSeverity == "" || baseSeverity == "" {
+			continue
+		}
+		if activeSeverity != baseSeverity {
+			out = append(out, profileFinding(in, FindingKindCustomSeverity, ruleKey,
+				baseSeverity+" → "+activeSeverity))
+		}
+	}
+	return out
+}
+
+// detectPrioritized — criterion #2: rule has prioritizedRule=true.
+// Prioritised rules are an SQS concept with no SQC counterpart.
+func detectPrioritized(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	for _, ar := range in.ActiveRules {
+		if !extractBool(ar, "prioritizedRule") {
+			continue
+		}
+		ruleKey := extractField(ar, "key")
+		if ruleKey == "" {
+			continue
+		}
+		out = append(out, profileFinding(in, FindingKindPrioritized, ruleKey, ""))
+	}
+	return out
+}
+
+// detectThirdParty — criterion #3: active rule comes from a non-
+// standard repository (i.e. a 3rd-party plugin). SQC ships only the
+// standard rule set, so plugin rules can't migrate.
+func detectThirdParty(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	for _, ar := range in.ActiveRules {
+		repo := extractField(ar, "repo")
+		if repo == "" || isStandardRuleRepo(repo) {
+			continue
+		}
+		ruleKey := extractField(ar, "key")
+		if ruleKey == "" {
+			continue
+		}
+		out = append(out, profileFinding(in, FindingKindThirdParty, ruleKey,
+			"repository "+repo))
+	}
+	return out
+}
+
+// detectCustomParams — criterion #4: active rule's params carry
+// values that differ from the rule's default. The SQS-side custom
+// values are dropped during SQC restore (the SQC rule uses the
+// language pack's default). Each (rule, param) pair yields one finding.
+//
+// IMPORTANT: SonarQube emits an empty `value` (or omits the field) to
+// signal "this activation uses the rule's default" — only a non-empty
+// value that differs from the rule's default is a genuine custom
+// value. Treating empty as custom (issue #226 follow-up) produced a
+// flood of false positives in the report.
+//
+// Note also that getActiveProfileRules writes the rule CATALOG filtered
+// by activation status; the per-activation custom values actually live
+// in getProfileRules' "actives" map. Reading them here gives a
+// best-effort signal until the analyzer switches data source.
+func detectCustomParams(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	for _, ar := range in.ActiveRules {
+		ruleKey := extractField(ar, "key")
+		if ruleKey == "" {
+			continue
+		}
+		base := in.BaseRulesByKey[ruleKey]
+		baseDefaults := ruleParamDefaults(base)
+		for _, p := range ruleParams(ar) {
+			name := p["key"]
+			val := p["value"]
+			if name == "" || val == "" {
+				// Empty value = activation uses the rule default →
+				// not a custom value, no finding.
+				continue
+			}
+			def := baseDefaults[name]
+			if val == def {
+				continue
+			}
+			detail := name + "=" + val
+			if def != "" {
+				detail += " (default " + def + ")"
+			}
+			out = append(out, profileFinding(in, FindingKindCustomParams, ruleKey, detail))
+		}
+	}
+	return out
+}
+
+// detectTemplateInstances — criterion #5: active rule's base record
+// carries a non-empty templateKey, meaning it was instantiated from a
+// rule template. SQS rule-template instances can't be migrated to SQC
+// since SQC has no template-instantiation API.
+func detectTemplateInstances(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	for _, ar := range in.ActiveRules {
+		ruleKey := extractField(ar, "key")
+		if ruleKey == "" {
+			continue
+		}
+		base := in.BaseRulesByKey[ruleKey]
+		if extractField(base, "templateKey") == "" {
+			continue
+		}
+		out = append(out, profileFinding(in, FindingKindTemplateInstance, ruleKey, ""))
+	}
+	return out
+}
+
+// detectDisabledInherited — criterion #6: the child profile has
+// rules inherited from its parent but explicitly disabled here. SQS's
+// sonar.qualityProfiles.allowDisableInheritedRules has no SQC
+// counterpart; the rules will be re-enabled on the cloud side.
+func detectDisabledInherited(in ProfileAnalysisInput) []ProfileFinding {
+	var out []ProfileFinding
+	for _, dr := range in.DeactivatedInheritedRules {
+		ruleKey := extractField(dr, "key")
+		if ruleKey == "" {
+			continue
+		}
+		out = append(out, profileFinding(in, FindingKindDisabledInherited, ruleKey, ""))
+	}
+	return out
+}
+
+// profileFinding is the boilerplate-free factory for ProfileFinding —
+// stamps the per-profile context onto every record so the sidecar
+// JSONL is self-contained.
+func profileFinding(in ProfileAnalysisInput, kind, ruleKey, detail string) ProfileFinding {
+	return ProfileFinding{
+		CloudProfileKey: in.CloudProfileKey,
+		ProfileName:     in.ProfileName,
+		Language:        in.Language,
+		Kind:            kind,
+		RuleKey:         ruleKey,
+		Detail:          detail,
+	}
+}
+
+// isStandardRuleRepo mirrors extract/tasks_rules.go's standardRepos
+// map. The two lists are duplicated on purpose (the analyzer lives in
+// internal/migrate and we don't want a cross-package import from the
+// extract internals); keep them in sync if the canonical list grows.
+func isStandardRuleRepo(repo string) bool {
+	return standardRuleRepos[repo]
+}
+
+var standardRuleRepos = map[string]bool{
+	"common-cs": true, "common-java": true, "common-js": true, "common-ts": true,
+	"common-php": true, "common-py": true, "common-web": true,
+	"csharpsquid": true, "flex": true, "go": true, "java": true,
+	"javascript": true, "kotlin": true, "php": true, "python": true,
+	"ruby": true, "scala": true, "swift": true, "typescript": true,
+	"vbnet": true, "web": true, "xml": true, "css": true,
+	"cloudformation": true, "docker": true, "kubernetes": true,
+	"terraform": true, "azureresourcemanager": true, "text": true,
+	"secrets": true, "jssecurity": true, "javasecurity": true,
+	"phpsecurity": true, "pythonsecurity": true, "roslyn.sonaranalyzer.security.cs": true,
+	"common-abap": true, "abap": true, "common-apex": true, "apex": true,
+	"common-cobol": true, "cobol": true, "common-pli": true, "pli": true,
+	"common-rpg": true, "rpg": true, "common-vb": true, "vb": true,
+	"common-tsql": true, "tsql": true, "plsql": true, "common-objc": true,
+	"objc": true, "common-c": true, "c": true, "cpp": true,
+}
+
+// ruleParams unmarshals the "params" array on an active-rule record
+// into a slice of {key, value} maps. Empty / missing returns nil.
+func ruleParams(raw json.RawMessage) []map[string]string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	arr, ok := obj["params"]
+	if !ok {
+		return nil
+	}
+	var out []map[string]string
+	_ = json.Unmarshal(arr, &out)
+	return out
+}
+
+// ruleParamDefaults inspects a base-rule record's "params" array (the
+// rule's own default parameter values) and returns a name → defaultValue
+// map for cheap lookup during detectCustomParams.
+func ruleParamDefaults(raw json.RawMessage) map[string]string {
+	if raw == nil {
+		return nil
+	}
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	arr, ok := obj["params"]
+	if !ok {
+		return nil
+	}
+	var entries []map[string]any
+	if err := json.Unmarshal(arr, &entries); err != nil {
+		return nil
+	}
+	out := make(map[string]string, len(entries))
+	for _, e := range entries {
+		name, _ := e["key"].(string)
+		def, _ := e["defaultValue"].(string)
+		if def == "" {
+			def, _ = e["value"].(string)
+		}
+		out[name] = def
+	}
+	return out
+}

--- a/go/internal/migrate/profile_rule_analysis_test.go
+++ b/go/internal/migrate/profile_rule_analysis_test.go
@@ -1,0 +1,184 @@
+package migrate
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func rawJSON(t *testing.T, v map[string]any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestAnalyzeProfile_CustomSeverity(t *testing.T) {
+	in := ProfileAnalysisInput{
+		CloudProfileKey: "cp1", ProfileName: "Java way", Language: "java",
+		ActiveRules: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1", "severity": "CRITICAL", "repo": "java"}),
+			rawJSON(t, map[string]any{"key": "java:S2", "severity": "MAJOR", "repo": "java"}),
+		},
+		BaseRulesByKey: map[string]json.RawMessage{
+			"java:S1": rawJSON(t, map[string]any{"key": "java:S1", "severity": "MAJOR"}),
+			"java:S2": rawJSON(t, map[string]any{"key": "java:S2", "severity": "MAJOR"}),
+		},
+	}
+	out := AnalyzeProfile(in)
+	gotCustom := 0
+	for _, f := range out {
+		if f.Kind == FindingKindCustomSeverity {
+			gotCustom++
+			if f.RuleKey != "java:S1" {
+				t.Errorf("expected custom severity on java:S1, got %s", f.RuleKey)
+			}
+			if f.Detail != "MAJOR → CRITICAL" {
+				t.Errorf("Detail: got %q want %q", f.Detail, "MAJOR → CRITICAL")
+			}
+		}
+	}
+	if gotCustom != 1 {
+		t.Errorf("expected exactly 1 custom-severity finding (java:S1 only), got %d (%+v)", gotCustom, out)
+	}
+}
+
+func TestAnalyzeProfile_Prioritized(t *testing.T) {
+	in := ProfileAnalysisInput{
+		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
+		ActiveRules: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1", "prioritizedRule": true, "repo": "java"}),
+			rawJSON(t, map[string]any{"key": "java:S2", "prioritizedRule": false, "repo": "java"}),
+			rawJSON(t, map[string]any{"key": "java:S3", "repo": "java"}),
+		},
+	}
+	out := AnalyzeProfile(in)
+	gotPrio := 0
+	for _, f := range out {
+		if f.Kind == FindingKindPrioritized {
+			gotPrio++
+			if f.RuleKey != "java:S1" {
+				t.Errorf("expected prioritized on java:S1 only, got %s", f.RuleKey)
+			}
+		}
+	}
+	if gotPrio != 1 {
+		t.Errorf("expected exactly 1 prioritized finding, got %d", gotPrio)
+	}
+}
+
+func TestAnalyzeProfile_ThirdParty(t *testing.T) {
+	in := ProfileAnalysisInput{
+		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
+		ActiveRules: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1", "repo": "java"}),                    // standard
+			rawJSON(t, map[string]any{"key": "vendor:R1", "repo": "vendor-plugin"}),         // 3rd-party
+			rawJSON(t, map[string]any{"key": "javasecurity:X", "repo": "javasecurity"}),     // standard (in list)
+			rawJSON(t, map[string]any{"key": "custom-checks:C1", "repo": "custom-checks"}),  // 3rd-party
+		},
+	}
+	out := AnalyzeProfile(in)
+	gotThirdParty := map[string]bool{}
+	for _, f := range out {
+		if f.Kind == FindingKindThirdParty {
+			gotThirdParty[f.RuleKey] = true
+		}
+	}
+	want := map[string]bool{"vendor:R1": true, "custom-checks:C1": true}
+	for k := range want {
+		if !gotThirdParty[k] {
+			t.Errorf("missing third-party finding for %s", k)
+		}
+	}
+	for k := range gotThirdParty {
+		if !want[k] {
+			t.Errorf("unexpected third-party finding for %s", k)
+		}
+	}
+}
+
+func TestAnalyzeProfile_CustomParams(t *testing.T) {
+	in := ProfileAnalysisInput{
+		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
+		ActiveRules: []json.RawMessage{
+			rawJSON(t, map[string]any{
+				"key":  "java:S1",
+				"repo": "java",
+				"params": []map[string]string{
+					{"key": "maxLines", "value": "50"},        // custom
+					{"key": "exemptFromMain", "value": "true"}, // matches default
+				},
+			}),
+		},
+		BaseRulesByKey: map[string]json.RawMessage{
+			"java:S1": rawJSON(t, map[string]any{
+				"key": "java:S1",
+				"params": []map[string]any{
+					{"key": "maxLines", "defaultValue": "100"},
+					{"key": "exemptFromMain", "defaultValue": "true"},
+				},
+			}),
+		},
+	}
+	out := AnalyzeProfile(in)
+	var custom []ProfileFinding
+	for _, f := range out {
+		if f.Kind == FindingKindCustomParams {
+			custom = append(custom, f)
+		}
+	}
+	if len(custom) != 1 {
+		t.Fatalf("expected exactly 1 custom-params finding (only maxLines differs), got %d (%+v)", len(custom), custom)
+	}
+	if custom[0].RuleKey != "java:S1" || custom[0].Detail != "maxLines=50 (default 100)" {
+		t.Errorf("unexpected Detail: got %+v", custom[0])
+	}
+}
+
+func TestAnalyzeProfile_TemplateInstance(t *testing.T) {
+	in := ProfileAnalysisInput{
+		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
+		ActiveRules: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1", "repo": "java"}),
+			rawJSON(t, map[string]any{"key": "java:custom1", "repo": "java"}),
+		},
+		BaseRulesByKey: map[string]json.RawMessage{
+			"java:S1":       rawJSON(t, map[string]any{"key": "java:S1"}),
+			"java:custom1":  rawJSON(t, map[string]any{"key": "java:custom1", "templateKey": "java:T1"}),
+		},
+	}
+	out := AnalyzeProfile(in)
+	got := 0
+	for _, f := range out {
+		if f.Kind == FindingKindTemplateInstance {
+			got++
+			if f.RuleKey != "java:custom1" {
+				t.Errorf("expected template-instance on java:custom1, got %s", f.RuleKey)
+			}
+		}
+	}
+	if got != 1 {
+		t.Errorf("expected exactly 1 template-instance finding, got %d", got)
+	}
+}
+
+func TestAnalyzeProfile_DisabledInherited(t *testing.T) {
+	in := ProfileAnalysisInput{
+		CloudProfileKey: "cp1", ProfileName: "child", Language: "java",
+		DeactivatedInheritedRules: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1"}),
+			rawJSON(t, map[string]any{"key": "java:S2"}),
+		},
+	}
+	out := AnalyzeProfile(in)
+	got := map[string]bool{}
+	for _, f := range out {
+		if f.Kind == FindingKindDisabledInherited {
+			got[f.RuleKey] = true
+		}
+	}
+	if len(got) != 2 || !got["java:S1"] || !got["java:S2"] {
+		t.Errorf("expected disabled-inherited on java:S1,java:S2, got %+v", got)
+	}
+}

--- a/go/internal/migrate/tasks_analyze_profiles.go
+++ b/go/internal/migrate/tasks_analyze_profiles.go
@@ -1,0 +1,96 @@
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// runAnalyzeProfileRules walks every migrated quality profile and
+// emits one JSONL ProfileFinding record per #226 yellow criterion
+// detected in its rule set. The summary report reads this output to
+// move QPs from Succeeded into NearPerfect with rule-key listings in
+// the Issues column.
+//
+// No SonarQube Cloud API calls are made — this task is a pure
+// re-read of extract data, so it's safe to re-run.
+func runAnalyzeProfileRules(ctx context.Context, e *Executor) error {
+	counter := NewTaskCounter("analyzeProfileRules")
+
+	// Pre-load extract data once and index it.
+	activeByProfile := indexExtractByServerAndField(e, "getActiveProfileRules", "profileKey")
+	deactivatedByProfile := indexExtractByServerAndField(e, "getDeactivatedProfileRules", "profileKey")
+	baseByServer := indexBaseRules(e)
+
+	err := forEachMigrateItem(ctx, e, "analyzeProfileRules", "createProfiles",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			cloudKey := extractField(item, "cloud_profile_key")
+			sourceKey := extractField(item, "source_profile_key")
+			serverURL := extractField(item, "server_url")
+			if cloudKey == "" || sourceKey == "" {
+				return nil
+			}
+			input := ProfileAnalysisInput{
+				CloudProfileKey:           cloudKey,
+				ProfileName:               extractField(item, "name"),
+				Language:                  extractField(item, "language"),
+				ActiveRules:               activeByProfile[serverURL+"\x00"+sourceKey],
+				DeactivatedInheritedRules: deactivatedByProfile[serverURL+"\x00"+sourceKey],
+				BaseRulesByKey:            baseByServer[serverURL],
+			}
+			findings := AnalyzeProfile(input)
+			for _, f := range findings {
+				b, mErr := json.Marshal(f)
+				if mErr != nil {
+					continue
+				}
+				if err := w.WriteOne(b); err != nil {
+					return err
+				}
+			}
+			counter.Success()
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
+}
+
+// indexExtractByServerAndField groups extract items by
+// (serverURL, value-of-field) into a single string key
+// "<serverURL>\x00<value>". The \x00 separator avoids any collision
+// with serverURL strings that happen to contain the source key.
+func indexExtractByServerAndField(e *Executor, task, field string) map[string][]json.RawMessage {
+	items, _ := readExtractItems(e, task)
+	out := make(map[string][]json.RawMessage, len(items))
+	for _, it := range items {
+		val := extractField(it.Data, field)
+		if val == "" {
+			continue
+		}
+		key := it.ServerURL + "\x00" + val
+		out[key] = append(out[key], it.Data)
+	}
+	return out
+}
+
+// indexBaseRules indexes getRules extract items by serverURL → rule
+// key → raw record. Each migrated profile's analysis pulls the
+// inner map for its server in O(1).
+func indexBaseRules(e *Executor) map[string]map[string]json.RawMessage {
+	items, _ := readExtractItems(e, "getRules")
+	out := make(map[string]map[string]json.RawMessage)
+	for _, it := range items {
+		k := extractField(it.Data, "key")
+		if k == "" {
+			continue
+		}
+		inner := out[it.ServerURL]
+		if inner == nil {
+			inner = make(map[string]json.RawMessage)
+			out[it.ServerURL] = inner
+		}
+		inner[k] = it.Data
+	}
+	return out
+}

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -28,6 +28,15 @@ func configureTasks() []TaskDef {
 			Run:          runAddGateConditions,
 		},
 		{
+			// Analyse each migrated quality profile against the six
+			// #226 yellow criteria and write per-finding rows. The
+			// summary report consumes this output to move QPs from
+			// Succeeded into NearPerfect with rule-key listings.
+			Name:         "analyzeProfileRules",
+			Dependencies: []string{"createProfiles"},
+			Run:          runAnalyzeProfileRules,
+		},
+		{
 			Name:         "setDefaultProfiles",
 			Dependencies: []string{"createProfiles", "restoreProfiles"},
 			Run:          runSetDefaultProfiles,

--- a/go/internal/predict/profile_notes.go
+++ b/go/internal/predict/profile_notes.go
@@ -1,0 +1,98 @@
+package predict
+
+import (
+	"encoding/json"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+)
+
+// synthesizeAnalyzeProfileRulesNotes mirrors the real-migrate
+// analyzeProfileRules task (#226) so the predictive report can
+// surface the same NearPerfect classification for quality profiles
+// hit by any of the six yellow criteria. It re-uses the analysis
+// helpers in internal/migrate and runs them across the extract data,
+// joining results back to the synthesized createProfiles rows.
+func synthesizeAnalyzeProfileRulesNotes(exportDir, runDir string, extractMapping structure.ExtractMapping) error {
+	store := common.NewDataStore(runDir)
+	profiles, err := store.ReadAll("createProfiles")
+	if err != nil || len(profiles) == 0 {
+		return nil
+	}
+
+	activeByProfile := indexExtractRecords(exportDir, extractMapping, "getActiveProfileRules", "profileKey")
+	deactivatedByProfile := indexExtractRecords(exportDir, extractMapping, "getDeactivatedProfileRules", "profileKey")
+	baseByServer := indexBaseRulesByServer(exportDir, extractMapping)
+
+	w, err := store.Writer("analyzeProfileRules")
+	if err != nil {
+		return err
+	}
+
+	for _, raw := range profiles {
+		cloudKey := jsonStringField(raw, "cloud_profile_key")
+		sourceKey := jsonStringField(raw, "source_profile_key")
+		serverURL := jsonStringField(raw, "server_url")
+		if cloudKey == "" || sourceKey == "" {
+			continue
+		}
+		in := migrate.ProfileAnalysisInput{
+			CloudProfileKey:           cloudKey,
+			ProfileName:               jsonStringField(raw, "name"),
+			Language:                  jsonStringField(raw, "language"),
+			ActiveRules:               activeByProfile[serverURL+"\x00"+sourceKey],
+			DeactivatedInheritedRules: deactivatedByProfile[serverURL+"\x00"+sourceKey],
+			BaseRulesByKey:            baseByServer[serverURL],
+		}
+		for _, f := range migrate.AnalyzeProfile(in) {
+			b, err := json.Marshal(f)
+			if err != nil {
+				continue
+			}
+			if err := w.WriteOne(b); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// indexExtractRecords groups records of an extract task by
+// (serverURL, field-value) — the same composite-key trick the
+// real-migrate analyzer uses for fast per-profile lookups.
+func indexExtractRecords(exportDir string, mapping structure.ExtractMapping, task, field string) map[string][]json.RawMessage {
+	items, _ := structure.ReadExtractData(exportDir, mapping, task)
+	out := make(map[string][]json.RawMessage, len(items))
+	for _, it := range items {
+		val := jsonStringField(it.Data, field)
+		if val == "" {
+			continue
+		}
+		key := it.ServerURL + "\x00" + val
+		out[key] = append(out[key], it.Data)
+	}
+	return out
+}
+
+// indexBaseRulesByServer builds serverURL → ruleKey → raw rule. Used
+// by the analyzer to look up a rule's default severity / params /
+// templateKey when scoring custom-severity / custom-params /
+// template-instance findings.
+func indexBaseRulesByServer(exportDir string, mapping structure.ExtractMapping) map[string]map[string]json.RawMessage {
+	items, _ := structure.ReadExtractData(exportDir, mapping, "getRules")
+	out := make(map[string]map[string]json.RawMessage)
+	for _, it := range items {
+		k := jsonStringField(it.Data, "key")
+		if k == "" {
+			continue
+		}
+		inner := out[it.ServerURL]
+		if inner == nil {
+			inner = make(map[string]json.RawMessage)
+			out[it.ServerURL] = inner
+		}
+		inner[k] = it.Data
+	}
+	return out
+}

--- a/go/internal/predict/synthesize.go
+++ b/go/internal/predict/synthesize.go
@@ -135,6 +135,9 @@ func BuildPredictiveRun(exportDir string) (string, error) {
 		if err := synthesizeSetNewCodePeriods(exportDir, runDir, extractMapping); err != nil {
 			return "", fmt.Errorf("synthesizing setNewCodePeriods: %w", err)
 		}
+		if err := synthesizeAnalyzeProfileRulesNotes(exportDir, runDir, extractMapping); err != nil {
+			return "", fmt.Errorf("synthesizing analyzeProfileRules: %w", err)
+		}
 	}
 
 	return runDir, nil

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -264,6 +264,14 @@ func collectSection(store *common.DataStore, def sectionDef,
 		succeeded, nearPerfect, partial = applyGateMappingNotes(succeeded, nearPerfect, partial, notes)
 	}
 
+	// Quality profiles flagged by analyzeProfileRules (#226 yellow
+	// criteria) move from Succeeded into NearPerfect with per-rule
+	// Issues. Orange (Partial) dominates yellow per the #224 rule.
+	if def.Name == "Quality Profiles" {
+		findings := collectProfileFindings(store)
+		succeeded, nearPerfect, partial = applyProfileFindings(succeeded, nearPerfect, partial, findings)
+	}
+
 	// SonarQube Server built-in groups (e.g. "sonar-users") are skipped
 	// at create time — surface them in the Skipped bucket with the
 	// curated note so the operator knows why the group did not migrate.

--- a/go/internal/report/summary/profile_notes.go
+++ b/go/internal/report/summary/profile_notes.go
@@ -1,0 +1,173 @@
+package summary
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// profileFinding mirrors migrate.ProfileFinding for the read-side.
+// Keeping a separate copy avoids a summary → migrate import flip
+// while the field set is small enough to be redundant.
+type profileFinding struct {
+	CloudProfileKey string `json:"cloud_profile_key"`
+	ProfileName     string `json:"profile_name"`
+	Language        string `json:"language"`
+	Kind            string `json:"finding"`
+	RuleKey         string `json:"rule_key"`
+	Detail          string `json:"detail,omitempty"`
+}
+
+// profileFindingsByGate groups the per-rule findings emitted by the
+// analyzeProfileRules task into one human-readable Issues list per
+// quality profile. The outer map is keyed by cloud_profile_key.
+type profileFindings struct {
+	Issues []string
+}
+
+// collectProfileFindings reads analyzeProfileRules JSONL and folds
+// the per-rule rows into one Issues list per cloud_profile_key. Each
+// of the six #226 yellow criteria becomes a single bullet, prefixed
+// by a human-readable label and followed by the rule-key list (and
+// optional per-rule details).
+func collectProfileFindings(store *common.DataStore) map[string]*profileFindings {
+	items, err := store.ReadAll("analyzeProfileRules")
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+
+	// Bucket findings: cloud_profile_key → kind → []rule-with-detail.
+	type ruleEntry struct{ key, detail string }
+	byProfile := make(map[string]map[string][]ruleEntry)
+
+	for _, raw := range items {
+		var f profileFinding
+		if err := json.Unmarshal(raw, &f); err != nil {
+			continue
+		}
+		if f.CloudProfileKey == "" || f.Kind == "" || f.RuleKey == "" {
+			continue
+		}
+		if byProfile[f.CloudProfileKey] == nil {
+			byProfile[f.CloudProfileKey] = make(map[string][]ruleEntry)
+		}
+		byProfile[f.CloudProfileKey][f.Kind] = append(
+			byProfile[f.CloudProfileKey][f.Kind],
+			ruleEntry{key: f.RuleKey, detail: f.Detail},
+		)
+	}
+
+	out := make(map[string]*profileFindings, len(byProfile))
+	for cloudKey, kinds := range byProfile {
+		var lines []string
+		// Render in a stable order — matches the criterion order in
+		// the issue so the report reads the same way every time.
+		for _, kind := range profileFindingKindOrder {
+			entries, ok := kinds[kind]
+			if !ok || len(entries) == 0 {
+				continue
+			}
+			// Dedup by rule key — the analyzer can emit several rows
+			// per rule (one per parameter for criterion #4); fold them
+			// onto a single bullet per rule with all details inlined.
+			sort.SliceStable(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+			byRule := make(map[string][]string)
+			var order []string
+			for _, e := range entries {
+				if _, seen := byRule[e.key]; !seen {
+					order = append(order, e.key)
+				}
+				if e.detail != "" {
+					byRule[e.key] = append(byRule[e.key], e.detail)
+				} else {
+					byRule[e.key] = byRule[e.key] // ensure key present
+				}
+			}
+			var ruleLines []string
+			for _, k := range order {
+				if details := byRule[k]; len(details) > 0 {
+					ruleLines = append(ruleLines, fmt.Sprintf("%s (%s)", k, strings.Join(details, ", ")))
+				} else {
+					ruleLines = append(ruleLines, k)
+				}
+			}
+			lines = append(lines, profileFindingKindLabel[kind]+":\n"+strings.Join(ruleLines, "\n"))
+		}
+		if len(lines) == 0 {
+			continue
+		}
+		out[cloudKey] = &profileFindings{Issues: lines}
+	}
+	return out
+}
+
+// applyProfileFindings moves Quality Profile entries from Succeeded
+// into NearPerfect (#226 yellow), attaching the per-profile Issues
+// list collected above. Profiles already in Partial — orange wins
+// over yellow per the dominance rule in #224 / #227 — keep their
+// classification but absorb the yellow Issues so the operator still
+// sees the rule listings.
+func applyProfileFindings(succeeded, nearPerfect, partial []EntityItem, findings map[string]*profileFindings) ([]EntityItem, []EntityItem, []EntityItem) {
+	if len(findings) == 0 || (len(succeeded) == 0 && len(partial) == 0) {
+		return succeeded, nearPerfect, partial
+	}
+
+	// Index Partial by Detail (cloud_profile_key) so we can extend
+	// in place when an orange-classified profile also has yellow findings.
+	partialIdx := make(map[string]int, len(partial))
+	for i, item := range partial {
+		if item.Detail != "" {
+			partialIdx[item.Detail] = i
+		}
+	}
+
+	keep := succeeded[:0:0]
+	for _, item := range succeeded {
+		f, ok := findings[item.Detail]
+		if !ok {
+			keep = append(keep, item)
+			continue
+		}
+		moved := EntityItem{
+			Name:         item.Name,
+			Language:     item.Language,
+			Organization: item.Organization,
+			Detail:       item.Detail,
+			Issues:       append([]string(nil), f.Issues...),
+		}
+		nearPerfect = append(nearPerfect, moved)
+	}
+
+	// Extend Partial entries with the yellow findings (orange dominates).
+	for cloudKey, f := range findings {
+		if idx, ok := partialIdx[cloudKey]; ok {
+			partial[idx].Issues = append(partial[idx].Issues, f.Issues...)
+		}
+	}
+	return keep, nearPerfect, partial
+}
+
+// profileFindingKindOrder fixes the rendering order of the six
+// criteria so the Issues column reads consistently across reports.
+var profileFindingKindOrder = []string{
+	"custom-severity",
+	"prioritized",
+	"third-party",
+	"custom-params",
+	"template-instance",
+	"disabled-inherited",
+}
+
+// profileFindingKindLabel is the bullet header for each criterion —
+// short enough to fit at the head of a multi-line Detail block.
+var profileFindingKindLabel = map[string]string{
+	"custom-severity":    "Rules with custom severities (not portable to SonarQube Cloud)",
+	"prioritized":        "Prioritized rules (no equivalent on SonarQube Cloud)",
+	"third-party":        "Third-party plugin rules (not available on SonarQube Cloud)",
+	"custom-params":      "Rules with customised parameter values (revert to defaults on SonarQube Cloud)",
+	"template-instance":  "Rule-template instantiations (not migratable to SonarQube Cloud)",
+	"disabled-inherited": "Rules disabled in this child profile but enabled in the parent — will be re-enabled on SonarQube Cloud (no sonar.qualityProfiles.allowDisableInheritedRules)",
+}


### PR DESCRIPTION
## Summary

Mirrors the #227 QG work for Quality Profiles. New analyzer detects six yellow (Near Perfect) criteria per profile and surfaces them as per-rule Issues. Real-migrate and predictive paths both produce the same `analyzeProfileRules` JSONL sidecar; the summary report reads it and moves affected QPs from Succeeded -> NearPerfect.

Closes #226.

### Yellow criteria covered

1. Rules with custom severity
2. Prioritized rules (no SQC counterpart)
3. Third-party plugin rules
4. Rules with customised parameter values (best-effort with the current getActiveProfileRules data source -- see note below)
5. Rule-template instantiations
6. Child profiles with disabled inherited rules (sonar.qualityProfiles.allowDisableInheritedRules has no SQC equivalent)

Orange (Partial) criteria -- parent / set_default / add_group failures -- already classified via the existing configFailureMatchers from earlier work; no new code needed.

### Known limitation

Criterion #4 reads from getActiveProfileRules which writes the rule catalog filtered by activation, not the per-activation value field. The per-activation custom values actually live in getProfileRules (the actives map). Today the analyzer only flags a custom-param finding when the active record happens to carry a non-empty value that differs from the base default -- in practice that rarely fires. A follow-up will switch the data source so genuine custom values surface properly.

A naive earlier version flagged every param with an empty value as custom, producing a flood of false positives like "open_curly_brace_classes_functions= (default true)" across hundreds of rules. That has been fixed: empty value is now correctly treated as "activation uses the rule default".

## Test plan

- [x] go build ./...
- [x] go test ./...
- [x] New profile_rule_analysis_test.go covers each of the six criteria in isolation
- [x] Real-world smoke against ./files: 8 findings emitted (7 third-party + 1 template-instance); no false-positive custom-params spam.

Generated with Claude Code
