### PR TITLE
Issue #258 quiet routine logs + decode HTTP error bodies

### DIFF
--- a/go/internal/common/common_test.go
+++ b/go/internal/common/common_test.go
@@ -293,3 +293,48 @@ func TestTruncate(t *testing.T) {
 		t.Errorf("expected 'hello...', got %q", got)
 	}
 }
+
+func TestHTTPErrorMessageDecoding(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want string
+	}{
+		{"sonarqube json with one msg",
+			`{"errors":[{"msg":"This organization is not bound to an ALM application"}]}`,
+			"This organization is not bound to an ALM application"},
+		{"sonarqube json with multiple msgs",
+			`{"errors":[{"msg":"one"},{"msg":"two"}]}`,
+			"one; two"},
+		{"non-json body falls back to raw",
+			`Internal server error`,
+			"Internal server error"},
+		{"empty errors array falls back to raw",
+			`{"errors":[]}`,
+			`{"errors":[]}`},
+		{"empty body",
+			``,
+			""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := &HTTPError{StatusCode: 400, Method: "GET", URL: "https://x/api/y", Body: tc.body}
+			if got := err.Message(); got != tc.want {
+				t.Errorf("Message: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTTPErrorErrorFormat(t *testing.T) {
+	err := &HTTPError{
+		StatusCode: 400,
+		Method:     "GET",
+		URL:        "https://sc-staging.io/api/alm_integration/list_repositories?organization=migration-tool-test-gh",
+		Body:       `{"errors":[{"msg":"This organization is not bound to an ALM application"}]}`,
+	}
+	want := "HTTP 400 GET https://sc-staging.io/api/alm_integration/list_repositories?organization=migration-tool-test-gh - This organization is not bound to an ALM application"
+	if got := err.Error(); got != want {
+		t.Errorf("Error: got %q, want %q", got, want)
+	}
+}

--- a/go/internal/common/rawclient.go
+++ b/go/internal/common/rawclient.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 )
 
 // HTTPError represents an HTTP error response with a status code.
@@ -21,7 +22,35 @@ type HTTPError struct {
 }
 
 func (e *HTTPError) Error() string {
-	return fmt.Sprintf("HTTP %d %s %s: %s", e.StatusCode, e.Method, e.URL, e.Body)
+	return fmt.Sprintf("HTTP %d %s %s - %s", e.StatusCode, e.Method, e.URL, e.Message())
+}
+
+// Message returns the human-readable error text extracted from a
+// SonarQube JSON error body (the first `errors[*].msg`). Falls back to
+// the raw body when the response is not the expected JSON shape, so
+// non-API errors are never accidentally hidden.
+func (e *HTTPError) Message() string {
+	if e.Body == "" {
+		return ""
+	}
+	var obj struct {
+		Errors []struct {
+			Msg string `json:"msg"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal([]byte(e.Body), &obj); err != nil || len(obj.Errors) == 0 {
+		return e.Body
+	}
+	msgs := make([]string, 0, len(obj.Errors))
+	for _, item := range obj.Errors {
+		if item.Msg != "" {
+			msgs = append(msgs, item.Msg)
+		}
+	}
+	if len(msgs) == 0 {
+		return e.Body
+	}
+	return strings.Join(msgs, "; ")
 }
 
 // IsHTTPError checks whether an error is an HTTPError with one of the given status codes.

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sq-api-go/cloud"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
@@ -132,8 +133,18 @@ func runCreateMigrationGroups(ctx context.Context, e *Executor) error {
 					Organization: orgKey,
 				})
 				if err != nil {
-					counter.Fail()
-					logAPIWarn(e.Logger, "createMigrationGroups failed", err, "group", groupName)
+					// "already exists" is the steady-state outcome for
+					// re-runs (the migration groups are deterministic
+					// per org) — surface it at Info so it doesn't
+					// pollute the warn channel, and count it as a
+					// success since the group is in the desired state.
+					if sqapi.IsAlreadyExists(err) {
+						e.Logger.Info("createMigrationGroups: already exists", "group", groupName, "org", orgKey)
+						counter.Success()
+					} else {
+						counter.Fail()
+						logAPIWarn(e.Logger, "createMigrationGroups failed", err, "group", groupName)
+					}
 				} else {
 					counter.Success()
 				}

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -150,7 +150,7 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 				params.Projects = refs
 			}
 
-			e.Logger.Info("configurePortfolios: sending PATCH",
+			e.Logger.Debug("configurePortfolios: sending PATCH",
 				"portfolio", portfolioID,
 				"name", name,
 				"selection", params.Selection,

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -764,7 +764,7 @@ func fanOutOutcome(ctx context.Context, e *Executor, raw json.RawMessage,
 		}
 	}
 	if alreadyKnown {
-		e.Logger.Info("setGlobalSettings: org-level write already rejected for this key, propagating to projects without retrying",
+		e.Logger.Debug("setGlobalSettings: org-level write already rejected for this key, propagating to projects without retrying",
 			"key", key, "org", org)
 	} else {
 		e.Logger.Info("setGlobalSettings: key not settable at org level despite list_definitions claim, propagating to projects",

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -508,7 +508,9 @@ func TestRunSetGlobalSettingsOrgLevelRejectionTriedOncePerKey(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
 	var logBuf bytes.Buffer
-	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	// The memoization log was demoted to Debug in #258 — open the
+	// logger to Debug so the assertion below still picks it up.
+	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "values": []string{"**/jacoco*.xml"}},


### PR DESCRIPTION
Closes #258.

## Summary
Four log cleanups from the issue:
- `setGlobalSettings: org-level write already rejected for this key…` → **Debug** (per-occurrence, not actionable at default verbosity).
- `configurePortfolios: sending PATCH` → **Debug** (one noisy line per portfolio; failures already covered).
- `createMigrationGroups failed` when the group already exists → now logged at **Info** (and counted as success) via `sqapi.IsAlreadyExists`. Steady-state outcome on re-runs.
- `common.HTTPError.Error()` now decodes the SonarQube JSON body and prints `HTTP <status> <method> <url> - <message>` instead of trailing the raw `{"errors":[{"msg":…}]}` blob. Falls back to the raw body for non-JSON responses.

## Test plan
- [x] `go test ./...` clean
- [x] New `TestHTTPErrorMessageDecoding` / `TestHTTPErrorErrorFormat` cover the example from #258 verbatim
- [x] Existing memoization-log assertion bumped to Debug-level capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)
