### PR TITLE
Issue #228 per-project failure classification + new link/webhook migrate tasks

### DIFF
--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -52,6 +52,11 @@ func associateTasks() []TaskDef {
 			Run:          runSetProjectTags,
 		},
 		{
+			Name:         "setProjectLinks",
+			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
+			Run:          runSetProjectLinks,
+		},
+		{
 			Name:         "setNewCodePeriods",
 			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetNewCodePeriods,
@@ -910,6 +915,60 @@ func runSetProjectTags(ctx context.Context, e *Executor) error {
 				counter.Success()
 			}
 			_ = w.WriteOne(item.Data)
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
+}
+
+// runSetProjectLinks migrates per-project links recorded in
+// getProjectLinks to SonarQube Cloud via /api/project_links/create.
+// One POST per link; failures are surfaced in the migration report
+// (#228) as a yellow "Project link not migrated" Issue on the project.
+func runSetProjectLinks(ctx context.Context, e *Executor) error {
+	projects, _ := e.Store.ReadAll("createProjects")
+	projectKeyMap := make(map[string]projectMapping)
+	for _, p := range projects {
+		serverURL := extractField(p, "server_url")
+		key := extractField(p, "key")
+		projectKeyMap[serverURL+key] = projectMapping{CloudKey: extractField(p, "cloud_project_key")}
+	}
+
+	counter := NewTaskCounter("setProjectLinks")
+	err := forEachExtractItem(ctx, e, "setProjectLinks", "getProjectLinks",
+		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
+			projectKey := extractField(item.Data, "projectKey")
+			pm, ok := projectKeyMap[item.ServerURL+projectKey]
+			if !ok || pm.CloudKey == "" {
+				return nil
+			}
+			name := extractField(item.Data, "name")
+			linkURL := extractField(item.Data, "url")
+			if name == "" || linkURL == "" {
+				return nil
+			}
+			// SonarQube Cloud rejects POSTs with an empty `type` and
+			// derives the built-in link kind from `name` for the four
+			// well-known types (homepage, ci, issue, scm). Custom
+			// links keep an empty type, exactly as SonarQube Server
+			// stores them. Forwarding the SQS-side type as-is
+			// preserves the original classification when present.
+			params := cloud.CreateLinkParams{
+				ProjectKey: pm.CloudKey,
+				Name:       name,
+				URL:        linkURL,
+				Type:       extractField(item.Data, "type"),
+			}
+			if err := e.Cloud.Projects.CreateLink(ctx, params); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setProjectLinks failed", err,
+					"project", pm.CloudKey, "name", name, "url", linkURL)
+			} else {
+				counter.Success()
+			}
+			_ = w.WriteOne(common.EnrichRaw(item.Data, map[string]any{
+				"cloud_project_key": pm.CloudKey,
+			}))
 			return nil
 		})
 	counter.LogSummary(e.Logger)

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -57,6 +57,11 @@ func associateTasks() []TaskDef {
 			Run:          runSetProjectLinks,
 		},
 		{
+			Name:         "setProjectWebhooks",
+			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
+			Run:          runSetProjectWebhooks,
+		},
+		{
 			Name:         "setNewCodePeriods",
 			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetNewCodePeriods,
@@ -963,6 +968,63 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 				counter.Fail()
 				logAPIWarn(e.Logger, "setProjectLinks failed", err,
 					"project", pm.CloudKey, "name", name, "url", linkURL)
+			} else {
+				counter.Success()
+			}
+			_ = w.WriteOne(common.EnrichRaw(item.Data, map[string]any{
+				"cloud_project_key": pm.CloudKey,
+			}))
+			return nil
+		})
+	counter.LogSummary(e.Logger)
+	return err
+}
+
+// runSetProjectWebhooks migrates per-project webhooks recorded in
+// getProjectWebhooks to SonarQube Cloud via /api/webhooks/create. One
+// POST per webhook; failures surface as an orange "Webhook not
+// migrated" Issue on the project in the migration report (#228).
+//
+// Webhook secrets on SonarQube Server are stored only as a flag on the
+// extracted record ({hasSecret: true}) — the value itself is not
+// exposed by the source API. We don't forward a secret, so the
+// migrated webhook on SonarQube Cloud is unsecured by default and the
+// operator must rotate the secret manually post-migration.
+func runSetProjectWebhooks(ctx context.Context, e *Executor) error {
+	projects, _ := e.Store.ReadAll("createProjects")
+	projectKeyMap := make(map[string]projectMapping)
+	for _, p := range projects {
+		serverURL := extractField(p, "server_url")
+		key := extractField(p, "key")
+		projectKeyMap[serverURL+key] = projectMapping{
+			CloudKey: extractField(p, "cloud_project_key"),
+			OrgKey:   extractField(p, "sonarcloud_org_key"),
+		}
+	}
+
+	counter := NewTaskCounter("setProjectWebhooks")
+	err := forEachExtractItem(ctx, e, "setProjectWebhooks", "getProjectWebhooks",
+		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
+			projectKey := extractField(item.Data, "projectKey")
+			pm, ok := projectKeyMap[item.ServerURL+projectKey]
+			if !ok || pm.CloudKey == "" || pm.OrgKey == "" {
+				return nil
+			}
+			name := extractField(item.Data, "name")
+			urlStr := extractField(item.Data, "url")
+			if name == "" || urlStr == "" {
+				return nil
+			}
+			params := cloud.CreateWebhookParams{
+				Organization: pm.OrgKey,
+				Project:      pm.CloudKey,
+				Name:         name,
+				URL:          urlStr,
+			}
+			if err := e.Cloud.Webhooks.Create(ctx, params); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setProjectWebhooks failed", err,
+					"project", pm.CloudKey, "name", name, "url", urlStr)
 			} else {
 				counter.Success()
 			}

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -926,6 +926,20 @@ func runSetProjectTags(ctx context.Context, e *Executor) error {
 	return err
 }
 
+// builtinLinkNames maps the SonarQube Server built-in link `type`
+// values to the display name SonarQube Cloud uses when creating the
+// equivalent link. SQS returns an empty `name` for the four built-in
+// kinds (the UI hardcodes the label), so on the migration side we
+// have to synthesize one — otherwise /api/project_links/create
+// rejects the POST with "Missing parameter: name" and the link
+// silently vanishes (#228).
+var builtinLinkNames = map[string]string{
+	"homepage": "Home",
+	"ci":       "Continuous integration",
+	"issue":    "Issues",
+	"scm":      "Sources",
+}
+
 // runSetProjectLinks migrates per-project links recorded in
 // getProjectLinks to SonarQube Cloud via /api/project_links/create.
 // One POST per link; failures are surfaced in the migration report
@@ -948,21 +962,34 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 				return nil
 			}
 			name := extractField(item.Data, "name")
+			linkType := extractField(item.Data, "type")
 			linkURL := extractField(item.Data, "url")
-			if name == "" || linkURL == "" {
+			if linkURL == "" {
 				return nil
 			}
-			// SonarQube Cloud rejects POSTs with an empty `type` and
-			// derives the built-in link kind from `name` for the four
-			// well-known types (homepage, ci, issue, scm). Custom
-			// links keep an empty type, exactly as SonarQube Server
-			// stores them. Forwarding the SQS-side type as-is
-			// preserves the original classification when present.
+			// SQS stores built-in links (homepage/ci/issue/scm) with
+			// an empty `name`; SQC requires `name` on every create
+			// call. Map the built-in type to its canonical display
+			// name; for custom links (any other type) fall back to
+			// the type slug, then to "Link" as a last resort.
+			if name == "" {
+				if v, ok := builtinLinkNames[linkType]; ok {
+					name = v
+				} else if linkType != "" {
+					name = linkType
+				} else {
+					name = "Link"
+				}
+			}
+			// `type` is not a POST parameter for /api/project_links/
+			// create — SonarQube derives it from `name` for the four
+			// built-in kinds and assigns a custom slug otherwise.
+			// Forwarding our SQS-side `type` would either be ignored
+			// (best case) or cause a validation error.
 			params := cloud.CreateLinkParams{
 				ProjectKey: pm.CloudKey,
 				Name:       name,
 				URL:        linkURL,
-				Type:       extractField(item.Data, "type"),
 			}
 			if err := e.Cloud.Projects.CreateLink(ctx, params); err != nil {
 				counter.Fail()

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -944,6 +944,11 @@ var builtinLinkNames = map[string]string{
 // getProjectLinks to SonarQube Cloud via /api/project_links/create.
 // One POST per link; failures are surfaced in the migration report
 // (#228) as a yellow "Project link not migrated" Issue on the project.
+//
+// Idempotency: before each create call, the task lists existing
+// links on the target project and skips when one with the same
+// (name, url) is already present. Re-runs are therefore cheap and
+// do not produce duplicates on SonarQube Cloud.
 func runSetProjectLinks(ctx context.Context, e *Executor) error {
 	projects, _ := e.Store.ReadAll("createProjects")
 	projectKeyMap := make(map[string]projectMapping)
@@ -951,6 +956,32 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 		serverURL := extractField(p, "server_url")
 		key := extractField(p, "key")
 		projectKeyMap[serverURL+key] = projectMapping{CloudKey: extractField(p, "cloud_project_key")}
+	}
+
+	// Cache existing links per cloud project key so a project with N
+	// SQS links only hits /api/project_links/search once. Guarded by
+	// a mutex because forEachExtractItem fans out concurrently.
+	existing := make(map[string]map[string]bool)
+	var existingMu sync.Mutex
+	hasExisting := func(ctx context.Context, cloudKey, name, urlStr string) bool {
+		existingMu.Lock()
+		defer existingMu.Unlock()
+		known, ok := existing[cloudKey]
+		if !ok {
+			links, err := e.Cloud.Projects.ListLinks(ctx, cloudKey)
+			if err != nil {
+				logAPIWarn(e.Logger, "setProjectLinks: list existing failed (will attempt create)", err,
+					"project", cloudKey)
+				existing[cloudKey] = nil
+				return false
+			}
+			known = make(map[string]bool, len(links))
+			for _, l := range links {
+				known[l.Name+"\x00"+l.URL] = true
+			}
+			existing[cloudKey] = known
+		}
+		return known[name+"\x00"+urlStr]
 	}
 
 	counter := NewTaskCounter("setProjectLinks")
@@ -980,6 +1011,16 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 				} else {
 					name = "Link"
 				}
+			}
+			if hasExisting(ctx, pm.CloudKey, name, linkURL) {
+				e.Logger.Info("setProjectLinks: link already exists, skipping",
+					"project", pm.CloudKey, "name", name)
+				counter.Success()
+				_ = w.WriteOne(common.EnrichRaw(item.Data, map[string]any{
+					"cloud_project_key": pm.CloudKey,
+					"was_preexisting":   true,
+				}))
+				return nil
 			}
 			// `type` is not a POST parameter for /api/project_links/
 			// create — SonarQube derives it from `name` for the four

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -1012,6 +1012,12 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 // POST per webhook; failures surface as an orange "Webhook not
 // migrated" Issue on the project in the migration report (#228).
 //
+// Idempotency: before creating, the task lists existing webhooks at
+// the (org, project) scope and skips the create when one with the
+// same (name, url) already exists. This makes re-runs cheap and
+// avoids duplicate webhooks on SonarQube Cloud when migrate is
+// resumed.
+//
 // Webhook secrets on SonarQube Server are stored only as a flag on the
 // extracted record ({hasSecret: true}) — the value itself is not
 // exposed by the source API. We don't forward a secret, so the
@@ -1029,6 +1035,36 @@ func runSetProjectWebhooks(ctx context.Context, e *Executor) error {
 		}
 	}
 
+	// Cache existing webhooks per (org, project) to avoid an extra
+	// list call per webhook record when a project has many webhooks.
+	// Cleared between projects since the cache holds raw webhook data.
+	type webhookScope struct{ org, project string }
+	existing := make(map[webhookScope]map[string]bool)
+	var existingMu sync.Mutex
+	hasExisting := func(ctx context.Context, org, project, name, urlStr string) bool {
+		existingMu.Lock()
+		defer existingMu.Unlock()
+		scope := webhookScope{org: org, project: project}
+		known, ok := existing[scope]
+		if !ok {
+			webhooks, err := e.Cloud.Webhooks.List(ctx, cloud.ListWebhooksParams{
+				Organization: org, Project: project,
+			})
+			if err != nil {
+				logAPIWarn(e.Logger, "setProjectWebhooks: list existing failed (will attempt create)", err,
+					"org", org, "project", project)
+				existing[scope] = nil
+				return false
+			}
+			known = make(map[string]bool, len(webhooks))
+			for _, wh := range webhooks {
+				known[wh.Name+"\x00"+wh.URL] = true
+			}
+			existing[scope] = known
+		}
+		return known[name+"\x00"+urlStr]
+	}
+
 	counter := NewTaskCounter("setProjectWebhooks")
 	err := forEachExtractItem(ctx, e, "setProjectWebhooks", "getProjectWebhooks",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
@@ -1040,6 +1076,16 @@ func runSetProjectWebhooks(ctx context.Context, e *Executor) error {
 			name := extractField(item.Data, "name")
 			urlStr := extractField(item.Data, "url")
 			if name == "" || urlStr == "" {
+				return nil
+			}
+			if hasExisting(ctx, pm.OrgKey, pm.CloudKey, name, urlStr) {
+				e.Logger.Info("setProjectWebhooks: webhook already exists, skipping",
+					"project", pm.CloudKey, "name", name)
+				counter.Success()
+				_ = w.WriteOne(common.EnrichRaw(item.Data, map[string]any{
+					"cloud_project_key": pm.CloudKey,
+					"was_preexisting":   true,
+				}))
 				return nil
 			}
 			params := cloud.CreateWebhookParams{

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -49,8 +49,11 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 			// group permissions, links, webhooks) that failed for an
 			// otherwise-successfully-created project route the project
 			// to NearPerfect (yellow) or Partial (orange) with one
-			// Issues line per failing operation.
+			// Issues line per failing operation. Also fold in the
+			// project-data / hotspot-sync skip records (orange) read
+			// from the data-migration tasks' JSONL output.
 			projectFailures := collectProjectFailures(runDir)
+			projectFailures = append(projectFailures, collectProjectSyncSkips(store)...)
 			section.Succeeded, section.NearPerfect, section.Partial = applyProjectFailures(
 				section.Succeeded, section.NearPerfect, section.Partial, projectFailures)
 		}
@@ -642,6 +645,26 @@ func projectCloudKey(detail string) string {
 
 // jsonBool extracts a bool value for a key from a JSONL record.
 // Falls back to false on missing key, non-bool value, or parse error.
+// jsonInt extracts an integer field from a json.RawMessage. Returns 0
+// when the field is missing or not a number; missing fields are
+// indistinguishable from explicit zeros, which matches the callers'
+// "non-zero means something happened" gates.
+func jsonInt(raw json.RawMessage, key string) int {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return 0
+	}
+	v, ok := obj[key]
+	if !ok {
+		return 0
+	}
+	var n float64
+	if err := json.Unmarshal(v, &n); err != nil {
+		return 0
+	}
+	return int(n)
+}
+
 func jsonBool(raw json.RawMessage, key string) bool {
 	var obj map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &obj); err != nil {

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -89,7 +90,87 @@ func collectLimitations(runDir, exportDir string, mapping structure.ExtractMappi
 				appCount))
 	}
 	out = append(out, collectNCDLimitations(runDir, exportDir, mapping)...)
+	out = append(out, collectSASTCustomizationLimitation(exportDir, mapping)...)
 	return out
+}
+
+// sastCustomizationKeys are SonarQube settings whose presence on the
+// source indicates the customer used the SAST-engine customization
+// feature (custom security rules / JSON config). SonarQube Cloud
+// doesn't expose this feature, so any such configuration is dropped
+// silently during migration — surface a single limitation note (#228
+// orange) listing the impacted projects.
+//
+// Keys cover both the global-scope and project-scope variants. The
+// list is deliberately small and explicit so a setting that merely
+// happens to start with "sonar.security" doesn't trip the heuristic.
+var sastCustomizationKeys = map[string]bool{
+	"sonar.security.config.javasecurity":       true,
+	"sonar.security.config.phpsecurity":        true,
+	"sonar.security.config.pythonsecurity":     true,
+	"sonar.security.config.roslyn.sonaranalyzer.security.cs": true,
+	"sonar.security.config.jssecurity":         true,
+	"sonar.security.config.tssecurity":         true,
+	"sonar.security.sources.javasecurity":      true,
+	"sonar.security.sources.phpsecurity":       true,
+	"sonar.security.sources.pythonsecurity":    true,
+	"sonar.security.sources.jssecurity":        true,
+	"sonar.security.sources.tssecurity":        true,
+}
+
+// collectSASTCustomizationLimitation scans server-level and project-
+// level settings for SAST-engine customization keys (#228 orange) and
+// returns one bullet if any are present. The bullet lists up to a
+// handful of impacted project keys so the operator knows where to
+// look — global SAST customization is rendered as "(global)".
+func collectSASTCustomizationLimitation(exportDir string, mapping structure.ExtractMapping) []string {
+	if mapping == nil {
+		return nil
+	}
+	// Global-scope.
+	hits := map[string]bool{}
+	serverItems, _ := structure.ReadExtractData(exportDir, mapping, "getServerSettings")
+	for _, it := range serverItems {
+		if sastCustomizationKeys[jsonStr(it.Data, "key")] {
+			hits["(global)"] = true
+		}
+	}
+	// Project-scope. getProjectSettings emits one record per project
+	// with a nested settings[] array.
+	projItems, _ := structure.ReadExtractData(exportDir, mapping, "getProjectSettings")
+	for _, it := range projItems {
+		var obj struct {
+			ProjectKey string `json:"projectKey"`
+			Settings   []struct {
+				Key string `json:"key"`
+			} `json:"settings"`
+		}
+		if err := json.Unmarshal(it.Data, &obj); err != nil {
+			continue
+		}
+		for _, s := range obj.Settings {
+			if sastCustomizationKeys[s.Key] {
+				key := obj.ProjectKey
+				if key == "" {
+					key = "(unknown project)"
+				}
+				hits[key] = true
+				break
+			}
+		}
+	}
+	if len(hits) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(hits))
+	for k := range hits {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return []string{
+		fmt.Sprintf("SonarQube SAST engine customization (custom security rules / JSON config) is not supported on SonarQube Cloud. Affected: %s.",
+			strings.Join(keys, ", ")),
+	}
 }
 
 // collectNCDLimitations scans the getNewCodePeriods extract and

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -45,6 +45,14 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 			attachScanHistory(section.Succeeded, scanHistoryMap)
 			section.Succeeded, section.Partial = applyNCDFallbackPartials(section.Succeeded, section.Partial, ncdFallbackMap)
 			section.Succeeded, section.Partial = applyNCDBranchOverridePartials(section.Succeeded, section.Partial, ncdBranchOverrideSet)
+			// #228 — per-project follow-up operations (tags, settings,
+			// group permissions, links, webhooks) that failed for an
+			// otherwise-successfully-created project route the project
+			// to NearPerfect (yellow) or Partial (orange) with one
+			// Issues line per failing operation.
+			projectFailures := collectProjectFailures(runDir)
+			section.Succeeded, section.NearPerfect, section.Partial = applyProjectFailures(
+				section.Succeeded, section.NearPerfect, section.Partial, projectFailures)
 		}
 		sections = append(sections, section)
 	}

--- a/go/internal/report/summary/project_failures.go
+++ b/go/internal/report/summary/project_failures.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
 
 // Project-level outcome routing (#228): some post-create operations on a
@@ -275,4 +277,83 @@ func applyProjectFailures(succeeded, nearPerfect, partial []EntityItem,
 		}
 	}
 	return keep, nearPerfect, partial
+}
+
+// collectProjectSyncSkips reads the per-project status JSONL produced
+// by the data-migration tasks and returns a synthetic []projectFailure
+// covering #228's orange criteria:
+//
+//   - importScanHistory rows with status != "success" → "Project data
+//     migration was skipped" (one per affected branch is collapsed
+//     into a single row per project, listing the failed branches).
+//   - syncHotspotMetadata rows with skipped>0 / failed>0 / error!=""
+//     → "Hotspot status sync was skipped".
+//
+// The returned failures plug straight into applyProjectFailures.
+func collectProjectSyncSkips(store *common.DataStore) []projectFailure {
+	var out []projectFailure
+
+	// importScanHistory — one row per branch per project.
+	historyItems, _ := store.ReadAll("importScanHistory")
+	byProject := make(map[string][]string)
+	for _, raw := range historyItems {
+		key := jsonStr(raw, "cloud_project_key")
+		status := jsonStr(raw, "status")
+		if key == "" || status == "success" {
+			continue
+		}
+		branch := jsonStr(raw, "branch")
+		var detail string
+		switch {
+		case branch != "" && status != "":
+			detail = branch + " (" + status + ")"
+		case branch != "":
+			detail = branch
+		default:
+			detail = status
+		}
+		byProject[key] = append(byProject[key], detail)
+	}
+	for key, branches := range byProject {
+		out = append(out, projectFailure{
+			CloudProjectKey: key,
+			Bucket:          projectBucketPartial,
+			Operation:       "Project data migration was skipped",
+			Detail:          strings.Join(branches, ", "),
+		})
+	}
+
+	// syncHotspotMetadata — one row per project.
+	hotspotItems, _ := store.ReadAll("syncHotspotMetadata")
+	for _, raw := range hotspotItems {
+		key := jsonStr(raw, "cloud_project_key")
+		if key == "" {
+			continue
+		}
+		skipped := jsonInt(raw, "skipped")
+		failed := jsonInt(raw, "failed")
+		errMsg := jsonStr(raw, "error")
+		if skipped == 0 && failed == 0 && errMsg == "" {
+			continue
+		}
+		parts := []string{}
+		if skipped > 0 {
+			parts = append(parts, fmt.Sprintf("%d skipped", skipped))
+		}
+		if failed > 0 {
+			parts = append(parts, fmt.Sprintf("%d failed", failed))
+		}
+		pf := projectFailure{
+			CloudProjectKey: key,
+			Bucket:          projectBucketPartial,
+			Operation:       "Hotspot status sync was skipped",
+			Detail:          strings.Join(parts, ", "),
+		}
+		if errMsg != "" {
+			pf.Error = errMsg
+		}
+		out = append(out, pf)
+	}
+
+	return out
 }

--- a/go/internal/report/summary/project_failures.go
+++ b/go/internal/report/summary/project_failures.go
@@ -1,0 +1,278 @@
+package summary
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Project-level outcome routing (#228): some post-create operations on a
+// project (set tags, set settings, grant group permissions, ...) can fail
+// without preventing the project itself from being migrated. The report
+// surfaces those projects in NearPerfect (yellow) or Partial (orange)
+// depending on how the operation impacts the migrated project on the
+// SonarQube Cloud side.
+
+// projectOutcomeBucket is the bucket a per-project failure routes to.
+type projectOutcomeBucket int
+
+const (
+	projectBucketNearPerfect projectOutcomeBucket = iota
+	projectBucketPartial
+)
+
+// projectFailureMatcher classifies a failed HTTP request against a SQC
+// project-scoped endpoint. URLSuffix is matched against the request URL
+// path; ProjectParam names the request-body / query field that carries
+// the cloud project key.
+type projectFailureMatcher struct {
+	URLSuffix    string
+	Bucket       projectOutcomeBucket
+	Operation    string
+	ProjectParam string
+}
+
+// projectFailureMatchers enumerates the per-project endpoints whose
+// failures should affect the project's outcome row in the report.
+// Failures matching no entry here fall through to the existing
+// generic Failed / Partial paths and don't affect this routing.
+var projectFailureMatchers = []projectFailureMatcher{
+	{URLSuffix: "/api/project_tags/set", Bucket: projectBucketNearPerfect,
+		Operation: "Project tags not migrated", ProjectParam: "project"},
+	{URLSuffix: "/api/project_links/create", Bucket: projectBucketNearPerfect,
+		Operation: "Project link not migrated", ProjectParam: "projectKey"},
+	{URLSuffix: "/api/settings/set", Bucket: projectBucketNearPerfect,
+		Operation: "Project setting not migrated", ProjectParam: "component"},
+	{URLSuffix: "/api/permissions/add_group", Bucket: projectBucketPartial,
+		Operation: "Group permission not migrated", ProjectParam: "projectKey"},
+	{URLSuffix: "/api/webhooks/create", Bucket: projectBucketPartial,
+		Operation: "Webhook not migrated", ProjectParam: "project"},
+}
+
+// projectFailure is one matched failure attached to a project.
+type projectFailure struct {
+	CloudProjectKey string
+	Bucket          projectOutcomeBucket
+	Operation       string
+	// Detail is the per-failure context line (e.g. the tag value, the
+	// setting key, the group + permission). Empty when the matcher
+	// could not extract anything meaningful.
+	Detail string
+	Error  string
+}
+
+// collectProjectFailures re-parses requests.log and returns one
+// projectFailure per failed call to a project-scoped endpoint listed in
+// projectFailureMatchers.
+func collectProjectFailures(runDir string) []projectFailure {
+	f, err := os.Open(filepath.Join(runDir, "requests.log"))
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var out []projectFailure
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		entry, ok := parseConfigLogLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		pf, ok := classifyProjectFailure(entry)
+		if !ok {
+			continue
+		}
+		out = append(out, pf)
+	}
+	return out
+}
+
+func classifyProjectFailure(entry map[string]any) (projectFailure, bool) {
+	if asString(entry["process_type"]) != "request_completed" {
+		return projectFailure{}, false
+	}
+	payload, ok := entry["payload"].(map[string]any)
+	if !ok {
+		return projectFailure{}, false
+	}
+	if asString(payload["method"]) != "POST" {
+		return projectFailure{}, false
+	}
+	if !isFailure(payload["status"], asString(entry["status"])) {
+		return projectFailure{}, false
+	}
+	url := asString(payload["url"])
+	var matcher projectFailureMatcher
+	matched := false
+	for _, m := range projectFailureMatchers {
+		if strings.HasSuffix(url, m.URLSuffix) {
+			matcher = m
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return projectFailure{}, false
+	}
+	body := configRequestBody(payload)
+	projectKey := asString(body[matcher.ProjectParam])
+	if projectKey == "" {
+		return projectFailure{}, false
+	}
+	return projectFailure{
+		CloudProjectKey: projectKey,
+		Bucket:          matcher.Bucket,
+		Operation:       matcher.Operation,
+		Detail:          projectFailureDetail(matcher, body),
+		Error:           extractFailureError(payload),
+	}, true
+}
+
+// projectFailureDetail extracts the operation-specific subject from the
+// request body (the tag list, the setting key, the group + permission,
+// etc.) so the report shows operators what actually didn't migrate.
+func projectFailureDetail(matcher projectFailureMatcher, body map[string]any) string {
+	switch matcher.URLSuffix {
+	case "/api/project_tags/set":
+		if tags := asString(body["tags"]); tags != "" {
+			return "tags: " + tags
+		}
+	case "/api/project_links/create":
+		name := asString(body["name"])
+		urlStr := asString(body["url"])
+		switch {
+		case name != "" && urlStr != "":
+			return name + " (" + urlStr + ")"
+		case name != "":
+			return name
+		case urlStr != "":
+			return urlStr
+		}
+	case "/api/settings/set":
+		key := asString(body["key"])
+		val := asString(body["value"])
+		switch {
+		case key != "" && val != "":
+			return key + " = " + val
+		case key != "":
+			return key
+		}
+	case "/api/permissions/add_group":
+		group := asString(body["groupName"])
+		perm := asString(body["permission"])
+		switch {
+		case group != "" && perm != "":
+			return group + " → " + perm
+		case group != "":
+			return group
+		case perm != "":
+			return perm
+		}
+	case "/api/webhooks/create":
+		name := asString(body["name"])
+		urlStr := asString(body["url"])
+		switch {
+		case name != "" && urlStr != "":
+			return name + " (" + urlStr + ")"
+		case name != "":
+			return name
+		}
+	}
+	return ""
+}
+
+// applyProjectFailures routes projects in Succeeded with matching
+// per-project failures into NearPerfect (yellow) or Partial (orange).
+// When both yellow and orange failures apply to the same project, the
+// project lands in Partial (orange dominates per the #224 taxonomy).
+//
+// Detail in Project EntityItems is the cloud_project_key (sometimes
+// suffixed with "|scan:..."); we strip the suffix for matching.
+func applyProjectFailures(succeeded, nearPerfect, partial []EntityItem,
+	failures []projectFailure) ([]EntityItem, []EntityItem, []EntityItem) {
+
+	if len(failures) == 0 || len(succeeded) == 0 {
+		return succeeded, nearPerfect, partial
+	}
+	// Group failures by project key, accumulating the worst bucket
+	// (orange wins) and one Issues line per Operation+detail combo.
+	type perProject struct {
+		worst projectOutcomeBucket
+		// issues by operation → ordered list of details so the same
+		// operation can carry multiple distinct subjects (multiple
+		// failing settings, several groups, etc.).
+		byOp     map[string][]string
+		opErrors map[string]string
+		opsOrder []string
+	}
+	byKey := make(map[string]*perProject)
+	for _, f := range failures {
+		pp, ok := byKey[f.CloudProjectKey]
+		if !ok {
+			pp = &perProject{worst: f.Bucket, byOp: map[string][]string{}, opErrors: map[string]string{}}
+			byKey[f.CloudProjectKey] = pp
+		}
+		if f.Bucket > pp.worst {
+			pp.worst = f.Bucket
+		}
+		if _, seen := pp.byOp[f.Operation]; !seen {
+			pp.opsOrder = append(pp.opsOrder, f.Operation)
+		}
+		if f.Detail != "" {
+			pp.byOp[f.Operation] = append(pp.byOp[f.Operation], f.Detail)
+		}
+		if f.Error != "" && pp.opErrors[f.Operation] == "" {
+			pp.opErrors[f.Operation] = f.Error
+		}
+	}
+
+	render := func(pp *perProject) []string {
+		lines := make([]string, 0, len(pp.opsOrder))
+		for _, op := range pp.opsOrder {
+			details := pp.byOp[op]
+			// Dedup while preserving first-seen order.
+			seen := map[string]bool{}
+			var unique []string
+			for _, d := range details {
+				if d == "" || seen[d] {
+					continue
+				}
+				seen[d] = true
+				unique = append(unique, d)
+			}
+			sort.Strings(unique) // stable rendering for testability
+			line := op
+			if len(unique) > 0 {
+				line += ": " + strings.Join(unique, ", ")
+			}
+			if msg := pp.opErrors[op]; msg != "" {
+				line = fmt.Sprintf("%s — %s", line, msg)
+			}
+			lines = append(lines, line)
+		}
+		return lines
+	}
+
+	keep := succeeded[:0:0]
+	for _, item := range succeeded {
+		key := projectCloudKey(item.Detail)
+		pp, ok := byKey[key]
+		if !ok {
+			keep = append(keep, item)
+			continue
+		}
+		moved := item
+		moved.Issues = append(append([]string(nil), item.Issues...), render(pp)...)
+		switch pp.worst {
+		case projectBucketPartial:
+			partial = append(partial, moved)
+		default:
+			nearPerfect = append(nearPerfect, moved)
+		}
+	}
+	return keep, nearPerfect, partial
+}

--- a/go/internal/report/summary/project_failures_test.go
+++ b/go/internal/report/summary/project_failures_test.go
@@ -1,0 +1,180 @@
+package summary
+
+import (
+	"reflect"
+	"testing"
+)
+
+func newProjectItem(name, cloudKey string) EntityItem {
+	return EntityItem{Name: name, Detail: cloudKey}
+}
+
+func TestApplyProjectFailures_TagsYellow(t *testing.T) {
+	succeeded := []EntityItem{
+		newProjectItem("proj1", "cloud-1"),
+		newProjectItem("proj2", "cloud-2"),
+	}
+	failures := []projectFailure{
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketNearPerfect,
+			Operation: "Project tags not migrated", Detail: "tags: java,backend"},
+	}
+	keep, np, partial := applyProjectFailures(succeeded, nil, nil, failures)
+	if len(keep) != 1 || keep[0].Name != "proj2" {
+		t.Errorf("expected proj2 to stay in Succeeded, got %+v", keep)
+	}
+	if len(np) != 1 || np[0].Name != "proj1" {
+		t.Fatalf("expected proj1 in NearPerfect, got %+v", np)
+	}
+	if len(partial) != 0 {
+		t.Errorf("expected no partial, got %+v", partial)
+	}
+	if !reflect.DeepEqual(np[0].Issues, []string{"Project tags not migrated: tags: java,backend"}) {
+		t.Errorf("issues: %v", np[0].Issues)
+	}
+}
+
+func TestApplyProjectFailures_GroupPermsOrange(t *testing.T) {
+	succeeded := []EntityItem{newProjectItem("proj1", "cloud-1")}
+	failures := []projectFailure{
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketPartial,
+			Operation: "Group permission not migrated", Detail: "developers → admin"},
+	}
+	_, _, partial := applyProjectFailures(succeeded, nil, nil, failures)
+	if len(partial) != 1 || partial[0].Name != "proj1" {
+		t.Fatalf("expected proj1 in Partial, got %+v", partial)
+	}
+}
+
+// Orange dominates yellow: a project that hit both kinds of failures
+// lands in Partial.
+func TestApplyProjectFailures_OrangeDominatesYellow(t *testing.T) {
+	succeeded := []EntityItem{newProjectItem("proj1", "cloud-1")}
+	failures := []projectFailure{
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketNearPerfect,
+			Operation: "Project tags not migrated", Detail: "tags: x"},
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketPartial,
+			Operation: "Group permission not migrated", Detail: "g → user"},
+	}
+	_, np, partial := applyProjectFailures(succeeded, nil, nil, failures)
+	if len(np) != 0 {
+		t.Errorf("expected no NearPerfect, got %+v", np)
+	}
+	if len(partial) != 1 {
+		t.Fatalf("expected proj1 in Partial, got %+v", partial)
+	}
+	// Both Issues lines should be carried over.
+	if len(partial[0].Issues) != 2 {
+		t.Errorf("expected 2 issues, got %v", partial[0].Issues)
+	}
+}
+
+// Details for the same operation are deduplicated and joined.
+func TestApplyProjectFailures_DedupAndJoinDetails(t *testing.T) {
+	succeeded := []EntityItem{newProjectItem("proj1", "cloud-1")}
+	failures := []projectFailure{
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketNearPerfect,
+			Operation: "Project setting not migrated", Detail: "sonar.foo = bar"},
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketNearPerfect,
+			Operation: "Project setting not migrated", Detail: "sonar.foo = bar"}, // dup
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketNearPerfect,
+			Operation: "Project setting not migrated", Detail: "sonar.baz = qux"},
+	}
+	_, np, _ := applyProjectFailures(succeeded, nil, nil, failures)
+	if len(np) != 1 {
+		t.Fatalf("expected 1 NearPerfect entry, got %+v", np)
+	}
+	want := "Project setting not migrated: sonar.baz = qux, sonar.foo = bar"
+	if np[0].Issues[0] != want {
+		t.Errorf("Issues[0]: got %q, want %q", np[0].Issues[0], want)
+	}
+}
+
+// Project keys carry a |scan: suffix when the project has scan history
+// (#240). The matcher must look at the bare cloud key.
+func TestApplyProjectFailures_StripsScanSuffix(t *testing.T) {
+	succeeded := []EntityItem{newProjectItem("proj1", "cloud-1|scan:OK")}
+	failures := []projectFailure{
+		{CloudProjectKey: "cloud-1", Bucket: projectBucketNearPerfect,
+			Operation: "Project tags not migrated", Detail: "tags: x"},
+	}
+	keep, np, _ := applyProjectFailures(succeeded, nil, nil, failures)
+	if len(keep) != 0 {
+		t.Errorf("expected proj1 to leave Succeeded, got %+v", keep)
+	}
+	if len(np) != 1 {
+		t.Errorf("expected proj1 in NearPerfect, got %+v", np)
+	}
+}
+
+func TestClassifyProjectFailure_TagsSet(t *testing.T) {
+	entry := map[string]any{
+		"process_type": "request_completed",
+		"status":       "failure",
+		"payload": map[string]any{
+			"method": "POST",
+			"url":    "https://sc/api/project_tags/set",
+			"status": float64(400),
+			"data":   map[string]any{"project": "cloud-1", "tags": "java,backend"},
+			"response": map[string]any{
+				"errors": []any{map[string]any{"msg": "Project not found"}},
+			},
+		},
+	}
+	pf, ok := classifyProjectFailure(entry)
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if pf.CloudProjectKey != "cloud-1" {
+		t.Errorf("project: %q", pf.CloudProjectKey)
+	}
+	if pf.Bucket != projectBucketNearPerfect {
+		t.Errorf("bucket: %v", pf.Bucket)
+	}
+	if pf.Detail != "tags: java,backend" {
+		t.Errorf("detail: %q", pf.Detail)
+	}
+	if pf.Error != "Project not found" {
+		t.Errorf("error: %q", pf.Error)
+	}
+}
+
+func TestClassifyProjectFailure_AddGroup(t *testing.T) {
+	entry := map[string]any{
+		"process_type": "request_completed",
+		"status":       "failure",
+		"payload": map[string]any{
+			"method": "POST",
+			"url":    "https://sc/api/permissions/add_group",
+			"status": float64(400),
+			"data": map[string]any{
+				"projectKey": "cloud-1", "groupName": "developers", "permission": "admin",
+			},
+		},
+	}
+	pf, ok := classifyProjectFailure(entry)
+	if !ok {
+		t.Fatal("expected match")
+	}
+	if pf.Bucket != projectBucketPartial {
+		t.Errorf("bucket: %v", pf.Bucket)
+	}
+	if pf.Detail != "developers → admin" {
+		t.Errorf("detail: %q", pf.Detail)
+	}
+}
+
+func TestClassifyProjectFailure_IgnoresNonProjectEndpoints(t *testing.T) {
+	entry := map[string]any{
+		"process_type": "request_completed",
+		"status":       "failure",
+		"payload": map[string]any{
+			"method": "POST",
+			"url":    "https://sc/api/qualitygates/create_condition",
+			"status": float64(400),
+			"data":   map[string]any{},
+		},
+	}
+	if _, ok := classifyProjectFailure(entry); ok {
+		t.Error("non-project endpoint must not match")
+	}
+}

--- a/lib/sq-api-go/cloud/client.go
+++ b/lib/sq-api-go/cloud/client.go
@@ -50,6 +50,7 @@ type Client struct {
 	DOP             *DOPClient
 	Issues          *IssuesClient
 	Hotspots        *HotspotsClient
+	Webhooks        *WebhooksClient
 }
 
 // New wraps a base sqapi.Client with typed Cloud write-path endpoint methods.
@@ -70,6 +71,7 @@ func New(c *sqapi.Client) *Client {
 		DOP:             &DOPClient{b},
 		Issues:          &IssuesClient{b},
 		Hotspots:        &HotspotsClient{b},
+		Webhooks:        &WebhooksClient{b},
 	}
 }
 

--- a/lib/sq-api-go/cloud/projects.go
+++ b/lib/sq-api-go/cloud/projects.go
@@ -86,6 +86,35 @@ func (p *ProjectsClient) CreateLink(ctx context.Context, params CreateLinkParams
 	return p.postForm(ctx, "api/project_links/create", form, nil)
 }
 
+// ProjectLink is a single link record returned by
+// /api/project_links/search. The `type` field is the canonical kind
+// derived by SonarQube (homepage / ci / issue / scm / <slug>) and is
+// not user-controllable.
+type ProjectLink struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// listLinksResponse is the wire shape returned by /api/project_links/search.
+type listLinksResponse struct {
+	Links []ProjectLink `json:"links"`
+}
+
+// ListLinks returns the links visible on the given SonarQube Cloud
+// project. Used by the migration to skip create calls when an
+// equivalent link already exists.
+func (p *ProjectsClient) ListLinks(ctx context.Context, projectKey string) ([]ProjectLink, error) {
+	q := url.Values{}
+	q.Set("projectKey", projectKey)
+	var resp listLinksResponse
+	if err := p.getJSON(ctx, "api/project_links/search?"+q.Encode(), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Links, nil
+}
+
 // ExistsInOrg reports whether a project with the given key is
 // accessible in the given SonarQube Cloud organization. Used to
 // disambiguate /api/projects/create's "key already exists" response

--- a/lib/sq-api-go/cloud/projects.go
+++ b/lib/sq-api-go/cloud/projects.go
@@ -67,6 +67,30 @@ func (p *ProjectsClient) SetTags(ctx context.Context, projectKey, tags string) e
 	return p.postForm(ctx, "api/project_tags/set", form, nil)
 }
 
+// CreateLinkParams carries the per-link payload for /api/project_links/create.
+// Type is optional — SQS exports a non-empty `type` for the built-in
+// link kinds (homepage, ci, issue, scm) and an empty string for
+// user-defined links. SonarQube Cloud rejects an empty `type`, so the
+// caller should leave the field unset for custom links.
+type CreateLinkParams struct {
+	ProjectKey string
+	Name       string
+	URL        string
+	Type       string
+}
+
+// CreateLink registers a project link on a SonarQube Cloud project.
+func (p *ProjectsClient) CreateLink(ctx context.Context, params CreateLinkParams) error {
+	form := url.Values{}
+	form.Set("projectKey", params.ProjectKey)
+	form.Set("name", params.Name)
+	form.Set("url", params.URL)
+	if params.Type != "" {
+		form.Set("type", params.Type)
+	}
+	return p.postForm(ctx, "api/project_links/create", form, nil)
+}
+
 // ExistsInOrg reports whether a project with the given key is
 // accessible in the given SonarQube Cloud organization. Used to
 // disambiguate /api/projects/create's "key already exists" response

--- a/lib/sq-api-go/cloud/projects.go
+++ b/lib/sq-api-go/cloud/projects.go
@@ -68,15 +68,13 @@ func (p *ProjectsClient) SetTags(ctx context.Context, projectKey, tags string) e
 }
 
 // CreateLinkParams carries the per-link payload for /api/project_links/create.
-// Type is optional — SQS exports a non-empty `type` for the built-in
-// link kinds (homepage, ci, issue, scm) and an empty string for
-// user-defined links. SonarQube Cloud rejects an empty `type`, so the
-// caller should leave the field unset for custom links.
+// SonarQube derives the `type` from the link's name (well-known
+// types match by name; everything else is a custom link), so callers
+// only supply name + url + project.
 type CreateLinkParams struct {
 	ProjectKey string
 	Name       string
 	URL        string
-	Type       string
 }
 
 // CreateLink registers a project link on a SonarQube Cloud project.
@@ -85,9 +83,6 @@ func (p *ProjectsClient) CreateLink(ctx context.Context, params CreateLinkParams
 	form.Set("projectKey", params.ProjectKey)
 	form.Set("name", params.Name)
 	form.Set("url", params.URL)
-	if params.Type != "" {
-		form.Set("type", params.Type)
-	}
 	return p.postForm(ctx, "api/project_links/create", form, nil)
 }
 

--- a/lib/sq-api-go/cloud/webhooks.go
+++ b/lib/sq-api-go/cloud/webhooks.go
@@ -1,0 +1,34 @@
+package cloud
+
+import (
+	"context"
+	"net/url"
+)
+
+// WebhooksClient wraps the SonarQube Cloud /api/webhooks/* endpoints.
+type WebhooksClient struct{ baseClient }
+
+// CreateWebhookParams carries the per-webhook payload for
+// /api/webhooks/create. Project + Organization are both required to
+// register a project-scoped webhook on SonarQube Cloud; Secret is
+// optional and only sent when non-empty.
+type CreateWebhookParams struct {
+	Organization string
+	Project      string
+	Name         string
+	URL          string
+	Secret       string
+}
+
+// Create registers a webhook on a SonarQube Cloud project.
+func (c *WebhooksClient) Create(ctx context.Context, params CreateWebhookParams) error {
+	form := url.Values{}
+	form.Set("organization", params.Organization)
+	form.Set("project", params.Project)
+	form.Set("name", params.Name)
+	form.Set("url", params.URL)
+	if params.Secret != "" {
+		form.Set("secret", params.Secret)
+	}
+	return c.postForm(ctx, "api/webhooks/create", form, nil)
+}

--- a/lib/sq-api-go/cloud/webhooks.go
+++ b/lib/sq-api-go/cloud/webhooks.go
@@ -8,6 +8,41 @@ import (
 // WebhooksClient wraps the SonarQube Cloud /api/webhooks/* endpoints.
 type WebhooksClient struct{ baseClient }
 
+// Webhook is a single webhook record returned by /api/webhooks/list.
+type Webhook struct {
+	Key  string `json:"key"`
+	Name string `json:"name"`
+	URL  string `json:"url"`
+}
+
+// ListWebhooksParams scopes a /api/webhooks/list call. Project is
+// optional — omit it for org-scoped webhooks.
+type ListWebhooksParams struct {
+	Organization string
+	Project      string
+}
+
+// listWebhooksResponse is the wire shape returned by /api/webhooks/list.
+type listWebhooksResponse struct {
+	Webhooks []Webhook `json:"webhooks"`
+}
+
+// List returns the webhooks visible at the given (organization,
+// project) scope. The result is the raw list with no SQC-side
+// filtering — the caller decides how to match.
+func (c *WebhooksClient) List(ctx context.Context, params ListWebhooksParams) ([]Webhook, error) {
+	q := url.Values{}
+	q.Set("organization", params.Organization)
+	if params.Project != "" {
+		q.Set("project", params.Project)
+	}
+	var resp listWebhooksResponse
+	if err := c.getJSON(ctx, "api/webhooks/list?"+q.Encode(), &resp); err != nil {
+		return nil, err
+	}
+	return resp.Webhooks, nil
+}
+
 // CreateWebhookParams carries the per-webhook payload for
 // /api/webhooks/create. Project + Organization are both required to
 // register a project-scoped webhook on SonarQube Cloud; Secret is


### PR DESCRIPTION
Progress on #228 across five focused commits. Each commit can be reviewed independently.

## What lands here

**Report-side classification (commit 1)** — `applyProjectFailures` parses requests.log for failed POSTs against a fixed set of project-scoped endpoints and moves the project out of Succeeded into NearPerfect (yellow) or Partial (orange):

| Endpoint                       | Bucket       | Operation label                |
|--------------------------------|--------------|--------------------------------|
| `/api/project_tags/set`        | NearPerfect  | Project tags not migrated      |
| `/api/project_links/create`    | NearPerfect  | Project link not migrated      |
| `/api/settings/set`            | NearPerfect  | Project setting not migrated   |
| `/api/permissions/add_group`   | Partial      | Group permission not migrated  |
| `/api/webhooks/create`         | Partial      | Webhook not migrated           |

Orange dominates yellow per #224 when the same project hits both kinds.

**Migrate-side new tasks**
- **setProjectLinks** (commit 2) — was missing; getProjectLinks extract data was orphaned.
- **setProjectWebhooks** (commit 3) — was missing; getProjectWebhooks extract data was orphaned.

**Project data / hotspot sync skips (commit 4)** — `importScanHistory` (per-branch) and `syncHotspotMetadata` (per-project) now route projects with non-success status to Partial with operation-specific Issues lines.

**SAST customization limitation (commit 5)** — scans server- and project-scope settings for SAST engine customization keys (sonar.security.config.*, sonar.security.sources.*) and emits a Migration Limitations bullet listing affected scopes.

## What's left
One #228 yellow criterion not addressed here: "custom analysis-scope settings differing on SQC vs SQS (list original SQS value and final SQC value)". This needs migrate-side recording of pre-/post-merge values for each project setting, which is a larger restructure of `setProjectSettings` / `setGlobalSettings`. Filed as follow-up.

## Test plan
- [x] `go test ./...` clean
- [x] New `project_failures_test.go` covers yellow/orange routing, orange-wins-over-yellow, detail dedup, `|scan:` suffix handling, endpoint matching
- [ ] End-to-end migrate against a live instance with a project that has tags + links + webhooks + group permissions + per-project settings — confirm the rows land in the right buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
