### PR TITLE
Issue #230 follow-up: Y1/Y5/O4 failure color routing

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -482,6 +482,18 @@ func collectSection(store *common.DataStore, def sectionDef,
 	// curated note so the operator knows why the group did not migrate.
 	if def.Name == "Groups" {
 		skipped = appendBuiltInGroupSkips(store, skipped)
+		// #230 O4: org-level (no projectKey) /api/permissions/add_group
+		// failures route the corresponding Groups row to Partial.
+		runDir := store.BaseDir()
+		succeeded, partial = applyGlobalGroupPermFailures(runDir, succeeded, partial)
+	}
+
+	// #230 Y5: a permission template that couldn't be set as default
+	// on SonarQube Cloud routes to NearPerfect (yellow) on the
+	// Permission Templates section — the template itself was created.
+	if def.Name == "Permission Templates" {
+		runDir := store.BaseDir()
+		succeeded, nearPerfect = applyTemplateDefaultFailures(runDir, store, succeeded, nearPerfect)
 	}
 
 	return Section{
@@ -907,9 +919,15 @@ func collectGlobalSettings(store *common.DataStore, def sectionDef) Section {
 		return Section{Name: def.Name}
 	}
 
-	var succeeded, partial, skipped, failed []EntityItem
+	var succeeded, nearPerfect, partial, skipped, failed []EntityItem
 	for _, raw := range items {
 		key := jsonStr(raw, def.NameField)
+		// #230 Y1: the synthetic newCodePeriod record is emitted by
+		// setGlobalNewCodePeriod, one outcome per org. A failed org
+		// means the global new-code-period couldn't be set on that
+		// SQC org — the source is migrated, just not the value, so
+		// the row routes to NearPerfect (yellow) rather than Failed.
+		ncdRecord := key == "newCodePeriod"
 		for _, oc := range parseOutcomes(raw) {
 			item := EntityItem{
 				Name:         key,
@@ -928,16 +946,21 @@ func collectGlobalSettings(store *common.DataStore, def sectionDef) Section {
 				skipped = append(skipped, item)
 			case "failed":
 				item.ErrorMessage = oc.Reason
-				failed = append(failed, item)
+				if ncdRecord {
+					nearPerfect = append(nearPerfect, item)
+				} else {
+					failed = append(failed, item)
+				}
 			}
 		}
 	}
 	return Section{
-		Name:      def.Name,
-		Succeeded: succeeded,
-		Partial:   partial,
-		Skipped:   skipped,
-		Failed:    failed,
+		Name:        def.Name,
+		Succeeded:   succeeded,
+		NearPerfect: nearPerfect,
+		Partial:     partial,
+		Skipped:     skipped,
+		Failed:      failed,
 	}
 }
 

--- a/go/internal/report/summary/global_failures.go
+++ b/go/internal/report/summary/global_failures.go
@@ -1,0 +1,170 @@
+package summary
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// global_failures.go covers two #230 criteria whose failure path goes
+// through requests.log (no per-task JSONL output exists today):
+//
+//   Y5: /api/permissions/set_default_template — when SonarQube Cloud
+//       rejects setting a permission template as the default, the
+//       template itself was created (green); only the "make default"
+//       step failed, so the row routes to NearPerfect (yellow).
+//   O4: /api/permissions/add_group with no projectKey/templateId in
+//       the body — this is the org-level (global) group permission
+//       grant. SQS-side group permissions don't make it to SQC when
+//       this fails; the corresponding group row routes to Partial
+//       (orange) since the group itself is migrated but its
+//       permissions aren't.
+
+// applyTemplateDefaultFailures (Y5) moves PermissionTemplates rows out
+// of Succeeded into NearPerfect when a setDefaultTemplates POST
+// against /api/permissions/set_default_template failed for them.
+func applyTemplateDefaultFailures(runDir string, store *common.DataStore,
+	succeeded, nearPerfect []EntityItem) ([]EntityItem, []EntityItem) {
+
+	failedTemplateIDs := scanRequestsLogForFailedTemplateIDs(runDir,
+		"/api/permissions/set_default_template")
+	if len(failedTemplateIDs) == 0 {
+		return succeeded, nearPerfect
+	}
+	// Resolve cloud_template_id → row Name via createPermissionTemplates.
+	templates, _ := store.ReadAll("createPermissionTemplates")
+	nameByCloudID := make(map[string]string, len(templates))
+	for _, t := range templates {
+		cloudID := jsonStr(t, "cloud_template_id")
+		name := jsonStr(t, "name")
+		if cloudID != "" && name != "" {
+			nameByCloudID[cloudID] = name
+		}
+	}
+	targetNames := make(map[string]bool, len(failedTemplateIDs))
+	for id := range failedTemplateIDs {
+		if name, ok := nameByCloudID[id]; ok {
+			targetNames[name] = true
+		}
+	}
+	if len(targetNames) == 0 {
+		return succeeded, nearPerfect
+	}
+	keep := succeeded[:0:0]
+	for _, item := range succeeded {
+		if !targetNames[item.Name] {
+			keep = append(keep, item)
+			continue
+		}
+		moved := item
+		moved.Issues = append(append([]string(nil), item.Issues...),
+			"Could not be set as the default permission template on SonarQube Cloud — set it manually after migration.")
+		nearPerfect = append(nearPerfect, moved)
+	}
+	return keep, nearPerfect
+}
+
+// applyGlobalGroupPermFailures (O4) moves Groups rows out of Succeeded
+// into Partial when an org-level (no projectKey) /api/permissions/
+// add_group POST failed for them. Per-project group permission
+// failures are handled by applyProjectFailures (#228).
+func applyGlobalGroupPermFailures(runDir string,
+	succeeded, partial []EntityItem) ([]EntityItem, []EntityItem) {
+
+	failedGroups := scanRequestsLogForFailedGlobalGroupPerms(runDir)
+	if len(failedGroups) == 0 {
+		return succeeded, partial
+	}
+	keep := succeeded[:0:0]
+	for _, item := range succeeded {
+		perms, ok := failedGroups[item.Name]
+		if !ok {
+			keep = append(keep, item)
+			continue
+		}
+		moved := item
+		moved.Issues = append(append([]string(nil), item.Issues...),
+			"Global permission(s) not migrated: "+strings.Join(perms, ", "))
+		partial = append(partial, moved)
+	}
+	return keep, partial
+}
+
+// scanRequestsLogForFailedTemplateIDs returns the set of templateId
+// request-body values from failed POSTs to the given URL suffix.
+func scanRequestsLogForFailedTemplateIDs(runDir, urlSuffix string) map[string]bool {
+	out := map[string]bool{}
+	f, err := os.Open(filepath.Join(runDir, "requests.log"))
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		entry, ok := parseConfigLogLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		payload, _ := entry["payload"].(map[string]any)
+		if payload == nil ||
+			asString(payload["method"]) != "POST" ||
+			!strings.HasSuffix(asString(payload["url"]), urlSuffix) ||
+			!isFailure(payload["status"], asString(entry["status"])) {
+			continue
+		}
+		body := configRequestBody(payload)
+		if tid := asString(body["templateId"]); tid != "" {
+			out[tid] = true
+		}
+	}
+	return out
+}
+
+// scanRequestsLogForFailedGlobalGroupPerms returns group name →
+// failed permission list for failed POSTs to /api/permissions/add_group
+// with no projectKey (global scope).
+func scanRequestsLogForFailedGlobalGroupPerms(runDir string) map[string][]string {
+	out := map[string][]string{}
+	seen := map[string]bool{}
+	f, err := os.Open(filepath.Join(runDir, "requests.log"))
+	if err != nil {
+		return out
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	for scanner.Scan() {
+		entry, ok := parseConfigLogLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		payload, _ := entry["payload"].(map[string]any)
+		if payload == nil ||
+			asString(payload["method"]) != "POST" ||
+			!strings.HasSuffix(asString(payload["url"]), "/api/permissions/add_group") ||
+			!isFailure(payload["status"], asString(entry["status"])) {
+			continue
+		}
+		body := configRequestBody(payload)
+		if asString(body["projectKey"]) != "" {
+			continue // per-project — handled by applyProjectFailures
+		}
+		group := asString(body["groupName"])
+		perm := asString(body["permission"])
+		if group == "" || perm == "" {
+			continue
+		}
+		key := fmt.Sprintf("%s\x00%s", group, perm)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out[group] = append(out[group], perm)
+	}
+	return out
+}


### PR DESCRIPTION
Follow-up to PR #263. Three failure-routing gaps I had marked "unchanged" in the original audit actually had color mismatches with #230 — failures landed in Failed (red) when the issue calls for yellow / orange.

## Color routing fixes

**Y1 — Global new-code-period failure → NearPerfect (yellow)**
`setGlobalNewCodePeriod` emits one outcome per SQC org; a failed org used to land in Failed (red). The row now routes to NearPerfect since the source configuration is preserved — only the per-org write didn't land. Fix lives inside `collectGlobalSettings` (key="newCodePeriod" special-case).

**Y5 — Permission template "set as default" failure → NearPerfect (yellow)**
`setDefaultTemplates` writes no JSONL, so failures only surface in `requests.log`. They were classified as "Permission Template Default" entity type which no section consumes — invisible in the report. New `global_failures.go` scanner picks them up, joins `templateId` back to the row Name, and moves the row to NearPerfect with an Issues line.

**O4 — Org-level group permission failure → Partial (orange)**
Same shape as Y5: `setOrgGroupPermissions` failures classified as "Group Permission" entity type with no consuming section. The scanner picks up POSTs to `/api/permissions/add_group` without a `projectKey` (per-project grants are handled by `applyProjectFailures` from #228), groups them by `groupName`, and moves the matching Groups row to Partial with an Issues line listing the missing permissions.

## Test plan
- [x] `go build ./... && go test ./...` clean
- [ ] End-to-end with a failed `set_default_template`, a failed global `add_group`, and a failed `setGlobalNewCodePeriod` org — confirm the rows land in NearPerfect / Partial / NearPerfect with the right Issues lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
