### PR TITLE
Hide Quality Gate cloud id from the Details column

### DIFF
--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -581,7 +581,7 @@ func buildUnifiedRows(section Section, predictive bool) []unifiedRow {
 	// Cloud-side internal ids carry no user value in the report:
 	// suppress them in the Details column for sections where they
 	// dominate the cell (QP cloud key, Portfolio cloud id).
-	hideCloudKey := section.Name == "Quality Profiles" || section.Name == "Portfolios"
+	hideCloudKey := section.Name == "Quality Profiles" || section.Name == "Portfolios" || section.Name == "Quality Gates"
 
 	for _, item := range section.Succeeded {
 		rows = append(rows, unifiedRow{

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -368,8 +368,11 @@ func TestBuildUnifiedRowsOrdering(t *testing.T) {
 	if rows[4].name != "GateD" {
 		t.Errorf("expected unused skipped second, got name %q", rows[4].name)
 	}
-	if rows[1].details != "43\nAdd condition: foo" {
-		t.Errorf("expected partial details to combine cloud key + issues on separate lines, got %q", rows[1].details)
+	// Quality Gates hide the opaque cloud gate id from Details
+	// (same treatment as Quality Profiles and Portfolios), so the
+	// partial row should render only the Issues lines.
+	if rows[1].details != "Add condition: foo" {
+		t.Errorf("expected partial details to be issues only (cloud key suppressed for QG), got %q", rows[1].details)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add "Quality Gates" to the set of sections that suppress the SQC-side cloud id from the Details column (already applied to Quality Profiles and Portfolios).
- The opaque cloud id carries no actionable information; the freed space lets QG condition Issues read more cleanly.

## Test plan
- [x] `go test ./...` clean (updated `TestBuildUnifiedRowsOrdering` to expect the new behavior)
- [x] Predictive PDF re-rendered against local fixtures — QG cloud id no longer in Details

🤖 Generated with [Claude Code](https://claude.com/claude-code)