### PR TITLE
Issue #230 close gaps in global-settings migration: template group perms, global webhooks, limitations notes

### DIFF
--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -62,6 +62,15 @@ func associateTasks() []TaskDef {
 			Run:          runSetProjectWebhooks,
 		},
 		{
+			// Issue #230 O5: migrate SQS server-scoped (global)
+			// webhooks. SonarQube Cloud has no enterprise scope but
+			// supports org-scoped webhooks, so the migration fans out
+			// each global SQS webhook to every migrated SQC org.
+			Name:         "setGlobalWebhooks",
+			Dependencies: []string{"generateOrganizationMappings"},
+			Run:          runSetGlobalWebhooks,
+		},
+		{
 			Name:         "setNewCodePeriods",
 			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetNewCodePeriods,
@@ -1209,4 +1218,105 @@ func extractStringArray(raw json.RawMessage, key string) []string {
 	var arr []string
 	json.Unmarshal(arrRaw, &arr)
 	return arr
+}
+
+// runSetGlobalWebhooks migrates each SonarQube Server server-scoped
+// webhook (the "global" webhooks in #230) by fanning the (name, url)
+// pair out to every migrated SonarQube Cloud organization via
+// /api/webhooks/create with no project parameter. Issue #230 O5.
+//
+// Idempotency: lists existing webhooks at each (org) scope before
+// creating, skipping when one with the same (name, url) is already
+// there. Same shape as runSetProjectWebhooks but with project=""
+// so the webhook ends up org-scoped.
+//
+// Webhook secrets on SonarQube Server are stored only as a flag on
+// the extracted record ({hasSecret: true}) — the value itself is
+// not exposed by the source API — so migrated webhooks land
+// unsecured and the operator has to rotate the secret manually.
+func runSetGlobalWebhooks(ctx context.Context, e *Executor) error {
+	webhooks, _ := readExtractItems(e, "getWebhooks")
+	if len(webhooks) == 0 {
+		e.Logger.Info("setGlobalWebhooks: no global webhooks extracted, nothing to migrate")
+		return nil
+	}
+	// Build target org set from the org mapping JSONL, skipping orgs
+	// the operator marked SKIPPED in the wizard.
+	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")
+	orgs := make(map[string]bool)
+	for _, item := range orgItems {
+		org := extractField(item, "sonarcloud_org_key")
+		if !shouldSkipOrg(org) {
+			orgs[org] = true
+		}
+	}
+	if len(orgs) == 0 {
+		e.Logger.Info("setGlobalWebhooks: no in-scope SQC organizations, nothing to migrate")
+		return nil
+	}
+
+	existing := make(map[string]map[string]bool)
+	var existingMu sync.Mutex
+	hasExisting := func(ctx context.Context, org, name, urlStr string) bool {
+		existingMu.Lock()
+		defer existingMu.Unlock()
+		known, ok := existing[org]
+		if !ok {
+			items, err := e.Cloud.Webhooks.List(ctx, cloud.ListWebhooksParams{Organization: org})
+			if err != nil {
+				logAPIWarn(e.Logger, "setGlobalWebhooks: list existing failed (will attempt create)", err, "org", org)
+				existing[org] = nil
+				return false
+			}
+			known = make(map[string]bool, len(items))
+			for _, wh := range items {
+				known[wh.Name+"\x00"+wh.URL] = true
+			}
+			existing[org] = known
+		}
+		return known[name+"\x00"+urlStr]
+	}
+
+	counter := NewTaskCounter("setGlobalWebhooks")
+	w, _ := e.Store.Writer("setGlobalWebhooks")
+	for _, hook := range webhooks {
+		name := extractField(hook.Data, "name")
+		urlStr := extractField(hook.Data, "url")
+		if name == "" || urlStr == "" {
+			continue
+		}
+		for org := range orgs {
+			if hasExisting(ctx, org, name, urlStr) {
+				e.Logger.Info("setGlobalWebhooks: webhook already exists, skipping",
+					"org", org, "name", name)
+				counter.Success()
+				if w != nil {
+					_ = w.WriteOne(common.EnrichRaw(hook.Data, map[string]any{
+						"sonarcloud_org_key": org,
+						"was_preexisting":    true,
+					}))
+				}
+				continue
+			}
+			err := e.Cloud.Webhooks.Create(ctx, cloud.CreateWebhookParams{
+				Organization: org,
+				Name:         name,
+				URL:          urlStr,
+			})
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setGlobalWebhooks failed", err,
+					"org", org, "name", name, "url", urlStr)
+			} else {
+				counter.Success()
+			}
+			if w != nil {
+				_ = w.WriteOne(common.EnrichRaw(hook.Data, map[string]any{
+					"sonarcloud_org_key": org,
+				}))
+			}
+		}
+	}
+	counter.LogSummary(e.Logger)
+	return nil
 }

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -3,6 +3,7 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"sync"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sq-api-go/cloud"
@@ -34,6 +35,15 @@ func permissionTasks() []TaskDef {
 			Name:         "addMigrationGroupToTemplates",
 			Dependencies: []string{"createPermissionTemplates", "createMigrationGroups"},
 			Run:          runAddMigrationGroupToTemplates,
+		},
+		{
+			// Issue #230 O3: migrate every SQS template group permission
+			// (not just the migration-tool's own groups). Reads the
+			// extracted getTemplateGroups* JSONL and replays the rows
+			// against SQC via /api/permissions/add_group_to_template.
+			Name:         "setTemplateGroupPermissions",
+			Dependencies: []string{"createPermissionTemplates", "createGroups"},
+			Run:          runSetTemplateGroupPermissions,
 		},
 		{
 			Name:         "setOrgGroupPermissions",
@@ -301,4 +311,120 @@ type profileRef struct {
 	OrgKey   string
 	Name     string
 	Language string
+}
+
+// runSetTemplateGroupPermissions migrates every SQS permission-template
+// group permission to its SonarQube Cloud counterpart. Reads the two
+// extract feeds — getTemplateGroupsScanners (groups with scan permission)
+// and getTemplateGroupsViewers (groups with user/browse permission) —
+// and deduplicates by (templateId, group) since each feed returns the
+// full permissions[] array for every matching row. Issue #230 O3.
+//
+// Built-in / migration-tool groups are skipped:
+//   - sonar-users / sonar-administrators have no SQC equivalent
+//     accessible via API.
+//   - migration-scanners / migration-viewers are wired up by
+//     addMigrationGroupToTemplates and don't need a second pass.
+//
+// Groups that didn't make it into createGroups (e.g. failed creation,
+// org-skipped) are silently passed over — the missing group is
+// already surfaced in the Groups section.
+func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
+	// SQS templateId → (SQC templateId, sonarcloud_org_key) lookup.
+	// createPermissionTemplates writes the SQS-side id under
+	// "source_template_key" (Template.SourceTemplateKey).
+	templates, _ := e.Store.ReadAll("createPermissionTemplates")
+	templateMap := make(map[string]struct{ cloudID, org string }, len(templates))
+	for _, t := range templates {
+		srvURL := extractField(t, "server_url")
+		srcID := extractField(t, "source_template_key")
+		if srvURL == "" || srcID == "" {
+			continue
+		}
+		templateMap[srvURL+"\x00"+srcID] = struct{ cloudID, org string }{
+			cloudID: extractField(t, "cloud_template_id"),
+			org:     extractField(t, "sonarcloud_org_key"),
+		}
+	}
+	if len(templateMap) == 0 {
+		e.Logger.Info("setTemplateGroupPermissions: no permission templates in scope, nothing to migrate")
+		return nil
+	}
+
+	// Set of migrated SQS group names per cloud org so we know which
+	// (org, group) pairs are safe to reference.
+	createdGroups, _ := e.Store.ReadAll("createGroups")
+	groupExists := make(map[string]bool, len(createdGroups))
+	for _, g := range createdGroups {
+		name := extractField(g, "name")
+		org := extractField(g, "sonarcloud_org_key")
+		if name != "" && org != "" {
+			groupExists[org+"\x00"+name] = true
+		}
+	}
+
+	skipGroups := map[string]bool{
+		"sonar-users":          true,
+		"sonar-administrators": true,
+		migrationScanners:      true,
+		migrationViewers:       true,
+	}
+
+	// Dedup applied (templateId, group, permission) triples — each
+	// extract feed surfaces the same row in both "scanners" and
+	// "viewers" responses when the group has both permissions.
+	type triple struct{ cloudTemplate, group, perm string }
+	applied := make(map[triple]bool)
+	var appliedMu sync.Mutex
+
+	counter := NewTaskCounter("setTemplateGroupPermissions")
+
+	apply := func(ctx context.Context, srvURL string, data json.RawMessage) {
+		srcTemplateID := extractField(data, "templateId")
+		groupName := extractField(data, "name")
+		if srcTemplateID == "" || groupName == "" || skipGroups[groupName] {
+			return
+		}
+		tmpl, ok := templateMap[srvURL+"\x00"+srcTemplateID]
+		if !ok || tmpl.cloudID == "" || tmpl.org == "" {
+			return
+		}
+		if !groupExists[tmpl.org+"\x00"+groupName] {
+			return
+		}
+		perms := extractStringArray(data, "permissions")
+		for _, perm := range perms {
+			if perm == "" {
+				continue
+			}
+			k := triple{tmpl.cloudID, groupName, perm}
+			appliedMu.Lock()
+			if applied[k] {
+				appliedMu.Unlock()
+				continue
+			}
+			applied[k] = true
+			appliedMu.Unlock()
+			if err := e.Cloud.Permissions.AddGroupToTemplate(ctx, tmpl.cloudID, groupName, perm, tmpl.org); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setTemplateGroupPermissions failed", err,
+					"template", tmpl.cloudID, "group", groupName, "perm", perm)
+			} else {
+				counter.Success()
+			}
+		}
+	}
+
+	for _, feed := range []string{"getTemplateGroupsScanners", "getTemplateGroupsViewers"} {
+		if err := forEachExtractItem(ctx, e, feed+":apply", feed,
+			func(ctx context.Context, item structure.ExtractItem, _ *common.ChunkWriter) error {
+				apply(ctx, item.ServerURL, item.Data)
+				return nil
+			}); err != nil {
+			counter.LogSummary(e.Logger)
+			return err
+		}
+	}
+	counter.LogSummary(e.Logger)
+	return nil
 }

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -91,7 +91,112 @@ func collectLimitations(runDir, exportDir string, mapping structure.ExtractMappi
 	}
 	out = append(out, collectNCDLimitations(runDir, exportDir, mapping)...)
 	out = append(out, collectSASTCustomizationLimitation(exportDir, mapping)...)
+	out = append(out, collectUserPermissionLimitations(exportDir, mapping)...)
+	out = append(out, collectGlobalSettingMappingLimitations(exportDir, mapping)...)
 	return out
+}
+
+// collectUserPermissionLimitations covers #230 Y3 and Y4. SonarQube
+// Cloud does not expose a way to grant permissions to individual
+// users via API — only to groups — so any SQS user permission on a
+// permission template or at the global scope is dropped during
+// migration. Surface a single limitation note per scope listing
+// the affected logins so the operator can re-grant them via the
+// SQC UI or via group membership.
+func collectUserPermissionLimitations(exportDir string, mapping structure.ExtractMapping) []string {
+	if mapping == nil {
+		return nil
+	}
+	collect := func(taskKey string) []string {
+		items, _ := structure.ReadExtractData(exportDir, mapping, taskKey)
+		if len(items) == 0 {
+			return nil
+		}
+		seen := map[string]bool{}
+		var logins []string
+		for _, it := range items {
+			login := jsonStr(it.Data, "login")
+			if login == "" || seen[login] {
+				continue
+			}
+			seen[login] = true
+			logins = append(logins, login)
+		}
+		sort.Strings(logins)
+		return logins
+	}
+	var notes []string
+	if tplLogins := collect("getTemplateUsersScanners"); len(tplLogins) > 0 ||
+		len(collect("getTemplateUsersViewers")) > 0 {
+		// Combine both feeds without losing logins that appear only
+		// in one of them.
+		seen := map[string]bool{}
+		var combined []string
+		for _, feed := range []string{"getTemplateUsersScanners", "getTemplateUsersViewers"} {
+			for _, l := range collect(feed) {
+				if !seen[l] {
+					seen[l] = true
+					combined = append(combined, l)
+				}
+			}
+		}
+		sort.Strings(combined)
+		notes = append(notes, fmt.Sprintf(
+			"SonarQube Cloud does not support user permissions via API. The following %d user(s) had permissions on SonarQube Server permission templates and were not migrated: %s.",
+			len(combined), strings.Join(combined, ", ")))
+	}
+	if globalLogins := collect("getUserPermissions"); len(globalLogins) > 0 {
+		notes = append(notes, fmt.Sprintf(
+			"SonarQube Cloud does not support user permissions via API. The following %d user(s) had global SonarQube Server permissions and were not migrated: %s.",
+			len(globalLogins), strings.Join(globalLogins, ", ")))
+	}
+	return notes
+}
+
+// sqsToSQCSettingMap captures known SQS → SQC setting key equivalences
+// where SonarQube Cloud uses a different key (or the feature was moved
+// to an org-level config). When the SQS extract carries one of these
+// keys and the migration didn't successfully map it (the catch-all
+// path treats it as "not on SQC" because the literal key is absent
+// from list_definitions on the cloud side), we surface a single
+// limitation note so the operator can re-create the configuration
+// manually on SonarQube Cloud.
+var sqsToSQCSettingMap = map[string]string{
+	"sonar.qualitygate.ignoreSmallChanges":       "Ignore duplication and coverage on small changes (org-level)",
+	"sonar.ai.suggestions.enabled":               "AI Code Fix (org-level, requires manual enablement on SQC)",
+	"sonar.ai.codeFix.enabled":                   "AI Code Fix (org-level, requires manual enablement on SQC)",
+	"sonar.projects.defaultVisibility":           "Allow only private projects (org-level)",
+}
+
+// collectGlobalSettingMappingLimitations covers #230 Y7, Y8 and O7
+// — three SQS configurations whose SQC equivalents live elsewhere
+// (org-level UI settings, not under the same list_definitions key).
+// If the SQS extract carries any of these settings as non-empty, emit
+// one limitation bullet per affected setting describing the manual
+// follow-up required on the SonarQube Cloud side.
+func collectGlobalSettingMappingLimitations(exportDir string, mapping structure.ExtractMapping) []string {
+	if mapping == nil {
+		return nil
+	}
+	items, _ := structure.ReadExtractData(exportDir, mapping, "getServerSettings")
+	if len(items) == 0 {
+		return nil
+	}
+	var notes []string
+	seen := map[string]bool{}
+	for _, it := range items {
+		key := jsonStr(it.Data, "key")
+		target, ok := sqsToSQCSettingMap[key]
+		if !ok || seen[key] {
+			continue
+		}
+		seen[key] = true
+		notes = append(notes, fmt.Sprintf(
+			"%s is set on SonarQube Server but has no /api/settings/set equivalent on SonarQube Cloud. Configure %q manually after migration.",
+			key, target))
+	}
+	sort.Strings(notes)
+	return notes
 }
 
 // sastCustomizationKeys are SonarQube settings whose presence on the


### PR DESCRIPTION
Addresses #230 across three focused commits. Each commit can be reviewed independently.

## Audit + gaps closed

Before writing code I audited every #230 criterion against the current codebase. Results:

| # | Color | Criterion | Before | After |
|---|-------|-----------|--------|-------|
| Y1 | 🟡 | Global NCD migration failed | Already wired via `setGlobalNewCodePeriod` outcomes | unchanged |
| Y2 | 🟡 | Global setting migration failed | Already wired via `setGlobalSettings` outcomes | unchanged |
| Y3 | 🟡 | Permission template had user perms | ❌ Extracted but not surfaced | ✅ Migration Limitations note (commit 3) |
| Y4 | 🟡 | Global perms had user perms | ❌ Not surfaced | ✅ Migration Limitations note (commit 3) |
| Y5 | 🟡 | Template not set as default | `setDefaultTemplates` failures already route to Failed | unchanged |
| Y6 | 🟡 | `sonar.global.exclusions` merged | Already done | unchanged |
| Y7 | 🟡 | AI Code Fix settings not migrated | ❌ No handling | ✅ Migration Limitations note (commit 3) |
| Y8 | 🟡 | `sonar.qualitygate.ignoreSmallChanges` not migrated | ❌ No mapping | ✅ Migration Limitations note (commit 3) |
| O1 | 🟠 | Group create failed | Already in Failed | unchanged |
| O2 | 🟠 | Perm template create failed | Already in Failed | unchanged |
| O3 | 🟠 | SQS template **group** perms not migrated | ❌ Major gap | ✅ New migrate task (commit 1) |
| O4 | 🟠 | Global perm group perm failed | `setOrgGroupPermissions` failures already route to Failed | unchanged |
| O5 | 🟠 | Global webhook not migrated | ❌ Major gap | ✅ New migrate task (commit 2) |
| O6 | 🟠 | `sonar.dbcleaner.branchesToKeepWhenInactive` | Already done (#249) | unchanged |
| O7 | 🟠 | Default project visibility → private-only | ❌ No mapping | ✅ Migration Limitations note (commit 3) |

## Commits

1. **`setTemplateGroupPermissions` migrate task (O3)** — joins `createPermissionTemplates` + `getTemplateGroups{Scanners,Viewers}`, calls `/api/permissions/add_group_to_template` for every distinct `(template, group, permission)` triple. Skips built-in groups (`sonar-users`, `sonar-administrators`) and the migration-tool's own groups.
2. **`setGlobalWebhooks` migrate task (O5)** — fans each SQS server-scoped webhook to every migrated SQC org via `/api/webhooks/create` with no `project`. Idempotent via `webhooks/list` per org.
3. **Limitations notes (Y3, Y4, Y7, Y8, O7)** — for SQS configurations whose SQC counterparts live in the org UI (not in `list_definitions`), surface a Migration Limitations bullet with the exact follow-up the operator needs.

## Caveats noted in commit 3

- Y3/Y4: SonarQube Cloud genuinely has no `/api/permissions/add_user` equivalent — there is no automation possible; the report tells the operator exactly which logins to re-grant manually (via group membership or the UI).
- Y7/Y8/O7: the SQC equivalents are org-level toggles set via the UI. The report names the toggle so the operator knows where to look.

## Test plan
- [x] `go build ./... && go test ./...` clean
- [ ] End-to-end on an enterprise SQS instance with template group permissions, global webhooks, and `sonar.qualitygate.ignoreSmallChanges` set — confirm the new tasks land the data on SQC and the limitations notes mention the right keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
