### PR TITLE
Issue #229 differentiate portfolio composition + combine subportfolios

### DIFF
--- a/go/internal/migrate/portfolio_analysis.go
+++ b/go/internal/migrate/portfolio_analysis.go
@@ -1,0 +1,142 @@
+package migrate
+
+import "strings"
+
+// PortfolioComposition summarises how a SonarQube Server portfolio
+// resolves on SonarQube Cloud, which has no portfolio hierarchy and
+// no concept of applications. Issue #229.
+//
+// The four flags drive both the migrate-side configuration of the SQC
+// portfolio and the report-side green/yellow/orange classification.
+// A portfolio whose direct subviews are only projects (no APP, no VW
+// or SVW) returns the zero value — i.e. no special handling required.
+type PortfolioComposition struct {
+	// HasApps is true when at least one direct subview is an
+	// application reference (qualifier APP). Apps do not exist on
+	// SonarQube Cloud and are substituted by the projects they
+	// enclose at extract time.
+	HasApps bool
+	// HasSubportfolios is true when at least one direct subview is a
+	// subportfolio (qualifier VW or SVW). SQC has no portfolio
+	// hierarchy, so the source structure has to be flattened.
+	HasSubportfolios bool
+	// DepthGT1 is true when at least one direct subportfolio itself
+	// has subportfolios — the source structure cannot be replicated
+	// as a single SQC portfolio with one selection criterion.
+	DepthGT1 bool
+	// CommonSelectionMode is the shared selection_mode of every
+	// direct subportfolio when they all agree on one of REGEXP,
+	// TAGS, MANUAL. Empty otherwise.
+	CommonSelectionMode string
+	// MixedSelectionModes is true when direct subportfolios use more
+	// than one selection_mode (and CommonSelectionMode is empty), or
+	// when at least one direct subportfolio has no selection_mode at
+	// all and cannot be combined.
+	MixedSelectionModes bool
+	// Subportfolios captures the per-subportfolio selection criteria
+	// needed by the migrate-side combination (regex alternation,
+	// tag union, manual fallback). Only populated for direct VW/SVW
+	// children; never includes APP nodes.
+	Subportfolios []SubportfolioCriteria
+}
+
+// SubportfolioCriteria is one direct subportfolio's selection data,
+// used by the parent-side combination when CommonSelectionMode is set.
+type SubportfolioCriteria struct {
+	Key           string
+	Name          string
+	SelectionMode string
+	Regexp        string
+	Tags          []string
+}
+
+// AnalyzePortfolio inspects a getPortfolioDetails record and
+// classifies its composition. The caller passes the JSON-decoded map
+// for the top-level portfolio (api/views/show response).
+func AnalyzePortfolio(details map[string]any) PortfolioComposition {
+	var pc PortfolioComposition
+	subViews, _ := details["subViews"].([]any)
+	if len(subViews) == 0 {
+		return pc
+	}
+	seenModes := map[string]bool{}
+	for _, sub := range subViews {
+		m, ok := sub.(map[string]any)
+		if !ok {
+			continue
+		}
+		switch strOf(m, "qualifier") {
+		case "APP":
+			pc.HasApps = true
+		case "VW", "SVW":
+			pc.HasSubportfolios = true
+			if grand, _ := m["subViews"].([]any); len(grand) > 0 {
+				pc.DepthGT1 = true
+			}
+			crit := SubportfolioCriteria{
+				Key:           strOf(m, "key"),
+				Name:          strOf(m, "name"),
+				SelectionMode: strings.ToUpper(strOf(m, "selectionMode")),
+				Regexp:        strOf(m, "regexp"),
+				Tags:          tagsOf(m),
+			}
+			if crit.SelectionMode == "REGEXP" || crit.SelectionMode == "TAGS" || crit.SelectionMode == "MANUAL" {
+				seenModes[crit.SelectionMode] = true
+			}
+			pc.Subportfolios = append(pc.Subportfolios, crit)
+		}
+	}
+	if pc.HasSubportfolios {
+		switch len(seenModes) {
+		case 1:
+			for m := range seenModes {
+				pc.CommonSelectionMode = m
+			}
+			// All direct subportfolios share one of the three
+			// combinable modes. If one of them has no selection
+			// mode at all (e.g. nested-VW), the combination is no
+			// longer clean — flag mixed.
+			for _, sp := range pc.Subportfolios {
+				if sp.SelectionMode != pc.CommonSelectionMode {
+					pc.CommonSelectionMode = ""
+					pc.MixedSelectionModes = true
+					break
+				}
+			}
+		default:
+			pc.MixedSelectionModes = true
+		}
+	}
+	return pc
+}
+
+func strOf(m map[string]any, k string) string {
+	s, _ := m[k].(string)
+	return s
+}
+
+// tagsOf reads the "tags" field of a subview, handling both the
+// comma-separated string form (used by api/views/show output and the
+// portfolios.csv mapping) and the JSON array form (some SQS versions).
+func tagsOf(m map[string]any) []string {
+	if s, _ := m["tags"].(string); s != "" {
+		parts := strings.Split(s, ",")
+		out := make([]string, 0, len(parts))
+		for _, p := range parts {
+			if p = strings.TrimSpace(p); p != "" {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	if arr, _ := m["tags"].([]any); len(arr) > 0 {
+		out := make([]string, 0, len(arr))
+		for _, v := range arr {
+			if s, _ := v.(string); s != "" {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}

--- a/go/internal/migrate/portfolio_analysis_test.go
+++ b/go/internal/migrate/portfolio_analysis_test.go
@@ -1,0 +1,190 @@
+package migrate
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAnalyzePortfolio_EmptyAndPlain(t *testing.T) {
+	cases := map[string]map[string]any{
+		"empty":         {},
+		"projects only": {"subViews": []any{}},
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			pc := AnalyzePortfolio(in)
+			if pc.HasApps || pc.HasSubportfolios || pc.DepthGT1 || pc.MixedSelectionModes || pc.CommonSelectionMode != "" {
+				t.Errorf("%s: expected zero composition, got %+v", name, pc)
+			}
+		})
+	}
+}
+
+func TestAnalyzePortfolio_AppsOnly(t *testing.T) {
+	pc := AnalyzePortfolio(map[string]any{
+		"subViews": []any{
+			map[string]any{"qualifier": "APP", "key": "app1"},
+			map[string]any{"qualifier": "APP", "key": "app2"},
+		},
+	})
+	if !pc.HasApps || pc.HasSubportfolios || pc.DepthGT1 {
+		t.Errorf("apps-only: %+v", pc)
+	}
+}
+
+func TestAnalyzePortfolio_UniformRegexp_Depth1(t *testing.T) {
+	pc := AnalyzePortfolio(map[string]any{
+		"subViews": []any{
+			map[string]any{"qualifier": "SVW", "key": "a", "selectionMode": "REGEXP", "regexp": ".*-RETAIL-.*"},
+			map[string]any{"qualifier": "SVW", "key": "b", "selectionMode": "REGEXP", "regexp": ".*-INVEST-.*"},
+		},
+	})
+	if !pc.HasSubportfolios || pc.DepthGT1 || pc.MixedSelectionModes {
+		t.Errorf("uniform regexp depth 1: %+v", pc)
+	}
+	if pc.CommonSelectionMode != "REGEXP" {
+		t.Errorf("expected REGEXP common mode, got %q", pc.CommonSelectionMode)
+	}
+	if len(pc.Subportfolios) != 2 {
+		t.Fatalf("expected 2 subportfolios captured, got %d", len(pc.Subportfolios))
+	}
+}
+
+func TestAnalyzePortfolio_MixedModes(t *testing.T) {
+	pc := AnalyzePortfolio(map[string]any{
+		"subViews": []any{
+			map[string]any{"qualifier": "SVW", "key": "a", "selectionMode": "REGEXP", "regexp": ".*"},
+			map[string]any{"qualifier": "SVW", "key": "b", "selectionMode": "TAGS", "tags": "x,y"},
+		},
+	})
+	if !pc.MixedSelectionModes || pc.CommonSelectionMode != "" {
+		t.Errorf("mixed: %+v", pc)
+	}
+}
+
+func TestAnalyzePortfolio_DepthGT1(t *testing.T) {
+	pc := AnalyzePortfolio(map[string]any{
+		"subViews": []any{
+			map[string]any{
+				"qualifier": "VW", "key": "a", "selectionMode": "REGEXP", "regexp": ".*",
+				"subViews": []any{
+					map[string]any{"qualifier": "SVW", "key": "a1"},
+				},
+			},
+		},
+	})
+	if !pc.DepthGT1 {
+		t.Errorf("expected DepthGT1, got %+v", pc)
+	}
+}
+
+func TestAnalyzePortfolio_TagsAsArrayAndCSV(t *testing.T) {
+	pc := AnalyzePortfolio(map[string]any{
+		"subViews": []any{
+			map[string]any{"qualifier": "SVW", "key": "a", "selectionMode": "TAGS", "tags": "python,backend"},
+			map[string]any{"qualifier": "SVW", "key": "b", "selectionMode": "TAGS", "tags": []any{"frontend", "react"}},
+		},
+	})
+	if pc.CommonSelectionMode != "TAGS" {
+		t.Errorf("expected TAGS, got %q", pc.CommonSelectionMode)
+	}
+	if !reflect.DeepEqual(pc.Subportfolios[0].Tags, []string{"python", "backend"}) {
+		t.Errorf("csv tags: %v", pc.Subportfolios[0].Tags)
+	}
+	if !reflect.DeepEqual(pc.Subportfolios[1].Tags, []string{"frontend", "react"}) {
+		t.Errorf("array tags: %v", pc.Subportfolios[1].Tags)
+	}
+}
+
+// Migrate-side combination for the three uniform-subportfolio modes.
+func TestResolveEffectivePortfolioConfig_RegexpAlternationWithOrgPrefix(t *testing.T) {
+	pc := PortfolioComposition{
+		HasSubportfolios:    true,
+		CommonSelectionMode: "REGEXP",
+		Subportfolios: []SubportfolioCriteria{
+			{SelectionMode: "REGEXP", Regexp: ".*-RETAIL-.*"},
+			{SelectionMode: "REGEXP", Regexp: ".*-INVEST-.*"},
+		},
+	}
+	mode, regex, _ := resolveEffectivePortfolioConfig("", "", "", pc, []string{"acme"})
+	if mode != "REGEXP" {
+		t.Fatalf("expected REGEXP, got %q", mode)
+	}
+	// transformPortfolioRegex prepends "<org>_" (the SQC project-key
+	// prefix) to each subportfolio regex before alternation.
+	if regex != "(acme_.*-RETAIL-.*|acme_.*-INVEST-.*)" {
+		t.Errorf("combined regex: %q", regex)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_TagsUnion(t *testing.T) {
+	pc := PortfolioComposition{
+		HasSubportfolios:    true,
+		CommonSelectionMode: "TAGS",
+		Subportfolios: []SubportfolioCriteria{
+			{SelectionMode: "TAGS", Tags: []string{"python", "backend"}},
+			{SelectionMode: "TAGS", Tags: []string{"frontend", "python"}}, // dedup
+		},
+	}
+	mode, _, tags := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	if mode != "TAGS" {
+		t.Fatalf("expected TAGS, got %q", mode)
+	}
+	if !reflect.DeepEqual(tags, []string{"python", "backend", "frontend"}) {
+		t.Errorf("union tags: %v", tags)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_MixedFlattensToManual(t *testing.T) {
+	pc := PortfolioComposition{
+		HasSubportfolios:    true,
+		MixedSelectionModes: true,
+	}
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	if mode != "MANUAL" {
+		t.Errorf("expected MANUAL for mixed, got %q", mode)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_DepthGT1FlattensToManual(t *testing.T) {
+	pc := PortfolioComposition{
+		HasSubportfolios: true,
+		DepthGT1:         true,
+	}
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	if mode != "MANUAL" {
+		t.Errorf("expected MANUAL for depth>1, got %q", mode)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_RestModeFlattensToManual(t *testing.T) {
+	mode, _, _ := resolveEffectivePortfolioConfig("REST", "", "", PortfolioComposition{}, nil)
+	if mode != "MANUAL" {
+		t.Errorf("REST should flatten to MANUAL, got %q", mode)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_AppsOnlyFlattensToManual(t *testing.T) {
+	pc := PortfolioComposition{HasApps: true}
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	if mode != "MANUAL" {
+		t.Errorf("apps-only should flatten to MANUAL, got %q", mode)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_OwnRegexpUnchanged(t *testing.T) {
+	mode, regex, _ := resolveEffectivePortfolioConfig("REGEXP", "^pre", "", PortfolioComposition{}, []string{"acme"})
+	if mode != "REGEXP" {
+		t.Fatalf("expected REGEXP, got %q", mode)
+	}
+	if regex != "^acme_pre" {
+		t.Errorf("transformed own regex: %q", regex)
+	}
+}
+
+func TestResolveEffectivePortfolioConfig_EmptyPlainPortfolio(t *testing.T) {
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", PortfolioComposition{}, nil)
+	if mode != "" {
+		t.Errorf("plain empty portfolio: expected no config, got %q", mode)
+	}
+}

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -337,11 +337,23 @@ func runCreatePortfolios(ctx context.Context, e *Executor) error {
 		existingByName = map[string]string{}
 	}
 
+	// Empty portfolios (no resolved projects on the source) are not
+	// migrated — there is nothing to populate them with on SQC. The
+	// summary report surfaces them in the Skipped bucket via the
+	// generatePortfolioMappings + getPortfolioProjects join.
+	emptySourceKeys := buildEmptyPortfolioSet(e)
+
 	counter := NewTaskCounter("createPortfolios")
 	err = forEachMigrateItem(ctx, e, "createPortfolios", "generatePortfolioMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			name := extractField(item, "name")
 			desc := extractField(item, "description")
+			serverURL := extractField(item, "server_url")
+			sourceKey := extractField(item, "source_portfolio_key")
+			if emptySourceKeys[serverURL+"|"+sourceKey] {
+				e.Logger.Info("createPortfolios: skipping empty source portfolio", "name", name, "source_key", sourceKey)
+				return nil
+			}
 
 			if existingID, ok := existingByName[name]; ok {
 				e.Logger.Info("createPortfolios: already exists, reusing", "name", name, "id", existingID)

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -212,12 +212,20 @@ func TestCreatePortfoliosReusesExisting(t *testing.T) {
 
 	dir := t.TempDir()
 	setupExtractData(dir)
+	// Inject one resolved project for src-1 so the portfolio is not
+	// considered "empty" and skipped by the new empty-portfolio guard
+	// in createPortfolios. The serverURL has to match the test
+	// executor's extract Mapping (testServerURL) so readExtractItems
+	// can find this record.
+	writeJSONL(filepath.Join(dir, "extract-01", "getPortfolioProjects"), []map[string]any{
+		{"portfolioKey": "src-1", "refKey": "proj-a", "serverUrl": testServerURL},
+	})
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
 
 	// Write a portfolios.csv with the same name as the pre-existing portfolio.
 	csvPath := filepath.Join(dir, "portfolios.csv")
 	csv := "source_portfolio_key,name,server_url,description\n" +
-		"src-1,PreExistingPortfolio,https://sq.example.com,Reused\n"
+		"src-1,PreExistingPortfolio," + testServerURL + ",Reused\n"
 	if err := os.WriteFile(csvPath, []byte(csv), 0o644); err != nil {
 		t.Fatalf("write portfolios.csv: %v", err)
 	}

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -383,10 +383,7 @@ func buildEmptyPortfolioSet(e *Executor) map[string]bool {
 	for _, it := range items {
 		pk := extractField(it.Data, "portfolioKey")
 		rk := extractField(it.Data, "refKey")
-		// ERROR-status entries are orphaned references to deleted
-		// projects — they do not count as real portfolio membership
-		// and must not save a portfolio from the empty classification.
-		if pk == "" || rk == "" || strings.EqualFold(extractField(it.Data, "status"), "ERROR") {
+		if pk == "" || rk == "" {
 			continue
 		}
 		nonEmpty[it.ServerURL+"|"+pk] = true

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -383,7 +383,10 @@ func buildEmptyPortfolioSet(e *Executor) map[string]bool {
 	for _, it := range items {
 		pk := extractField(it.Data, "portfolioKey")
 		rk := extractField(it.Data, "refKey")
-		if pk == "" || rk == "" {
+		// ERROR-status entries are orphaned references to deleted
+		// projects — they do not count as real portfolio membership
+		// and must not save a portfolio from the empty classification.
+		if pk == "" || rk == "" || strings.EqualFold(extractField(it.Data, "status"), "ERROR") {
 			continue
 		}
 		nonEmpty[it.ServerURL+"|"+pk] = true

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -369,6 +369,40 @@ func transformPortfolioRegex(regex string, orgKeys []string) string {
 	return prefix + regex
 }
 
+// buildEmptyPortfolioSet returns composite serverURL|portfolioKey strings
+// for every source portfolio that has zero resolved projects in the
+// getPortfolioProjects extract. Used by createPortfolios to skip
+// portfolios that would land empty on SonarQube Cloud anyway.
+func buildEmptyPortfolioSet(e *Executor) map[string]bool {
+	mappings, _ := e.Store.ReadAll("generatePortfolioMappings")
+	if len(mappings) == 0 {
+		return nil
+	}
+	nonEmpty := make(map[string]bool)
+	items, _ := readExtractItems(e, "getPortfolioProjects")
+	for _, it := range items {
+		pk := extractField(it.Data, "portfolioKey")
+		rk := extractField(it.Data, "refKey")
+		if pk == "" || rk == "" {
+			continue
+		}
+		nonEmpty[it.ServerURL+"|"+pk] = true
+	}
+	out := make(map[string]bool)
+	for _, m := range mappings {
+		serverURL := extractField(m, "server_url")
+		sourceKey := extractField(m, "source_portfolio_key")
+		if serverURL == "" || sourceKey == "" {
+			continue
+		}
+		composite := serverURL + "|" + sourceKey
+		if !nonEmpty[composite] {
+			out[composite] = true
+		}
+	}
+	return out
+}
+
 // indexPortfolioCompositions reads getPortfolioDetails JSONL and returns
 // a map of composite serverURL|portfolioKey → PortfolioComposition for
 // every parent portfolio. Leaf portfolios (no subviews) are absent —

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -73,6 +73,7 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 	portfolioProjects := buildPortfolioProjectList(e, projectIndex)
 	portfolioOrgs := buildPortfolioOrgIndex(e, projectIndex)
 	allMigratedOrgs := collectAllMigratedOrgs(projectIndex)
+	portfolioCompositions := indexPortfolioCompositions(e)
 
 	// Side-channel writer that records per-portfolio task-level failures
 	// (skipped because of missing data, etc.) so the summary report can mark
@@ -86,11 +87,9 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 	err := forEachMigrateItem(ctx, e, "configurePortfolios", "createPortfolios",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			selectionMode := strings.ToUpper(extractField(item, "selection_mode"))
-			if selectionMode != "REGEXP" && selectionMode != "TAGS" && selectionMode != "MANUAL" {
-				return nil
-			}
 			portfolioID := extractField(item, "cloud_portfolio_id")
 			sourceKey := extractField(item, "source_portfolio_key")
+			serverURL := extractField(item, "server_url")
 			name := extractField(item, "name")
 			if portfolioID == "" || sourceKey == "" {
 				return nil
@@ -103,19 +102,30 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 				orgs = allMigratedOrgs
 			}
 
+			composition := portfolioCompositions[serverURL+"|"+sourceKey]
+			// Effective selection mode + criteria after #229: a parent
+			// portfolio whose own selection_mode is empty/NONE/REST is
+			// configured from the composition of its direct subviews —
+			// apps (substituted by their enclosed projects), or
+			// subportfolios (combined when uniform / flattened
+			// otherwise). Single-mode portfolios are unaffected.
+			effMode, effRegexp, effTags := resolveEffectivePortfolioConfig(selectionMode,
+				extractField(item, "regexp"), extractField(item, "tags"),
+				composition, orgs)
+			if effMode == "" {
+				return nil
+			}
+
 			params := cloud.UpdatePortfolioParams{
 				PortfolioID: portfolioID,
 			}
-			switch selectionMode {
+			switch effMode {
 			case "REGEXP":
 				params.Selection = "regex"
-				params.RegularExpression = transformPortfolioRegex(
-					extractField(item, "regexp"), orgs)
+				params.RegularExpression = effRegexp
 			case "TAGS":
 				params.Selection = "tags"
-				if tagsStr := extractField(item, "tags"); tagsStr != "" {
-					params.Tags = strings.Split(tagsStr, ",")
-				}
+				params.Tags = effTags
 			case "MANUAL":
 				cloudKeys := portfolioProjects[sourceKey]
 				if len(cloudKeys) == 0 {
@@ -359,3 +369,130 @@ func transformPortfolioRegex(regex string, orgKeys []string) string {
 	return prefix + regex
 }
 
+// indexPortfolioCompositions reads getPortfolioDetails JSONL and returns
+// a map of composite serverURL|portfolioKey → PortfolioComposition for
+// every parent portfolio. Leaf portfolios (no subviews) are absent —
+// the caller treats a zero-value composition as "no special handling".
+func indexPortfolioCompositions(e *Executor) map[string]PortfolioComposition {
+	items, _ := readExtractItems(e, "getPortfolioDetails")
+	out := make(map[string]PortfolioComposition, len(items))
+	for _, item := range items {
+		var d map[string]any
+		if err := json.Unmarshal(item.Data, &d); err != nil {
+			continue
+		}
+		k, _ := d["key"].(string)
+		if k == "" {
+			continue
+		}
+		pc := AnalyzePortfolio(d)
+		if !pc.HasApps && !pc.HasSubportfolios {
+			continue
+		}
+		out[item.ServerURL+"|"+k] = pc
+	}
+	return out
+}
+
+// resolveEffectivePortfolioConfig produces the (mode, regex, tags) that
+// configurePortfolios should apply to a single SQC portfolio.
+//
+//  1. When the source portfolio's own selection_mode is one of
+//     REGEXP/TAGS/MANUAL, that takes precedence — single-portfolio
+//     migration is unchanged.
+//  2. When the source portfolio has only applications and no own mode,
+//     the SQC portfolio is configured as MANUAL with the flat resolved
+//     project list (apps are substituted by their enclosed projects via
+//     api/views/projects_status).
+//  3. When the source portfolio has direct subportfolios whose modes
+//     all agree (REGEXP / TAGS / MANUAL) AND none of them has further
+//     nested subportfolios, the criteria are combined — regex
+//     alternation, tag union, or the same flat project list for MANUAL.
+//  4. Anything else (mixed modes, nested depth ≥ 2) falls back to
+//     MANUAL with the flat resolved project list — the only safe
+//     translation of a non-uniform hierarchy on SQC.
+//
+// An empty effMode return means "no configurePortfolios call" (e.g. a
+// truly empty parent with no children).
+func resolveEffectivePortfolioConfig(parentMode, parentRegexp, parentTags string,
+	composition PortfolioComposition, orgs []string) (effMode, effRegexp string, effTags []string) {
+
+	if parentMode == "REGEXP" {
+		return "REGEXP", transformPortfolioRegex(parentRegexp, orgs), nil
+	}
+	if parentMode == "TAGS" {
+		if parentTags == "" {
+			return "TAGS", "", nil
+		}
+		return "TAGS", "", splitTrim(parentTags)
+	}
+	if parentMode == "MANUAL" {
+		return "MANUAL", "", nil
+	}
+	// REST mode (catch-all for "rest of projects") has no SQC
+	// equivalent — flatten to the resolved project list captured at
+	// extract time. #229.
+	if parentMode == "REST" {
+		return "MANUAL", "", nil
+	}
+
+	// Composition-driven configuration (#229).
+	switch {
+	case composition.HasSubportfolios && !composition.DepthGT1 && composition.CommonSelectionMode != "":
+		switch composition.CommonSelectionMode {
+		case "REGEXP":
+			parts := make([]string, 0, len(composition.Subportfolios))
+			for _, sp := range composition.Subportfolios {
+				if sp.Regexp == "" {
+					continue
+				}
+				parts = append(parts, transformPortfolioRegex(sp.Regexp, orgs))
+			}
+			if len(parts) == 0 {
+				return "", "", nil
+			}
+			if len(parts) == 1 {
+				return "REGEXP", parts[0], nil
+			}
+			return "REGEXP", "(" + strings.Join(parts, "|") + ")", nil
+		case "TAGS":
+			seen := map[string]bool{}
+			var union []string
+			for _, sp := range composition.Subportfolios {
+				for _, t := range sp.Tags {
+					t = strings.TrimSpace(t)
+					if t == "" || seen[t] {
+						continue
+					}
+					seen[t] = true
+					union = append(union, t)
+				}
+			}
+			if len(union) == 0 {
+				return "", "", nil
+			}
+			return "TAGS", "", union
+		case "MANUAL":
+			return "MANUAL", "", nil
+		}
+	case composition.HasSubportfolios:
+		// Depth ≥ 2 or mixed modes → flat project list.
+		return "MANUAL", "", nil
+	case composition.HasApps:
+		// Apps only → flat project list (apps substituted by enclosed
+		// projects via the resolved getPortfolioProjects data).
+		return "MANUAL", "", nil
+	}
+	return "", "", nil
+}
+
+func splitTrim(csv string) []string {
+	parts := strings.Split(csv, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -243,6 +243,13 @@ func collectSection(store *common.DataStore, def sectionDef,
 	if def.Name == "Portfolios" && extractMapping != nil {
 		classifications := portfolioClassifications(exportDir, extractMapping)
 		succeeded, nearPerfect, partial = applyPortfolioClassifications(store, succeeded, nearPerfect, partial, classifications)
+
+		// Empty portfolios (no resolved projects on the source) are
+		// not worth migrating — surface them in the Skipped bucket
+		// with a standard message and remove from any non-Skipped
+		// bucket they may have landed in.
+		empties := detectEmptyPortfolios(store, exportDir, extractMapping)
+		succeeded, nearPerfect, partial, skipped = applyEmptyPortfolioSkips(store, succeeded, nearPerfect, partial, skipped, empties)
 	}
 
 	// Portfolio PATCH/DELETE failures encode the id in the URL — re-parse

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -236,12 +236,13 @@ func collectSection(store *common.DataStore, def sectionDef,
 		skipped = append(skipped, collectExtractSkipped(def, exportDir, extractMapping, store)...)
 	}
 
-	// SonarQube Cloud has no portfolio hierarchy: any source portfolio that
-	// has subportfolios is migrated as a flat project list, so its perimeter
-	// may differ from the source. Mark those as Partial.
+	// Portfolio classification (#229): apps and combinable subportfolios
+	// (depth=1 with a uniform selection mode) route to NearPerfect with
+	// the appropriate Issues line; deeper nesting or mixed-mode
+	// subportfolios route to Partial. Plain portfolios stay in Succeeded.
 	if def.Name == "Portfolios" && extractMapping != nil {
-		parents := portfoliosWithSubportfolios(exportDir, extractMapping)
-		succeeded, partial = markPartialPortfolios(store, succeeded, partial, parents)
+		classifications := portfolioClassifications(exportDir, extractMapping)
+		succeeded, nearPerfect, partial = applyPortfolioClassifications(store, succeeded, nearPerfect, partial, classifications)
 	}
 
 	// Portfolio PATCH/DELETE failures encode the id in the URL — re-parse

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -459,6 +459,14 @@ func TestCollectSummaryPortfolioHierarchyPartial(t *testing.T) {
 		},
 		{"key": "soloKey", "name": "Solo"},
 	})
+	// Empty-portfolio detection requires non-empty getPortfolioProjects
+	// entries for portfolios we want to keep out of the Skipped bucket.
+	writeTaskJSONL(t, extractDir, "getPortfolioProjects", []map[string]any{
+		{"portfolioKey": "topKey", "refKey": "proj-a"},
+		{"portfolioKey": "midKey", "refKey": "proj-a"},
+		{"portfolioKey": "leafKey", "refKey": "proj-a"},
+		{"portfolioKey": "soloKey", "refKey": "proj-a"},
+	})
 
 	// createPortfolios JSONL — all four portfolios were created successfully.
 	writeTaskJSONL(t, runDir, "createPortfolios", []map[string]any{
@@ -560,6 +568,11 @@ func TestCollectSummaryPortfolioApplicationsClassification(t *testing.T) {
 			},
 		},
 		{"key": "plainKey", "name": "PlainPortfolio"},
+	})
+	writeTaskJSONL(t, extractDir, "getPortfolioProjects", []map[string]any{
+		{"portfolioKey": "appsKey", "refKey": "proj-a"},
+		{"portfolioKey": "mixedKey", "refKey": "proj-a"},
+		{"portfolioKey": "plainKey", "refKey": "proj-a"},
 	})
 
 	writeTaskJSONL(t, runDir, "createPortfolios", []map[string]any{

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -448,10 +448,11 @@ func TestCollectSummaryPortfolioHierarchyPartial(t *testing.T) {
 			"name": "Top",
 			"subViews": []map[string]any{
 				{
-					"key":  "midKey",
-					"name": "Mid",
+					"key":       "midKey",
+					"name":      "Mid",
+					"qualifier": "VW",
 					"subViews": []map[string]any{
-						{"key": "leafKey", "name": "Leaf"},
+						{"key": "leafKey", "name": "Leaf", "qualifier": "SVW", "selectionMode": "REGEXP", "regexp": ".*"},
 					},
 				},
 			},
@@ -481,14 +482,24 @@ func TestCollectSummaryPortfolioHierarchyPartial(t *testing.T) {
 	for _, item := range portfolios.Succeeded {
 		succeededNames[item.Name] = true
 	}
+	nearPerfectNames := map[string]bool{}
+	for _, item := range portfolios.NearPerfect {
+		nearPerfectNames[item.Name] = true
+	}
 	partialNames := map[string]bool{}
 	for _, item := range portfolios.Partial {
 		partialNames[item.Name] = true
 	}
 
-	// Top and Mid have subportfolios → Partial.
-	if !partialNames["Top"] || !partialNames["Mid"] {
-		t.Errorf("expected Top and Mid in Partial, got %v", partialNames)
+	// Top has nested depth ≥ 2 (Mid itself has Leaf) → Partial (orange).
+	if !partialNames["Top"] {
+		t.Errorf("expected Top in Partial, got partials=%v nearPerfect=%v", partialNames, nearPerfectNames)
+	}
+	// Mid has direct subportfolios with uniform REGEXP mode (Leaf only) →
+	// NearPerfect (yellow). Per #229: depth=1 + same mode is the combinable
+	// path with perimeter perfectly replicated.
+	if !nearPerfectNames["Mid"] {
+		t.Errorf("expected Mid in NearPerfect, got %v", nearPerfectNames)
 	}
 	// Leaf (subportfolio with no children) and Solo (standalone) → Success.
 	if !succeededNames["Leaf"] {
@@ -501,16 +512,102 @@ func TestCollectSummaryPortfolioHierarchyPartial(t *testing.T) {
 		t.Errorf("Top/Mid should not remain in Succeeded, got %v", succeededNames)
 	}
 
-	// Issue text should explain the hierarchy.
+	// Issue text should explain why each portfolio left the green bucket.
 	for _, item := range portfolios.Partial {
 		if len(item.Issues) == 0 {
 			t.Errorf("portfolio %q has no issues attached", item.Name)
 			continue
 		}
-		if !strings.Contains(item.Issues[0], "subportfolios") {
-			t.Errorf("portfolio %q: issue does not mention subportfolios: %q", item.Name, item.Issues[0])
+		if item.Name == "Top" && !strings.Contains(item.Issues[0], "nested subportfolios depth") {
+			t.Errorf("Top: expected nested-depth message, got %q", item.Issues[0])
 		}
 	}
+	for _, item := range portfolios.NearPerfect {
+		if item.Name == "Mid" && (len(item.Issues) == 0 || !strings.Contains(item.Issues[0], "uniform selection mode")) {
+			t.Errorf("Mid: expected uniform-mode message, got %v", item.Issues)
+		}
+	}
+}
+
+// Portfolios composed of applications (qualifier APP) are migrated as a flat
+// list of the projects enclosed in those apps — apps-only routes to
+// NearPerfect (yellow) with a distinct Issues line. A portfolio that also
+// has a subportfolio with no parseable selection mode (mixed) routes to
+// Partial (orange dominates) and carries both messages.
+func TestCollectSummaryPortfolioApplicationsClassification(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	writeTaskJSONL(t, extractDir, "getPortfolioDetails", []map[string]any{
+		{
+			"key":  "appsKey",
+			"name": "AppsPortfolio",
+			"subViews": []map[string]any{
+				{"key": "app1", "name": "App1", "qualifier": "APP"},
+				{"key": "app2", "name": "App2", "qualifier": "APP"},
+			},
+		},
+		{
+			"key":  "mixedKey",
+			"name": "MixedPortfolio",
+			"subViews": []map[string]any{
+				{"key": "vw1", "name": "SubP", "qualifier": "SVW"},
+				{"key": "app3", "name": "App3", "qualifier": "APP"},
+			},
+		},
+		{"key": "plainKey", "name": "PlainPortfolio"},
+	})
+
+	writeTaskJSONL(t, runDir, "createPortfolios", []map[string]any{
+		{"name": "AppsPortfolio", "server_url": "https://sq.example.com", "source_portfolio_key": "appsKey", "cloud_portfolio_id": "1"},
+		{"name": "MixedPortfolio", "server_url": "https://sq.example.com", "source_portfolio_key": "mixedKey", "cloud_portfolio_id": "2"},
+		{"name": "PlainPortfolio", "server_url": "https://sq.example.com", "source_portfolio_key": "plainKey", "cloud_portfolio_id": "3"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	portfolios := findSection(summary, "Portfolios")
+	if portfolios == nil {
+		t.Fatal("missing Portfolios section")
+	}
+
+	nearPerfectByName := map[string]EntityItem{}
+	for _, it := range portfolios.NearPerfect {
+		nearPerfectByName[it.Name] = it
+	}
+	partialByName := map[string]EntityItem{}
+	for _, it := range portfolios.Partial {
+		partialByName[it.Name] = it
+	}
+
+	apps, ok := nearPerfectByName["AppsPortfolio"]
+	if !ok {
+		t.Fatalf("AppsPortfolio should be NearPerfect (apps-only is yellow), got partial=%v nearPerfect=%v", partialByName, nearPerfectByName)
+	}
+	if len(apps.Issues) != 1 || !strings.Contains(apps.Issues[0], "applications") {
+		t.Errorf("AppsPortfolio issues: %v", apps.Issues)
+	}
+
+	mixed, ok := partialByName["MixedPortfolio"]
+	if !ok {
+		t.Fatalf("MixedPortfolio should be Partial (subportfolio with no mode + app = mixed-modes orange)")
+	}
+	if len(mixed.Issues) != 2 {
+		t.Errorf("MixedPortfolio should carry both apps + mixed-modes issues, got %v", mixed.Issues)
+	}
+
+	for _, it := range portfolios.Succeeded {
+		if it.Name == "PlainPortfolio" {
+			return
+		}
+	}
+	t.Errorf("PlainPortfolio should remain in Succeeded")
 }
 
 func TestCollectSummaryPortfolioPATCHFailureMovesToFailed(t *testing.T) {

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -610,6 +610,69 @@ func TestCollectSummaryPortfolioApplicationsClassification(t *testing.T) {
 	t.Errorf("PlainPortfolio should remain in Succeeded")
 }
 
+// Empty portfolios — those with no resolved projects in the source
+// extract — go to Skipped with the standardised message, even if they
+// were already created on SonarQube Cloud and landed in Succeeded.
+func TestCollectSummaryPortfolioEmpty(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	os.MkdirAll(runDir, 0o755)
+
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+	// "NonEmpty" has one resolved project, "Empty" has none.
+	writeTaskJSONL(t, extractDir, "getPortfolioProjects", []map[string]any{
+		{"portfolioKey": "neKey", "refKey": "proj-a"},
+	})
+	writeTaskJSONL(t, extractDir, "getPortfolioDetails", []map[string]any{
+		{"key": "neKey", "name": "NonEmpty"},
+		{"key": "emptyKey", "name": "Empty"},
+	})
+
+	writeTaskJSONL(t, runDir, "generatePortfolioMappings", []map[string]any{
+		{"name": "NonEmpty", "server_url": "https://sq.example.com", "source_portfolio_key": "neKey"},
+		{"name": "Empty", "server_url": "https://sq.example.com", "source_portfolio_key": "emptyKey"},
+	})
+	writeTaskJSONL(t, runDir, "createPortfolios", []map[string]any{
+		{"name": "NonEmpty", "server_url": "https://sq.example.com", "source_portfolio_key": "neKey", "cloud_portfolio_id": "1"},
+		// Migrate might still have created an empty portfolio in an
+		// older binary; assert the report flips it to Skipped anyway.
+		{"name": "Empty", "server_url": "https://sq.example.com", "source_portfolio_key": "emptyKey", "cloud_portfolio_id": "2"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	portfolios := findSection(summary, "Portfolios")
+	if portfolios == nil {
+		t.Fatal("missing Portfolios section")
+	}
+
+	for _, it := range portfolios.Succeeded {
+		if it.Name == "Empty" {
+			t.Errorf("Empty portfolio should not be in Succeeded")
+		}
+	}
+	var emptyRow *EntityItem
+	for i := range portfolios.Skipped {
+		if portfolios.Skipped[i].Name == "Empty" {
+			emptyRow = &portfolios.Skipped[i]
+			break
+		}
+	}
+	if emptyRow == nil {
+		t.Fatalf("Empty portfolio should be in Skipped, got %+v", portfolios.Skipped)
+	}
+	if emptyRow.SkipReason != SkipReasonEmpty {
+		t.Errorf("expected SkipReason=%q, got %q", SkipReasonEmpty, emptyRow.SkipReason)
+	}
+	if !strings.Contains(emptyRow.Detail, "empty") {
+		t.Errorf("expected message to mention empty, got %q", emptyRow.Detail)
+	}
+}
+
 func TestCollectSummaryPortfolioPATCHFailureMovesToFailed(t *testing.T) {
 	dir := t.TempDir()
 	runID := "run-01"

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -41,6 +41,7 @@ var skipReasonOrder = []struct {
 	{SkipReasonOrgSkipped, "Organization skipped"},
 	{SkipReasonBuiltIn, "Built-in"},
 	{SkipReasonUnused, "Unused"},
+	{SkipReasonEmpty, "Empty (no projects)"},
 	{"", "Other"},
 	// SQS-only settings appear last so the section ends with the
 	// "not applicable on SQC" notes — one row per such setting,

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -136,6 +136,22 @@ func strFieldFromMap(m map[string]any, k string) string {
 	return s
 }
 
+// portfolioProjectCounts decides whether a getPortfolioProjects entry
+// represents a real project in the portfolio. Entries with no refKey
+// or with status="ERROR" are orphaned references (deleted projects
+// the portfolio still mentions) and do NOT make the portfolio
+// non-empty — without this filter, every portfolio that contained a
+// since-deleted project would dodge the empty-portfolio classification.
+func portfolioProjectCounts(data json.RawMessage) bool {
+	if jsonStr(data, "refKey") == "" {
+		return false
+	}
+	if strings.EqualFold(jsonStr(data, "status"), "ERROR") {
+		return false
+	}
+	return true
+}
+
 // emptyPortfolioInfo carries the per-portfolio data needed to emit a
 // Skipped row: the entity name (so it shows up correctly in the report)
 // and the composite key (so we can match against entries already
@@ -166,9 +182,11 @@ func detectEmptyPortfolios(store *common.DataStore, exportDir string,
 	items, err := structure.ReadExtractData(exportDir, mapping, "getPortfolioProjects")
 	if err == nil {
 		for _, it := range items {
+			if !portfolioProjectCounts(it.Data) {
+				continue
+			}
 			pk := jsonStr(it.Data, "portfolioKey")
-			rk := jsonStr(it.Data, "refKey")
-			if pk == "" || rk == "" {
+			if pk == "" {
 				continue
 			}
 			nonEmpty[it.ServerURL+"|"+pk] = true

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -136,22 +136,6 @@ func strFieldFromMap(m map[string]any, k string) string {
 	return s
 }
 
-// portfolioProjectCounts decides whether a getPortfolioProjects entry
-// represents a real project in the portfolio. Entries with no refKey
-// or with status="ERROR" are orphaned references (deleted projects
-// the portfolio still mentions) and do NOT make the portfolio
-// non-empty — without this filter, every portfolio that contained a
-// since-deleted project would dodge the empty-portfolio classification.
-func portfolioProjectCounts(data json.RawMessage) bool {
-	if jsonStr(data, "refKey") == "" {
-		return false
-	}
-	if strings.EqualFold(jsonStr(data, "status"), "ERROR") {
-		return false
-	}
-	return true
-}
-
 // emptyPortfolioInfo carries the per-portfolio data needed to emit a
 // Skipped row: the entity name (so it shows up correctly in the report)
 // and the composite key (so we can match against entries already
@@ -161,53 +145,87 @@ type emptyPortfolioInfo struct {
 	Name      string
 }
 
-// detectEmptyPortfolios reads generatePortfolioMappings (every portfolio
-// from portfolios.csv, regardless of whether migrate actually created
-// it) and getPortfolioProjects (the resolved project membership) and
-// returns one info entry per portfolio whose resolved project list is
-// empty.
+// detectEmptyPortfolios walks getPortfolioDetails (every portfolio in
+// the source, including subportfolios that structure's MapPortfolios
+// deduplicates out of portfolios.csv) and returns one info entry per
+// portfolio whose resolved project list is empty.
 //
 // The resolved list reflects how SonarQube Server evaluated the
 // portfolio's selection criteria, so an empty list means the portfolio
 // has no projects regardless of selection mode (MANUAL with no picks,
-// REGEXP/TAGS with no matches, REST that caught nothing).
+// REGEXP/TAGS with no matches, REST that caught nothing). Walking
+// getPortfolioDetails — rather than generatePortfolioMappings — is
+// what lets empty subportfolios surface in the report: MapPortfolios
+// drops them because their project-composition hash is the empty hash
+// and all empties collapse into one row.
 func detectEmptyPortfolios(store *common.DataStore, exportDir string,
 	mapping structure.ExtractMapping) []emptyPortfolioInfo {
 
-	mappings, err := store.ReadAll("generatePortfolioMappings")
-	if err != nil || len(mappings) == 0 {
-		return nil
-	}
 	nonEmpty := make(map[string]bool)
 	items, err := structure.ReadExtractData(exportDir, mapping, "getPortfolioProjects")
 	if err == nil {
 		for _, it := range items {
-			if !portfolioProjectCounts(it.Data) {
-				continue
-			}
 			pk := jsonStr(it.Data, "portfolioKey")
-			if pk == "" {
+			rk := jsonStr(it.Data, "refKey")
+			if pk == "" || rk == "" {
 				continue
 			}
 			nonEmpty[it.ServerURL+"|"+pk] = true
 		}
 	}
 
+	detailItems, err := structure.ReadExtractData(exportDir, mapping, "getPortfolioDetails")
+	if err != nil || len(detailItems) == 0 {
+		return nil
+	}
 	var out []emptyPortfolioInfo
 	seen := make(map[string]bool)
-	for _, m := range mappings {
-		serverURL := jsonStr(m, "server_url")
-		sourceKey := jsonStr(m, "source_portfolio_key")
-		name := jsonStr(m, "name")
-		if serverURL == "" || sourceKey == "" || name == "" {
-			continue
+	classify := func(serverURL, key, name string) {
+		if key == "" || name == "" {
+			return
 		}
-		composite := serverURL + "|" + sourceKey
+		composite := serverURL + "|" + key
 		if seen[composite] || nonEmpty[composite] {
-			continue
+			return
 		}
 		seen[composite] = true
 		out = append(out, emptyPortfolioInfo{Composite: composite, Name: name})
+	}
+	// walkSVW recurses through SVW subviews of `node`. SVW (standard
+	// view) subportfolios are defined inline under their parent — they
+	// have no top-level api/views/show entry and use their bare key.
+	// They may themselves contain nested SVW children. VW subviews are
+	// skipped: those are by-reference and the same portfolio already
+	// appears as a top-level entry under its bare key (the subview's
+	// "key" field is compound like "Banking:Private_Banking" and would
+	// not match getPortfolioProjects' bare keys). APP subviews are
+	// applications, not portfolios.
+	var walkSVW func(serverURL string, node map[string]any)
+	walkSVW = func(serverURL string, node map[string]any) {
+		subs, _ := node["subViews"].([]any)
+		for _, s := range subs {
+			m, ok := s.(map[string]any)
+			if !ok {
+				continue
+			}
+			if q, _ := m["qualifier"].(string); q != "SVW" {
+				continue
+			}
+			sk, _ := m["key"].(string)
+			sn, _ := m["name"].(string)
+			classify(serverURL, sk, sn)
+			walkSVW(serverURL, m)
+		}
+	}
+	for _, it := range detailItems {
+		var d map[string]any
+		if err := json.Unmarshal(it.Data, &d); err != nil {
+			continue
+		}
+		key, _ := d["key"].(string)
+		name, _ := d["name"].(string)
+		classify(it.ServerURL, key, name)
+		walkSVW(it.ServerURL, d)
 	}
 	return out
 }

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -2,82 +2,151 @@ package summary
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
-// partialPortfolioIssue is the human-readable issue text attached to a
-// portfolio that has at least one subportfolio in the source. SonarQube Cloud
-// has no portfolio hierarchy, so such portfolios are migrated as a flat
-// project list (snapshot of the resolved projects at extract time). New
-// projects that match a regex/tags subportfolio after migration will not
-// appear in the SQC portfolio until it is updated manually.
-const partialPortfolioIssue = "The source portfolio has subportfolios. The target portfolio is migrated as a flat list of projects. The portfolio project perimeter may be slightly different on SonarQube Cloud"
+// Issue text emitted for each #229 sub-criterion. Wording mirrors the
+// issue description verbatim so report consumers and tickets stay in
+// sync with the issue tracker.
+const (
+	// Yellow: portfolio contains application references. Apps don't
+	// exist on SQC and are substituted by their enclosed projects.
+	portfolioIssueApps = "The SQS portfolio contains applications that will be replaced by their enclosed projects"
+	// Yellow: every direct subportfolio uses the same selection mode
+	// and there is no further nesting — the perimeter is perfectly
+	// replicated on SQC via a combined regex / tag union / project
+	// list.
+	portfolioIssueSubportfoliosUniform = "The source portfolio has subportfolios with a uniform selection mode. Their criteria have been combined on SonarQube Cloud — the portfolio perimeter is preserved."
+	// Orange: nesting depth ≥ 2 — can't be represented as a single
+	// SQC portfolio with one selection criterion; falls back to a
+	// flat project list.
+	portfolioIssueNestedDepth = "The SQS portfolio has nested subportfolios depth higher than 2, it will be converted to a flat list of projects in SQC. The portfolio perimeter may be slightly different"
+	// Orange: direct subportfolios use mixed selection modes — can't
+	// combine into a single criterion; falls back to a flat project
+	// list.
+	portfolioIssueMixedModes = "The SQS portfolio has nested subportfolios with different selection modes, it will be converted to a flat list of projects in SQC. The portfolio perimeter may be slightly different"
+	// Orange: portfolio uses REST selection mode ("rest of projects"
+	// catch-all). No SQC equivalent — falls back to a flat project
+	// list of whatever the source resolved at extract time.
+	portfolioIssueRestMode = "The SQS portfolio is defined with REST selection mode, it will be converted to a flat list of projects in SQC. The portfolio perimeter may be slightly different"
+)
 
-// portfoliosWithSubportfolios walks getPortfolioDetails across all extracts
-// and returns the set of portfolio keys that have at least one direct
-// subportfolio (i.e. non-empty subViews). Leaf portfolios — including
-// subportfolios that do not themselves have children — are not included.
+// portfolioClassification rolls up the per-portfolio composition flags
+// produced by migrate.AnalyzePortfolio into the report-side outcome:
+// which yellow / orange issue lines to attach and whether the worst
+// classification is orange (Partial) or yellow (NearPerfect).
+type portfolioClassification struct {
+	Issues   []string
+	IsOrange bool
+}
+
+// portfolioClassifications walks getPortfolioDetails and returns the
+// classification for every portfolio it encounters — top-level AND
+// every nested subportfolio. SQS-side subportfolios surface in the
+// extract via api/views/search (qualifier VW/SVW), get a createPortfolios
+// row of their own, and therefore need their own classification (a
+// subportfolio that itself has subportfolios is depth=1 from its own
+// frame of reference, so it still hits the same rules).
 //
-// Keys are returned as composite serverURL|portfolioKey strings so they can
-// be matched against createPortfolios JSONL entries (which carry both
-// server_url and source_portfolio_key).
-func portfoliosWithSubportfolios(exportDir string, mapping structure.ExtractMapping) map[string]bool {
-	set := make(map[string]bool)
+// The map key is the composite serverURL|portfolioKey string so it can
+// be matched against createPortfolios JSONL rows.
+func portfolioClassifications(exportDir string, mapping structure.ExtractMapping) map[string]portfolioClassification {
+	out := make(map[string]portfolioClassification)
 	items, err := structure.ReadExtractData(exportDir, mapping, "getPortfolioDetails")
 	if err != nil || len(items) == 0 {
-		return set
+		return out
 	}
 	for _, item := range items {
 		var obj map[string]any
 		if err := json.Unmarshal(item.Data, &obj); err != nil {
 			continue
 		}
-		markPortfolioParents(item.ServerURL, obj, set)
+		walkPortfolioClassification(item.ServerURL, obj, out)
 	}
-	return set
+	return out
 }
 
-// markPortfolioParents walks a portfolio object (recursively through its
-// subViews) and records every node whose subViews list is non-empty.
-func markPortfolioParents(serverURL string, portfolio map[string]any, set map[string]bool) {
-	subViewsRaw, ok := portfolio["subViews"]
-	if !ok {
-		return
+// walkPortfolioClassification classifies a portfolio node and recurses
+// into its subportfolios. Every node visited may produce a row in
+// createPortfolios, so each gets its own classification entry.
+func walkPortfolioClassification(serverURL string, portfolio map[string]any, out map[string]portfolioClassification) {
+	cls := classificationFor(portfolio)
+	if len(cls.Issues) > 0 {
+		if key, _ := portfolio["key"].(string); key != "" {
+			out[serverURL+"|"+key] = cls
+		}
 	}
-	subViews, ok := subViewsRaw.([]any)
-	if !ok || len(subViews) == 0 {
-		return
-	}
-	if key, ok := portfolio["key"].(string); ok && key != "" {
-		set[serverURL+"|"+key] = true
-	}
+	subViews, _ := portfolio["subViews"].([]any)
 	for _, sub := range subViews {
 		if subMap, ok := sub.(map[string]any); ok {
-			markPortfolioParents(serverURL, subMap, set)
+			walkPortfolioClassification(serverURL, subMap, out)
 		}
 	}
 }
 
-// markPartialPortfolios moves portfolios that have at least one subportfolio
-// from Succeeded to Partial, adding partialPortfolioIssue to the entry. Leaf
-// portfolios stay in Succeeded. The match is done on the composite
-// serverURL|source_portfolio_key key, which both getPortfolioDetails (via the
-// walker above) and createPortfolios JSONL produce.
-func markPartialPortfolios(store *common.DataStore, succeeded, partial []EntityItem,
-	parents map[string]bool) ([]EntityItem, []EntityItem) {
+// classificationFor inspects a single top-level portfolio's JSON and
+// returns the report-side {Issues, IsOrange} pair derived from #229:
+//   - REST selection mode → Orange + REST message.
+//   - Apps among direct subviews → adds the apps message (yellow on its
+//     own; orange combined with another orange flag).
+//   - Subportfolios with nested depth ≥ 2 → Orange + nested message.
+//   - Subportfolios with mixed modes → Orange + mixed-modes message.
+//   - Subportfolios uniform mode + depth=1 → Yellow + uniform message.
+//
+// Multiple flags can apply (e.g. REST + apps). The row carries every
+// applicable Issues line and is routed to Partial if any orange flag
+// is present.
+func classificationFor(portfolio map[string]any) portfolioClassification {
+	var cls portfolioClassification
 
-	if len(parents) == 0 || len(succeeded) == 0 {
-		return succeeded, partial
+	mode := strings.ToUpper(strFieldFromMap(portfolio, "selectionMode"))
+	if mode == "REST" {
+		cls.Issues = append(cls.Issues, portfolioIssueRestMode)
+		cls.IsOrange = true
 	}
 
-	// Build name → composite key map from createPortfolios output. The
-	// EntityItem.Name comes from the same JSONL "name" field, so this is a
-	// reliable join.
+	pc := migrate.AnalyzePortfolio(portfolio)
+	if pc.HasApps {
+		cls.Issues = append(cls.Issues, portfolioIssueApps)
+	}
+	if pc.HasSubportfolios {
+		switch {
+		case pc.DepthGT1:
+			cls.Issues = append(cls.Issues, portfolioIssueNestedDepth)
+			cls.IsOrange = true
+		case pc.MixedSelectionModes:
+			cls.Issues = append(cls.Issues, portfolioIssueMixedModes)
+			cls.IsOrange = true
+		case pc.CommonSelectionMode != "":
+			cls.Issues = append(cls.Issues, portfolioIssueSubportfoliosUniform)
+		}
+	}
+	return cls
+}
+
+func strFieldFromMap(m map[string]any, k string) string {
+	s, _ := m[k].(string)
+	return s
+}
+
+// applyPortfolioClassifications moves classified portfolios out of
+// Succeeded into either NearPerfect or Partial, attaching the Issues
+// lines from the classification. Portfolios with no entry in the
+// classification map stay in Succeeded.
+func applyPortfolioClassifications(store *common.DataStore, succeeded, nearPerfect, partial []EntityItem,
+	classifications map[string]portfolioClassification) ([]EntityItem, []EntityItem, []EntityItem) {
+
+	if len(classifications) == 0 || len(succeeded) == 0 {
+		return succeeded, nearPerfect, partial
+	}
+
 	items, err := store.ReadAll("createPortfolios")
 	if err != nil || len(items) == 0 {
-		return succeeded, partial
+		return succeeded, nearPerfect, partial
 	}
 	nameToCompositeKey := make(map[string]string, len(items))
 	for _, item := range items {
@@ -96,12 +165,17 @@ func markPartialPortfolios(store *common.DataStore, succeeded, partial []EntityI
 	kept := succeeded[:0:0]
 	for _, item := range succeeded {
 		composite := nameToCompositeKey[item.Name]
-		if composite != "" && parents[composite] {
-			item.Issues = append(item.Issues, partialPortfolioIssue)
-			partial = append(partial, item)
+		cls, ok := classifications[composite]
+		if !ok || len(cls.Issues) == 0 {
+			kept = append(kept, item)
 			continue
 		}
-		kept = append(kept, item)
+		item.Issues = append(item.Issues, cls.Issues...)
+		if cls.IsOrange {
+			partial = append(partial, item)
+		} else {
+			nearPerfect = append(nearPerfect, item)
+		}
 	}
-	return kept, partial
+	return kept, nearPerfect, partial
 }

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -33,6 +33,9 @@ const (
 	// catch-all). No SQC equivalent — falls back to a flat project
 	// list of whatever the source resolved at extract time.
 	portfolioIssueRestMode = "The SQS portfolio is defined with REST selection mode, it will be converted to a flat list of projects in SQC. The portfolio perimeter may be slightly different"
+	// Grey (Skipped): portfolio's resolved project list is empty at
+	// extract time — there is nothing to migrate.
+	portfolioIssueEmpty = "The SQS portfolio is empty, will not be migrated"
 )
 
 // portfolioClassification rolls up the per-portfolio composition flags
@@ -131,6 +134,107 @@ func classificationFor(portfolio map[string]any) portfolioClassification {
 func strFieldFromMap(m map[string]any, k string) string {
 	s, _ := m[k].(string)
 	return s
+}
+
+// emptyPortfolioInfo carries the per-portfolio data needed to emit a
+// Skipped row: the entity name (so it shows up correctly in the report)
+// and the composite key (so we can match against entries already
+// present in other buckets and pull them out).
+type emptyPortfolioInfo struct {
+	Composite string
+	Name      string
+}
+
+// detectEmptyPortfolios reads generatePortfolioMappings (every portfolio
+// from portfolios.csv, regardless of whether migrate actually created
+// it) and getPortfolioProjects (the resolved project membership) and
+// returns one info entry per portfolio whose resolved project list is
+// empty.
+//
+// The resolved list reflects how SonarQube Server evaluated the
+// portfolio's selection criteria, so an empty list means the portfolio
+// has no projects regardless of selection mode (MANUAL with no picks,
+// REGEXP/TAGS with no matches, REST that caught nothing).
+func detectEmptyPortfolios(store *common.DataStore, exportDir string,
+	mapping structure.ExtractMapping) []emptyPortfolioInfo {
+
+	mappings, err := store.ReadAll("generatePortfolioMappings")
+	if err != nil || len(mappings) == 0 {
+		return nil
+	}
+	nonEmpty := make(map[string]bool)
+	items, err := structure.ReadExtractData(exportDir, mapping, "getPortfolioProjects")
+	if err == nil {
+		for _, it := range items {
+			pk := jsonStr(it.Data, "portfolioKey")
+			rk := jsonStr(it.Data, "refKey")
+			if pk == "" || rk == "" {
+				continue
+			}
+			nonEmpty[it.ServerURL+"|"+pk] = true
+		}
+	}
+
+	var out []emptyPortfolioInfo
+	seen := make(map[string]bool)
+	for _, m := range mappings {
+		serverURL := jsonStr(m, "server_url")
+		sourceKey := jsonStr(m, "source_portfolio_key")
+		name := jsonStr(m, "name")
+		if serverURL == "" || sourceKey == "" || name == "" {
+			continue
+		}
+		composite := serverURL + "|" + sourceKey
+		if seen[composite] || nonEmpty[composite] {
+			continue
+		}
+		seen[composite] = true
+		out = append(out, emptyPortfolioInfo{Composite: composite, Name: name})
+	}
+	return out
+}
+
+// applyEmptyPortfolioSkips removes empty portfolios from every active
+// bucket (Succeeded, NearPerfect, Partial) and appends one Skipped row
+// per empty portfolio. Works whether migrate created the empty
+// portfolio on SQC (it'll be in one of the buckets and we move it) or
+// skipped it (it isn't anywhere and we add a fresh Skipped row).
+func applyEmptyPortfolioSkips(store *common.DataStore, succeeded, nearPerfect, partial, skipped []EntityItem,
+	empties []emptyPortfolioInfo) ([]EntityItem, []EntityItem, []EntityItem, []EntityItem) {
+
+	if len(empties) == 0 {
+		return succeeded, nearPerfect, partial, skipped
+	}
+
+	emptyNames := make(map[string]bool, len(empties))
+	for _, e := range empties {
+		emptyNames[e.Name] = true
+	}
+
+	// Pull any empty portfolios out of the non-Skipped buckets — they
+	// may have been routed there before the empty check ran.
+	filter := func(bucket []EntityItem) (kept []EntityItem) {
+		kept = bucket[:0:0]
+		for _, item := range bucket {
+			if emptyNames[item.Name] {
+				continue
+			}
+			kept = append(kept, item)
+		}
+		return kept
+	}
+	succeeded = filter(succeeded)
+	nearPerfect = filter(nearPerfect)
+	partial = filter(partial)
+
+	for _, e := range empties {
+		skipped = append(skipped, EntityItem{
+			Name:       e.Name,
+			Detail:     portfolioIssueEmpty,
+			SkipReason: SkipReasonEmpty,
+		})
+	}
+	return succeeded, nearPerfect, partial, skipped
 }
 
 // applyPortfolioClassifications moves classified portfolios out of

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -74,6 +74,9 @@ const (
 	SkipReasonUnused       = "unused"
 	SkipReasonSQSOnly      = "sqs-only"
 	SkipReasonDefaultValue = "default-value"
+	// SkipReasonEmpty marks portfolios that resolve to zero projects
+	// on the source — empty SQS portfolios are not migrated.
+	SkipReasonEmpty = "empty"
 )
 
 // sectionDef maps a report section to its corresponding task names and analysis entity type.


### PR DESCRIPTION
Closes #229.

## Summary
Previously every portfolio with subportfolios was lumped into Partial with a single generic message, and `configurePortfolios` left the SQC portfolio empty when the parent's own `selection_mode` was empty or REST. This PR implements the full taxonomy from #229 on both the migrate and report sides.

### Migrate
- **`AnalyzePortfolio`** (new `internal/migrate/portfolio_analysis.go`) classifies a portfolio by its direct subviews: applications (qualifier APP), subportfolios with a uniform `selection_mode`, nested depth ≥ 2, mixed modes.
- **`resolveEffectivePortfolioConfig`** picks the SQC payload:
  - Parent has its own REGEXP/TAGS/MANUAL → unchanged.
  - REST → MANUAL with the flat resolved project list.
  - Apps-only → MANUAL with the flat resolved project list.
  - Uniform-mode subportfolios depth=1 → combined regex alternation (with `transformPortfolioRegex` applied per subportfolio so the org prefix lands correctly) / tag union / MANUAL flat.
  - Depth ≥ 2 or mixed modes → MANUAL with the flat resolved list.

### Report
- `portfolio_hierarchy.go` now returns per-portfolio `{Issues, IsOrange}` classifications instead of a binary "has subportfolios" bool.
- Yellow (NearPerfect): apps message, uniform-mode message.
- Orange (Partial): REST mode message, nested-depth message, mixed-modes message.
- Multiple criteria can apply; orange dominates the routing.

## Test plan
- [x] New `portfolio_analysis_test.go` covers analyzer + every combination path (regex alternation with org prefix, tag union, mixed/depth/REST/apps fallbacks).
- [x] Updated `collect_test.go` covers NearPerfect routing for yellow and Partial for orange.
- [x] `go test ./...` clean.
- [x] Predictive PDF regenerated against local fixtures — "Portfolio of Apps" lands in NearPerfect with the apps message, "Banking" lands in Partial with the nested-depth message.
- [ ] End-to-end real migrate validation against a live enterprise instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
