### PR TITLE
Issue #226 + #241 follow-up: QP report tuning

### DIFF
--- a/go/internal/migrate/profile_rule_analysis.go
+++ b/go/internal/migrate/profile_rule_analysis.go
@@ -64,12 +64,21 @@ type ProfileAnalysisInput struct {
 // profile's data and returns all findings. Order: by Kind then by
 // RuleKey, so the JSONL sidecar is deterministic and tests stay
 // stable.
+//
+// Note on criterion #4 (custom params): #226 specifies this is
+// error-driven, not value-driven — the analyzer should only flag a
+// custom-params finding when an API error occurred trying to migrate
+// the value. Proactive detection (value-differs-from-default) was
+// removed because everything migrates fine via /qualityprofiles/restore
+// in the common case; the analyzer was producing misleading
+// "customised" warnings for params that work end-to-end. A future
+// migrate-time error handler can emit FindingKindCustomParams rows
+// when a per-rule param API call actually fails.
 func AnalyzeProfile(in ProfileAnalysisInput) []ProfileFinding {
 	var out []ProfileFinding
 	out = append(out, detectCustomSeverities(in)...)
 	out = append(out, detectPrioritized(in)...)
 	out = append(out, detectThirdParty(in)...)
-	out = append(out, detectCustomParams(in)...)
 	out = append(out, detectTemplateInstances(in)...)
 	out = append(out, detectDisabledInherited(in)...)
 	return out
@@ -140,46 +149,6 @@ func detectThirdParty(in ProfileAnalysisInput) []ProfileFinding {
 		}
 		out = append(out, profileFinding(in, FindingKindThirdParty, ruleKey,
 			"repository "+repo))
-	}
-	return out
-}
-
-// detectCustomParams — criterion #4: per-activation params carry
-// values that differ from the rule's default. The SQS-side custom
-// values are dropped during SQC restore (the SQC rule uses the
-// language pack's default). Each (rule, param) pair yields one
-// finding.
-//
-// Reads from in.Activations: SonarQube's "actives" map only includes
-// params the operator has actually customised, with the chosen
-// value. Empty / missing entries imply "uses default" — a defensive
-// `val == ""` guard remains so we never flag a param that simply
-// echoes the default.
-func detectCustomParams(in ProfileAnalysisInput) []ProfileFinding {
-	var out []ProfileFinding
-	for _, act := range in.Activations {
-		ruleKey := extractField(act, "key")
-		if ruleKey == "" {
-			continue
-		}
-		base := in.BaseRulesByKey[ruleKey]
-		baseDefaults := ruleParamDefaults(base)
-		for _, p := range ruleParams(act) {
-			name := p["key"]
-			val := p["value"]
-			if name == "" || val == "" {
-				continue
-			}
-			def := baseDefaults[name]
-			if val == def {
-				continue
-			}
-			detail := name + "=" + val
-			if def != "" {
-				detail += " (default " + def + ")"
-			}
-			out = append(out, profileFinding(in, FindingKindCustomParams, ruleKey, detail))
-		}
 	}
 	return out
 }

--- a/go/internal/migrate/profile_rule_analysis.go
+++ b/go/internal/migrate/profile_rule_analysis.go
@@ -50,6 +50,14 @@ type ProfileAnalysisInput struct {
 	// the active-rule severity / params against the base rule's
 	// default and detect template-instantiated rules via templateKey.
 	BaseRulesByKey map[string]json.RawMessage
+	// Activations carries per-rule activation records for THIS
+	// profile, sourced from getProfileRules' "actives" map. Each
+	// record is the activation object decorated with a synthetic
+	// "key" field carrying the rule key. Used by criteria that need
+	// per-activation flags the rule catalog doesn't expose:
+	// prioritizedRule (criterion #2), severity overrides
+	// (criterion #1), custom params with value (criterion #4).
+	Activations []json.RawMessage
 }
 
 // AnalyzeProfile runs every #226 yellow detection across the given
@@ -67,18 +75,19 @@ func AnalyzeProfile(in ProfileAnalysisInput) []ProfileFinding {
 	return out
 }
 
-// detectCustomSeverities — criterion #1: active rule's severity differs
-// from the base rule's default severity, OR its impacts (MQR mode)
-// differ from the base rule's default impacts. Both signal a custom
-// severity choice that does not propagate to SonarQube Cloud.
+// detectCustomSeverities — criterion #1: per-activation severity
+// differs from the base rule's default severity. Reads from
+// in.Activations because the per-activation severity (the one the
+// operator picked for THIS profile) lives in getProfileRules' actives
+// map, not on the rule catalog that getActiveProfileRules emits.
 func detectCustomSeverities(in ProfileAnalysisInput) []ProfileFinding {
 	var out []ProfileFinding
-	for _, ar := range in.ActiveRules {
-		ruleKey := extractField(ar, "key")
+	for _, act := range in.Activations {
+		ruleKey := extractField(act, "key")
 		if ruleKey == "" {
 			continue
 		}
-		activeSeverity := extractField(ar, "severity")
+		activeSeverity := extractField(act, "severity")
 		base := in.BaseRulesByKey[ruleKey]
 		baseSeverity := extractField(base, "severity")
 		if activeSeverity == "" || baseSeverity == "" {
@@ -92,18 +101,24 @@ func detectCustomSeverities(in ProfileAnalysisInput) []ProfileFinding {
 	return out
 }
 
-// detectPrioritized — criterion #2: rule has prioritizedRule=true.
-// Prioritised rules are an SQS concept with no SQC counterpart.
+// detectPrioritized — criterion #2: rule has prioritizedRule=true on
+// THIS profile's activation. Prioritised rules are an SQS concept
+// with no SQC counterpart. Reads from in.Activations because the
+// prioritizedRule flag is per-activation and lives in
+// getProfileRules' "actives" map — not on the rule catalog that
+// getActiveProfileRules emits.
 func detectPrioritized(in ProfileAnalysisInput) []ProfileFinding {
 	var out []ProfileFinding
-	for _, ar := range in.ActiveRules {
-		if !extractBool(ar, "prioritizedRule") {
+	seen := make(map[string]bool)
+	for _, act := range in.Activations {
+		if !extractBool(act, "prioritizedRule") {
 			continue
 		}
-		ruleKey := extractField(ar, "key")
-		if ruleKey == "" {
+		ruleKey := extractField(act, "key")
+		if ruleKey == "" || seen[ruleKey] {
 			continue
 		}
+		seen[ruleKey] = true
 		out = append(out, profileFinding(in, FindingKindPrioritized, ruleKey, ""))
 	}
 	return out
@@ -129,36 +144,30 @@ func detectThirdParty(in ProfileAnalysisInput) []ProfileFinding {
 	return out
 }
 
-// detectCustomParams — criterion #4: active rule's params carry
+// detectCustomParams — criterion #4: per-activation params carry
 // values that differ from the rule's default. The SQS-side custom
 // values are dropped during SQC restore (the SQC rule uses the
-// language pack's default). Each (rule, param) pair yields one finding.
+// language pack's default). Each (rule, param) pair yields one
+// finding.
 //
-// IMPORTANT: SonarQube emits an empty `value` (or omits the field) to
-// signal "this activation uses the rule's default" — only a non-empty
-// value that differs from the rule's default is a genuine custom
-// value. Treating empty as custom (issue #226 follow-up) produced a
-// flood of false positives in the report.
-//
-// Note also that getActiveProfileRules writes the rule CATALOG filtered
-// by activation status; the per-activation custom values actually live
-// in getProfileRules' "actives" map. Reading them here gives a
-// best-effort signal until the analyzer switches data source.
+// Reads from in.Activations: SonarQube's "actives" map only includes
+// params the operator has actually customised, with the chosen
+// value. Empty / missing entries imply "uses default" — a defensive
+// `val == ""` guard remains so we never flag a param that simply
+// echoes the default.
 func detectCustomParams(in ProfileAnalysisInput) []ProfileFinding {
 	var out []ProfileFinding
-	for _, ar := range in.ActiveRules {
-		ruleKey := extractField(ar, "key")
+	for _, act := range in.Activations {
+		ruleKey := extractField(act, "key")
 		if ruleKey == "" {
 			continue
 		}
 		base := in.BaseRulesByKey[ruleKey]
 		baseDefaults := ruleParamDefaults(base)
-		for _, p := range ruleParams(ar) {
+		for _, p := range ruleParams(act) {
 			name := p["key"]
 			val := p["value"]
 			if name == "" || val == "" {
-				// Empty value = activation uses the rule default →
-				// not a custom value, no finding.
 				continue
 			}
 			def := baseDefaults[name]
@@ -249,6 +258,14 @@ var standardRuleRepos = map[string]bool{
 	"common-rpg": true, "rpg": true, "common-vb": true, "vb": true,
 	"common-tsql": true, "tsql": true, "plsql": true, "common-objc": true,
 	"objc": true, "common-c": true, "c": true, "cpp": true,
+	// Recent additions to the Sonar-shipped language set (post-2024).
+	"dart": true, "common-dart": true,
+	"rust": true, "common-rust": true,
+	"ipynb": true,
+	"jcl": true,
+	"shell": true,
+	"ansible": true,
+	"dotnetcli": true,
 }
 
 // ruleParams unmarshals the "params" array on an active-rule record

--- a/go/internal/migrate/profile_rule_analysis_test.go
+++ b/go/internal/migrate/profile_rule_analysis_test.go
@@ -104,47 +104,12 @@ func TestAnalyzeProfile_ThirdParty(t *testing.T) {
 	}
 }
 
-func TestAnalyzeProfile_CustomParams(t *testing.T) {
-	// Per-activation params with values come from getProfileRules'
-	// actives map (decorated with the synthetic rule "key" field).
-	in := ProfileAnalysisInput{
-		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
-		Activations: []json.RawMessage{
-			rawJSON(t, map[string]any{
-				"key":      "java:S1",
-				"qProfile": "qp1",
-				"params": []map[string]string{
-					{"key": "maxLines", "value": "50"},        // custom
-					{"key": "exemptFromMain", "value": "true"}, // matches default
-					{"key": "noValueGiven", "value": ""},       // empty → ignored
-				},
-			}),
-		},
-		BaseRulesByKey: map[string]json.RawMessage{
-			"java:S1": rawJSON(t, map[string]any{
-				"key": "java:S1",
-				"params": []map[string]any{
-					{"key": "maxLines", "defaultValue": "100"},
-					{"key": "exemptFromMain", "defaultValue": "true"},
-					{"key": "noValueGiven", "defaultValue": "X"},
-				},
-			}),
-		},
-	}
-	out := AnalyzeProfile(in)
-	var custom []ProfileFinding
-	for _, f := range out {
-		if f.Kind == FindingKindCustomParams {
-			custom = append(custom, f)
-		}
-	}
-	if len(custom) != 1 {
-		t.Fatalf("expected exactly 1 custom-params finding (only maxLines differs; exemptFromMain matches default; noValueGiven is empty), got %d (%+v)", len(custom), custom)
-	}
-	if custom[0].RuleKey != "java:S1" || custom[0].Detail != "maxLines=50 (default 100)" {
-		t.Errorf("unexpected Detail: got %+v", custom[0])
-	}
-}
+// Criterion #4 (custom params) is now error-driven (#226 follow-up) —
+// the analyzer no longer emits findings proactively. A migrate-time
+// error handler will populate FindingKindCustomParams when a per-rule
+// param API call actually fails. The previous proactive-detection
+// test was removed accordingly; once the error-driven emitter lands,
+// its dedicated test will cover the flow.
 
 func TestAnalyzeProfile_TemplateInstance(t *testing.T) {
 	in := ProfileAnalysisInput{

--- a/go/internal/migrate/profile_rule_analysis_test.go
+++ b/go/internal/migrate/profile_rule_analysis_test.go
@@ -15,11 +15,13 @@ func rawJSON(t *testing.T, v map[string]any) json.RawMessage {
 }
 
 func TestAnalyzeProfile_CustomSeverity(t *testing.T) {
+	// Custom severity is per-activation: lives in getProfileRules'
+	// actives map, decorated with the synthetic "key" rule key.
 	in := ProfileAnalysisInput{
 		CloudProfileKey: "cp1", ProfileName: "Java way", Language: "java",
-		ActiveRules: []json.RawMessage{
-			rawJSON(t, map[string]any{"key": "java:S1", "severity": "CRITICAL", "repo": "java"}),
-			rawJSON(t, map[string]any{"key": "java:S2", "severity": "MAJOR", "repo": "java"}),
+		Activations: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1", "qProfile": "qp1", "severity": "CRITICAL"}),
+			rawJSON(t, map[string]any{"key": "java:S2", "qProfile": "qp1", "severity": "MAJOR"}),
 		},
 		BaseRulesByKey: map[string]json.RawMessage{
 			"java:S1": rawJSON(t, map[string]any{"key": "java:S1", "severity": "MAJOR"}),
@@ -45,12 +47,16 @@ func TestAnalyzeProfile_CustomSeverity(t *testing.T) {
 }
 
 func TestAnalyzeProfile_Prioritized(t *testing.T) {
+	// Prioritized data lives on the per-activation record (sourced
+	// from getProfileRules' "actives" map), NOT on the rule catalog
+	// rows. The migrate task decorates each activation with a
+	// synthetic "key" field carrying the rule key.
 	in := ProfileAnalysisInput{
 		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
-		ActiveRules: []json.RawMessage{
-			rawJSON(t, map[string]any{"key": "java:S1", "prioritizedRule": true, "repo": "java"}),
-			rawJSON(t, map[string]any{"key": "java:S2", "prioritizedRule": false, "repo": "java"}),
-			rawJSON(t, map[string]any{"key": "java:S3", "repo": "java"}),
+		Activations: []json.RawMessage{
+			rawJSON(t, map[string]any{"key": "java:S1", "qProfile": "qp1", "prioritizedRule": true}),
+			rawJSON(t, map[string]any{"key": "java:S2", "qProfile": "qp1", "prioritizedRule": false}),
+			rawJSON(t, map[string]any{"key": "java:S3", "qProfile": "qp1"}),
 		},
 	}
 	out := AnalyzeProfile(in)
@@ -99,15 +105,18 @@ func TestAnalyzeProfile_ThirdParty(t *testing.T) {
 }
 
 func TestAnalyzeProfile_CustomParams(t *testing.T) {
+	// Per-activation params with values come from getProfileRules'
+	// actives map (decorated with the synthetic rule "key" field).
 	in := ProfileAnalysisInput{
 		CloudProfileKey: "cp1", ProfileName: "x", Language: "java",
-		ActiveRules: []json.RawMessage{
+		Activations: []json.RawMessage{
 			rawJSON(t, map[string]any{
-				"key":  "java:S1",
-				"repo": "java",
+				"key":      "java:S1",
+				"qProfile": "qp1",
 				"params": []map[string]string{
 					{"key": "maxLines", "value": "50"},        // custom
 					{"key": "exemptFromMain", "value": "true"}, // matches default
+					{"key": "noValueGiven", "value": ""},       // empty → ignored
 				},
 			}),
 		},
@@ -117,6 +126,7 @@ func TestAnalyzeProfile_CustomParams(t *testing.T) {
 				"params": []map[string]any{
 					{"key": "maxLines", "defaultValue": "100"},
 					{"key": "exemptFromMain", "defaultValue": "true"},
+					{"key": "noValueGiven", "defaultValue": "X"},
 				},
 			}),
 		},
@@ -129,7 +139,7 @@ func TestAnalyzeProfile_CustomParams(t *testing.T) {
 		}
 	}
 	if len(custom) != 1 {
-		t.Fatalf("expected exactly 1 custom-params finding (only maxLines differs), got %d (%+v)", len(custom), custom)
+		t.Fatalf("expected exactly 1 custom-params finding (only maxLines differs; exemptFromMain matches default; noValueGiven is empty), got %d (%+v)", len(custom), custom)
 	}
 	if custom[0].RuleKey != "java:S1" || custom[0].Detail != "maxLines=50 (default 100)" {
 		t.Errorf("unexpected Detail: got %+v", custom[0])

--- a/go/internal/migrate/tasks_analyze_profiles.go
+++ b/go/internal/migrate/tasks_analyze_profiles.go
@@ -22,6 +22,7 @@ func runAnalyzeProfileRules(ctx context.Context, e *Executor) error {
 	activeByProfile := indexExtractByServerAndField(e, "getActiveProfileRules", "profileKey")
 	deactivatedByProfile := indexExtractByServerAndField(e, "getDeactivatedProfileRules", "profileKey")
 	baseByServer := indexBaseRules(e)
+	activationsByProfile := indexProfileActivations(e)
 
 	err := forEachMigrateItem(ctx, e, "analyzeProfileRules", "createProfiles",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
@@ -38,6 +39,7 @@ func runAnalyzeProfileRules(ctx context.Context, e *Executor) error {
 				ActiveRules:               activeByProfile[serverURL+"\x00"+sourceKey],
 				DeactivatedInheritedRules: deactivatedByProfile[serverURL+"\x00"+sourceKey],
 				BaseRulesByKey:            baseByServer[serverURL],
+				Activations:               activationsByProfile[serverURL+"\x00"+sourceKey],
 			}
 			findings := AnalyzeProfile(input)
 			for _, f := range findings {
@@ -70,6 +72,41 @@ func indexExtractByServerAndField(e *Executor, task, field string) map[string][]
 		}
 		key := it.ServerURL + "\x00" + val
 		out[key] = append(out[key], it.Data)
+	}
+	return out
+}
+
+// indexProfileActivations parses getProfileRules JSONL records — each
+// record is a map of ruleKey → array of activations (one per profile
+// that has the rule active) sourced from SonarQube's "actives" map.
+// Flatten across all chunks and group by (serverURL, qProfile) so the
+// analyzer can look up "the activations belonging to THIS profile" in
+// O(1). Each activation is decorated with a synthetic "key" field
+// carrying the rule key so downstream detectors can read it without
+// having to thread the rule key separately.
+func indexProfileActivations(e *Executor) map[string][]json.RawMessage {
+	items, _ := readExtractItems(e, "getProfileRules")
+	out := make(map[string][]json.RawMessage)
+	for _, it := range items {
+		var rulesMap map[string]json.RawMessage
+		if err := json.Unmarshal(it.Data, &rulesMap); err != nil {
+			continue
+		}
+		for ruleKey, activationsRaw := range rulesMap {
+			var activations []json.RawMessage
+			if err := json.Unmarshal(activationsRaw, &activations); err != nil {
+				continue
+			}
+			for _, act := range activations {
+				qProfile := extractField(act, "qProfile")
+				if qProfile == "" {
+					continue
+				}
+				enriched := common.EnrichRaw(act, map[string]any{"key": ruleKey})
+				bucket := it.ServerURL + "\x00" + qProfile
+				out[bucket] = append(out[bucket], enriched)
+			}
+		}
 	}
 	return out
 }

--- a/go/internal/predict/profile_notes.go
+++ b/go/internal/predict/profile_notes.go
@@ -24,6 +24,7 @@ func synthesizeAnalyzeProfileRulesNotes(exportDir, runDir string, extractMapping
 	activeByProfile := indexExtractRecords(exportDir, extractMapping, "getActiveProfileRules", "profileKey")
 	deactivatedByProfile := indexExtractRecords(exportDir, extractMapping, "getDeactivatedProfileRules", "profileKey")
 	baseByServer := indexBaseRulesByServer(exportDir, extractMapping)
+	activationsByProfile := indexProfileActivationsForPredict(exportDir, extractMapping)
 
 	w, err := store.Writer("analyzeProfileRules")
 	if err != nil {
@@ -44,6 +45,7 @@ func synthesizeAnalyzeProfileRulesNotes(exportDir, runDir string, extractMapping
 			ActiveRules:               activeByProfile[serverURL+"\x00"+sourceKey],
 			DeactivatedInheritedRules: deactivatedByProfile[serverURL+"\x00"+sourceKey],
 			BaseRulesByKey:            baseByServer[serverURL],
+			Activations:               activationsByProfile[serverURL+"\x00"+sourceKey],
 		}
 		for _, f := range migrate.AnalyzeProfile(in) {
 			b, err := json.Marshal(f)
@@ -71,6 +73,39 @@ func indexExtractRecords(exportDir string, mapping structure.ExtractMapping, tas
 		}
 		key := it.ServerURL + "\x00" + val
 		out[key] = append(out[key], it.Data)
+	}
+	return out
+}
+
+// indexProfileActivationsForPredict mirrors migrate.indexProfileActivations
+// for the predict pipeline: parses getProfileRules JSONL records — each
+// record is a map of ruleKey → array of activations — and groups them
+// by (serverURL, qProfile). Each activation is decorated with a
+// synthetic "key" field so the shared analyzer can read the rule key
+// without an out-of-band parameter.
+func indexProfileActivationsForPredict(exportDir string, mapping structure.ExtractMapping) map[string][]json.RawMessage {
+	items, _ := structure.ReadExtractData(exportDir, mapping, "getProfileRules")
+	out := make(map[string][]json.RawMessage)
+	for _, it := range items {
+		var rulesMap map[string]json.RawMessage
+		if err := json.Unmarshal(it.Data, &rulesMap); err != nil {
+			continue
+		}
+		for ruleKey, activationsRaw := range rulesMap {
+			var activations []json.RawMessage
+			if err := json.Unmarshal(activationsRaw, &activations); err != nil {
+				continue
+			}
+			for _, act := range activations {
+				qProfile := jsonStringField(act, "qProfile")
+				if qProfile == "" {
+					continue
+				}
+				enriched := common.EnrichRaw(act, map[string]any{"key": ruleKey})
+				bucket := it.ServerURL + "\x00" + qProfile
+				out[bucket] = append(out[bucket], enriched)
+			}
+		}
 	}
 	return out
 }

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -553,6 +553,11 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 		successLabel = "Perfect"
 	}
 
+	// Quality profile cloud ids (cloud_profile_key) are opaque SQC
+	// identifiers, not user-facing — strip them from the Details
+	// column for the Quality Profiles section regardless of mode.
+	hideCloudKey := section.Name == "Quality Profiles"
+
 	for _, item := range section.Succeeded {
 		rows = append(rows, unifiedRow{
 			name:     item.Name,
@@ -560,7 +565,7 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 			org:      item.Organization,
 			outcome:  successLabel,
 			color:    colorGreen,
-			details:  successDetails(item, predictive),
+			details:  successDetails(item, predictive, hideCloudKey),
 		})
 	}
 	for _, item := range section.NearPerfect {
@@ -574,7 +579,7 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 			org:      item.Organization,
 			outcome:  outcomeNearPerfect,
 			color:    colorYellow,
-			details:  partialDetails(item, predictive),
+			details:  partialDetails(item, predictive, hideCloudKey),
 		})
 	}
 	for _, item := range section.Partial {
@@ -588,7 +593,7 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 			org:      item.Organization,
 			outcome:  outcomePartial,
 			color:    colorAmber,
-			details:  partialDetails(item, predictive),
+			details:  partialDetails(item, predictive, hideCloudKey),
 		})
 	}
 	for _, item := range section.Failed {
@@ -635,9 +640,9 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 // other Detail string (e.g. the #249 dbcleaner-branches transformation
 // note) is kept verbatim so genuinely informative content reaches the
 // report.
-func successDetails(item EntityItem, predictive bool) string {
+func successDetails(item EntityItem, predictive, hideCloudKey bool) string {
 	cloudKey, scan, ncdFallback := parseProjectDetailMarkers(item.Detail)
-	if predictive && strings.HasPrefix(cloudKey, "predict:") {
+	if hideCloudKey || (predictive && strings.HasPrefix(cloudKey, "predict:")) {
 		cloudKey = ""
 	}
 	parts := []string{}
@@ -661,10 +666,10 @@ func successDetails(item EntityItem, predictive bool) string {
 // synthetic predict:<task>:<org>:<name> placeholder is suppressed
 // (issue #240). Non-synthetic Detail strings are kept so genuinely
 // informative content (e.g. transformation notes) still renders.
-func partialDetails(item EntityItem, predictive bool) string {
+func partialDetails(item EntityItem, predictive, hideCloudKey bool) string {
 	issues := strings.Join(item.Issues, "\n")
 	detail := item.Detail
-	if predictive && strings.HasPrefix(detail, "predict:") {
+	if hideCloudKey || (predictive && strings.HasPrefix(detail, "predict:")) {
 		detail = ""
 	}
 	if detail != "" && issues != "" {

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -404,7 +404,7 @@ func TestUnifiedRowDisplayNameWithLanguage(t *testing.T) {
 }
 
 func TestSuccessDetailsScanHistory(t *testing.T) {
-	got := successDetails(EntityItem{Detail: "proj1|scan:failed"}, false)
+	got := successDetails(EntityItem{Detail: "proj1|scan:failed"}, false, false)
 	if !strings.Contains(got, "proj1") || !strings.Contains(got, "Failed") {
 		t.Errorf("expected scan history in details, got %q", got)
 	}

--- a/go/internal/report/summary/profile_notes.go
+++ b/go/internal/report/summary/profile_notes.go
@@ -71,20 +71,39 @@ func collectProfileFindings(store *common.DataStore) map[string]*profileFindings
 				continue
 			}
 			// Dedup by rule key — the analyzer can emit several rows
-			// per rule (one per parameter for criterion #4); fold them
-			// onto a single bullet per rule with all details inlined.
+			// per rule (one per parameter for criterion #4, one per
+			// source-org-mapped profile when several SQS orgs migrate
+			// into the same SQC org). Fold onto a single bullet per
+			// rule with deduplicated detail strings inlined.
 			sort.SliceStable(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
 			byRule := make(map[string][]string)
+			seenDetail := make(map[string]map[string]bool)
 			var order []string
 			for _, e := range entries {
 				if _, seen := byRule[e.key]; !seen {
 					order = append(order, e.key)
+					byRule[e.key] = nil
+					seenDetail[e.key] = make(map[string]bool)
 				}
-				if e.detail != "" {
-					byRule[e.key] = append(byRule[e.key], e.detail)
-				} else {
-					byRule[e.key] = byRule[e.key] // ensure key present
+				if e.detail == "" || seenDetail[e.key][e.detail] {
+					continue
 				}
+				seenDetail[e.key][e.detail] = true
+				byRule[e.key] = append(byRule[e.key], e.detail)
+			}
+			// Per-criterion rendering: a few criteria collapse to a
+			// single sentence with the rule keys comma-separated.
+			// custom-severity drops the severity-transition detail
+			// (the message itself states the outcome — revert to
+			// default), and third-party drops the repo name (the
+			// message itself says the rules will be removed).
+			if kind == "custom-severity" {
+				lines = append(lines, "Because rules custom severities are not supported in SQC, the following rules with will be reverted to their default severities: "+strings.Join(order, ", "))
+				continue
+			}
+			if kind == "third-party" {
+				lines = append(lines, "Because SQC does not support 3rd party plugins, the following 3rd party rules will be removed from the quality profile: "+strings.Join(order, ", "))
+				continue
 			}
 			var ruleLines []string
 			for _, k := range order {

--- a/go/internal/report/summary/profile_notes.go
+++ b/go/internal/report/summary/profile_notes.go
@@ -69,6 +69,33 @@ func collectProfileFindings(store *common.DataStore) map[string]*profileFindings
 
 	out := make(map[string]*profileFindings, len(byProfile))
 	for cloudKey, kinds := range byProfile {
+		// Instantiated rules (template-instance criterion) always
+		// have a custom severity, so they'd also appear under the
+		// custom-severity criterion. Suppress them there since the
+		// template-instance message already says the rule is not
+		// migrated at all — reporting a severity revert for the
+		// same rule is misleading.
+		if templateEntries, hasTemplate := kinds["template-instance"]; hasTemplate {
+			instantiated := make(map[string]bool, len(templateEntries))
+			for _, e := range templateEntries {
+				instantiated[e.key] = true
+			}
+			if csEntries := kinds["custom-severity"]; len(csEntries) > 0 {
+				filtered := csEntries[:0]
+				for _, e := range csEntries {
+					if instantiated[e.key] {
+						continue
+					}
+					filtered = append(filtered, e)
+				}
+				if len(filtered) == 0 {
+					delete(kinds, "custom-severity")
+				} else {
+					kinds["custom-severity"] = filtered
+				}
+			}
+		}
+
 		var lines []string
 		// Render in a stable order — matches the criterion order in
 		// the issue so the report reads the same way every time.

--- a/go/internal/report/summary/profile_notes.go
+++ b/go/internal/report/summary/profile_notes.go
@@ -21,11 +21,18 @@ type profileFinding struct {
 	Detail          string `json:"detail,omitempty"`
 }
 
-// profileFindingsByGate groups the per-rule findings emitted by the
+// profileFindings groups the per-rule findings emitted by the
 // analyzeProfileRules task into one human-readable Issues list per
 // quality profile. The outer map is keyed by cloud_profile_key.
+//
+// HasOrangeCriterion is true when at least one finding belongs to a
+// criterion treated as Partial (orange) rather than NearPerfect
+// (yellow) — currently just "third-party" rules. Those represent a
+// real loss of coverage on SQC (rules dropped from the profile), so
+// the QP should be classified Partial.
 type profileFindings struct {
-	Issues []string
+	Issues             []string
+	HasOrangeCriterion bool
 }
 
 // collectProfileFindings reads analyzeProfileRules JSONL and folds
@@ -105,6 +112,22 @@ func collectProfileFindings(store *common.DataStore) map[string]*profileFindings
 				lines = append(lines, "Because SQC does not support 3rd party plugins, the following 3rd party rules will be removed from the quality profile: "+strings.Join(order, ", "))
 				continue
 			}
+			if kind == "prioritized" {
+				lines = append(lines, "Since SQC does not support prioritized rules, the following rules will be migrated in the profile as regular rules: "+strings.Join(order, ", "))
+				continue
+			}
+			if kind == "template-instance" {
+				lines = append(lines, "Because rule templates and instantiated rules are not supported in SQC, the following rules will not be migrated: "+strings.Join(order, ", "))
+				continue
+			}
+			if kind == "custom-params" {
+				lines = append(lines, "The following rules custom parameters could not be migrated due to an unexpected error: "+strings.Join(order, ", "))
+				continue
+			}
+			if kind == "disabled-inherited" {
+				lines = append(lines, "Since SQC does not support parent profile rules disabled in child profiles, the following rules will be enabled in the profile: "+strings.Join(order, ", "))
+				continue
+			}
 			var ruleLines []string
 			for _, k := range order {
 				if details := byRule[k]; len(details) > 0 {
@@ -118,7 +141,11 @@ func collectProfileFindings(store *common.DataStore) map[string]*profileFindings
 		if len(lines) == 0 {
 			continue
 		}
-		out[cloudKey] = &profileFindings{Issues: lines}
+		_, hasOrange := kinds["third-party"]
+		out[cloudKey] = &profileFindings{
+			Issues:             lines,
+			HasOrangeCriterion: hasOrange,
+		}
 	}
 	return out
 }
@@ -157,7 +184,15 @@ func applyProfileFindings(succeeded, nearPerfect, partial []EntityItem, findings
 			Detail:       item.Detail,
 			Issues:       append([]string(nil), f.Issues...),
 		}
-		nearPerfect = append(nearPerfect, moved)
+		// 3rd-party rules (and any other future orange criteria) are
+		// a real loss of coverage on SQC — route the QP into Partial
+		// rather than NearPerfect. All other yellow criteria stay
+		// NearPerfect.
+		if f.HasOrangeCriterion {
+			partial = append(partial, moved)
+		} else {
+			nearPerfect = append(nearPerfect, moved)
+		}
 	}
 
 	// Extend Partial entries with the yellow findings (orange dominates).


### PR DESCRIPTION
## Summary

Follow-up to PR #254, finishing up #226 (QP migration report accuracy). Also closes several duplicates filed against the same area.

Closes #226.
Closes #241.
Closes #130. (duplicate — third-party plugin rules)
Closes #131. (duplicate — instantiated rules)
Closes #132. (duplicate — parameterized rules with custom params)

### Bug fixes

- **Dart (and 7 other modern Sonar languages) added to `standardRuleRepos`** — `dart:*` rules were being mass-flagged as 3rd-party plugin rules. Also covered: `rust`, `ipynb`, `jcl`, `shell`, `ansible`, `dotnetcli`, and the `common-*` siblings.
- **Detail-string dedup** — when several SQS source orgs migrated into the same SQC org, the report column repeated each rule's detail N times (e.g. `(repository dart, repository dart, repository dart)`). Each `(rule, detail)` is now rendered at most once per profile.
- **Detection data source fixed** for criteria 1 (custom severity), 2 (prioritized), 4 (custom params). Previously read from `getActiveProfileRules`, which is the rule catalog filtered by activation — not the per-activation overrides. The analyzer now also reads `getProfileRules`' `actives` map and joins by `(serverURL, qProfile)` to get the real per-activation values.
- **Instantiated rules** filtered out of the custom-severity bullet — they're already covered by the template-instance bullet ("rules will not be migrated"), and reporting a severity revert on the same rules is misleading.

### Yellow / orange routing

3rd-party plugin rules now route the parent QP into **Partial** (orange) rather than NearPerfect — they represent a real loss of coverage on SQC, not a near-perfect migration. All other yellow criteria still produce NearPerfect.

### Rendering tweaks

- Cloud profile id (`cloud_profile_key`) is stripped from the Details column for Quality Profiles regardless of mode. It's an opaque SQC identifier with no user-facing value. Projects (where `cloud_project_key` IS meaningful) and other sections are unaffected.
- Per-criterion wording finalised to single-sentence, comma-separated rule keys per the issue:

| Criterion | Wording |
|-----------|---------|
| custom-severity | "Because rules custom severities are not supported in SQC, the following rules with will be reverted to their default severities: \<keys\>" |
| third-party | "Because SQC does not support 3rd party plugins, the following 3rd party rules will be removed from the quality profile: \<keys\>" |
| prioritized | "Since SQC does not support prioritized rules, the following rules will be migrated in the profile as regular rules: \<keys\>" |
| template-instance | "Because rule templates and instantiated rules are not supported in SQC, the following rules will not be migrated: \<keys\>" |
| custom-params | "The following rules custom parameters could not be migrated due to an unexpected error: \<keys\>" |
| disabled-inherited | "Since SQC does not support parent profile rules disabled in child profiles, the following rules will be enabled in the profile: \<keys\>" |

### Custom-params: proactive -> error-driven

Per #226's "this should never happen except for an API error" clause, the analyzer no longer proactively flags any param value that differs from the rule default. That detection was producing misleading "customised" warnings for params that migrate fine via `/qualityprofiles/restore`. A future migrate-time error handler can populate `FindingKindCustomParams` rows when a per-rule param API call actually fails; the rendering wording for that future flow is in place.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] Real-world smoke against `./files`: 4 custom-severity findings + 1 template-instance, no more spurious custom-params, no more `dart:*` mis-classified as third-party, no more double-reporting of instantiated rules under custom-severity.

Generated with Claude Code
