### PR TITLE
Issue #266 unified config-file shape (source + target)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,10 @@ sonarqube-export/
 *migration-files*
 files/
 
-# Config files with secrets (keep example files in examples/)
+# Config files with secrets (keep example files in examples/ and
+# JSON Schemas under schemas/)
 !examples/*.example.json
+!schemas/*.json
 config.json
 *-config.json
 my-*.json

--- a/examples/config.unified.example.json
+++ b/examples/config.unified.example.json
@@ -1,0 +1,31 @@
+{
+  "concurrency": 10,
+  "timeout": 60,
+  "export_directory": "./migration-files",
+  "source": {
+    "url": "https://sonarqube.example.com",
+    "token": "squ_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "extract_type": "all",
+    "concurrency": 10,
+    "timeout": 60,
+    "pem_file_path": null,
+    "key_file_path": null,
+    "cert_password": null,
+    "target_task": null,
+    "extract_id": null,
+    "enterprise_key": null,
+    "organization_key": null,
+    "edition": "enterprise"
+  },
+  "target": {
+    "url": "https://sonarcloud.io/",
+    "token": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "enterprise_key": null,
+    "edition": "enterprise",
+    "concurrency": 10,
+    "timeout": 60,
+    "run_id": null,
+    "target_task": null,
+    "organization_key": null
+  }
+}

--- a/go/internal/extract/config_file.go
+++ b/go/internal/extract/config_file.go
@@ -6,18 +6,22 @@ import (
 	"os"
 )
 
-// configFileShape is the union of the three documented config-file
-// formats for the extract command (issue #158):
+// configFileShape is the union of the four documented config-file
+// formats for the extract command (issue #158, #266):
 //
 //   - examples/config-extract.example.json — flat top-level keys
 //   - examples/config.example.json         — "extract" sub-object
 //   - examples/migration-config.example.json — "sonarqube" + "settings"
 //     sub-objects (the SonarCloud-side blocks are ignored by extract)
+//   - examples/config.unified.example.json — top-level
+//     concurrency/timeout/export_directory + "source"/"target"
+//     sub-objects (#266 unified shape)
 //
 // Detection at parse time:
-//   - sonarqube present -> shape 3 (side-sectioned)
-//   - extract present   -> shape 2 (command-sectioned)
-//   - else              -> shape 1 (flat)
+//   - source or target present -> shape 4 (unified)
+//   - sonarqube present        -> shape 3 (side-sectioned)
+//   - extract present          -> shape 2 (command-sectioned)
+//   - else                     -> shape 1 (flat)
 type configFileShape struct {
 	// Shape 1 (flat) fields. Reused inside Shape 2's "extract" object.
 	URL                string `json:"url"`
@@ -41,6 +45,49 @@ type configFileShape struct {
 	// the SonarQube-side credentials and shared settings block.
 	SonarQube *sonarQubeBlock `json:"sonarqube"`
 	Settings  *settingsBlock  `json:"settings"`
+
+	// Shape 4 (unified, #266). Extract pulls from the "source" block,
+	// with top-level concurrency / timeout / export_directory as
+	// defaults. The "target" block exists in this shape for migrate
+	// but is ignored by extract.
+	Source *unifiedSourceBlock `json:"source"`
+	Target *unifiedTargetBlock `json:"target"`
+}
+
+// unifiedSourceBlock mirrors the "source" sub-object documented in
+// #266. The enterprise_key / organization_key / edition / run_id
+// fields are accepted but currently ignored — they're provisional for
+// future SQC-to-SQC migration work.
+type unifiedSourceBlock struct {
+	URL             string `json:"url"`
+	Token           string `json:"token"`
+	ExtractType     string `json:"extract_type"`
+	Concurrency     int    `json:"concurrency"`
+	Timeout         int    `json:"timeout"`
+	PEMFilePath     string `json:"pem_file_path"`
+	KeyFilePath     string `json:"key_file_path"`
+	CertPassword    string `json:"cert_password"`
+	TargetTask      string `json:"target_task"`
+	ExtractID       string `json:"extract_id"`
+	EnterpriseKey   string `json:"enterprise_key"`   // provisional, ignored
+	OrganizationKey string `json:"organization_key"` // provisional, ignored
+	Edition         string `json:"edition"`          // provisional, ignored
+	RunID           string `json:"run_id"`           // ignored by extract
+}
+
+// unifiedTargetBlock mirrors the "target" sub-object documented in
+// #266. Lives here so the unified shape parses successfully for the
+// extract command even though extract ignores the block.
+type unifiedTargetBlock struct {
+	URL             string `json:"url"`
+	Token           string `json:"token"`
+	EnterpriseKey   string `json:"enterprise_key"`
+	Edition         string `json:"edition"`
+	Concurrency     int    `json:"concurrency"`
+	Timeout         int    `json:"timeout"`
+	RunID           string `json:"run_id"`
+	TargetTask      string `json:"target_task"`
+	OrganizationKey string `json:"organization_key"` // provisional, ignored
 }
 
 type sonarQubeBlock struct {
@@ -72,6 +119,31 @@ func parseConfigFile(path string) (configFileShape, error) {
 func (s configFileShape) toExtractConfig() ExtractConfig {
 	var cfg ExtractConfig
 	switch {
+	case s.Source != nil || s.Target != nil:
+		// #266 unified shape. Extract pulls from the "source"
+		// sub-object; top-level concurrency / timeout / export_directory
+		// supply defaults. The "target" sub-object is ignored.
+		if s.Source != nil {
+			cfg.URL = s.Source.URL
+			cfg.Token = s.Source.Token
+			cfg.ExtractType = s.Source.ExtractType
+			cfg.PEMFilePath = s.Source.PEMFilePath
+			cfg.KeyFilePath = s.Source.KeyFilePath
+			cfg.CertPassword = s.Source.CertPassword
+			cfg.TargetTask = s.Source.TargetTask
+			cfg.ExtractID = s.Source.ExtractID
+			cfg.Concurrency = s.Source.Concurrency
+			cfg.Timeout = s.Source.Timeout
+		}
+		// Fall back to top-level for concurrency / timeout when the
+		// source block didn't override.
+		if cfg.Concurrency == 0 {
+			cfg.Concurrency = s.Concurrency
+		}
+		if cfg.Timeout == 0 {
+			cfg.Timeout = s.Timeout
+		}
+		cfg.ExportDirectory = s.ExportDirectory
 	case s.SonarQube != nil:
 		cfg.URL = s.SonarQube.URL
 		cfg.Token = s.SonarQube.Token

--- a/go/internal/extract/config_file_test.go
+++ b/go/internal/extract/config_file_test.go
@@ -147,3 +147,67 @@ func TestLoadExtractConfigFileErrors(t *testing.T) {
 		}
 	})
 }
+
+// #266 unified shape: extract pulls from "source", with top-level
+// concurrency / timeout / export_directory as defaults.
+func TestLoadExtractConfigFileUnifiedShape(t *testing.T) {
+	body := `{
+  "concurrency": 12,
+  "timeout": 90,
+  "export_directory": "./out",
+  "source": {
+    "url": "https://sq.example.com",
+    "token": "squ_token",
+    "extract_type": "all",
+    "pem_file_path": "/pem",
+    "extract_id": "extract-7",
+    "target_task": "getProjects"
+  },
+  "target": {
+    "url": "ignored-by-extract",
+    "token": "ignored"
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/unified.json"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadExtractConfigFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL != "https://sq.example.com" || cfg.Token != "squ_token" {
+		t.Errorf("URL/Token: %+v", cfg)
+	}
+	if cfg.ExportDirectory != "./out" {
+		t.Errorf("ExportDirectory: %q", cfg.ExportDirectory)
+	}
+	if cfg.Concurrency != 12 || cfg.Timeout != 90 {
+		t.Errorf("top-level defaults: concurrency=%d timeout=%d", cfg.Concurrency, cfg.Timeout)
+	}
+	if cfg.ExtractType != "all" || cfg.PEMFilePath != "/pem" ||
+		cfg.ExtractID != "extract-7" || cfg.TargetTask != "getProjects" {
+		t.Errorf("source-block fields: %+v", cfg)
+	}
+}
+
+// Source block overrides top-level concurrency / timeout when set.
+func TestLoadExtractConfigFileUnifiedShape_SourceOverridesGlobals(t *testing.T) {
+	body := `{
+  "concurrency": 10,
+  "timeout": 60,
+  "source": {
+    "url": "u", "token": "t",
+    "concurrency": 25,
+    "timeout": 120
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/unified.json"
+	os.WriteFile(path, []byte(body), 0o644)
+	cfg, _ := LoadExtractConfigFile(path)
+	if cfg.Concurrency != 25 || cfg.Timeout != 120 {
+		t.Errorf("override: concurrency=%d timeout=%d", cfg.Concurrency, cfg.Timeout)
+	}
+}

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -6,14 +6,16 @@ import (
 	"os"
 )
 
-// configFileShape is the union of the three documented config-file formats
+// configFileShape is the union of the four documented config-file formats
 // (see examples/config-migrate.example.json, examples/config.example.json,
-// and examples/migration-config.example.json). Issue #176.
+// examples/migration-config.example.json, and examples/config.unified.example.json).
+// Issues #176, #266.
 //
 // Detection at parse time:
-//   - sonarcloud present -> shape 3 (side-sectioned)
-//   - migrate present    -> shape 2 (command-sectioned)
-//   - else               -> shape 1 (flat)
+//   - source or target present -> shape 4 (unified)
+//   - sonarcloud present       -> shape 3 (side-sectioned)
+//   - migrate present          -> shape 2 (command-sectioned)
+//   - else                     -> shape 1 (flat)
 type configFileShape struct {
 	// Shape 1 (flat) fields. Also reused inside Shape 2's "migrate" object.
 	Token              string `json:"token"`
@@ -22,6 +24,7 @@ type configFileShape struct {
 	Edition            string `json:"edition"`
 	ExportDirectory    string `json:"export_directory"`
 	Concurrency        int    `json:"concurrency"`
+	Timeout            int    `json:"timeout"`
 	RunID              string `json:"run_id"`
 	TargetTask         string `json:"target_task"`
 	SkipProfiles       bool   `json:"skip_profiles"`
@@ -35,6 +38,46 @@ type configFileShape struct {
 	// migrate/reset only consume SonarCloud-side values.
 	SonarCloud *sonarCloudBlock `json:"sonarcloud"`
 	Settings   *settingsBlock   `json:"settings"`
+
+	// Shape 4 (unified, #266). Migrate / reset pull from the "target"
+	// block with top-level concurrency / timeout / export_directory
+	// as defaults. The "source" block is ignored.
+	Source *unifiedSourceBlock `json:"source"`
+	Target *unifiedTargetBlock `json:"target"`
+}
+
+// unifiedSourceBlock is here only so the unified shape parses
+// without dropping fields. Migrate ignores everything in it.
+type unifiedSourceBlock struct {
+	URL             string `json:"url"`
+	Token           string `json:"token"`
+	ExtractType     string `json:"extract_type"`
+	Concurrency     int    `json:"concurrency"`
+	Timeout         int    `json:"timeout"`
+	PEMFilePath     string `json:"pem_file_path"`
+	KeyFilePath     string `json:"key_file_path"`
+	CertPassword    string `json:"cert_password"`
+	TargetTask      string `json:"target_task"`
+	ExtractID       string `json:"extract_id"`
+	EnterpriseKey   string `json:"enterprise_key"`
+	OrganizationKey string `json:"organization_key"`
+	Edition         string `json:"edition"`
+	RunID           string `json:"run_id"`
+}
+
+// unifiedTargetBlock carries the SonarQube Cloud-side credentials for
+// the unified config shape (#266). organization_key is provisional
+// for future SQC-org-to-SQC-org migration and is ignored for now.
+type unifiedTargetBlock struct {
+	URL             string `json:"url"`
+	Token           string `json:"token"`
+	EnterpriseKey   string `json:"enterprise_key"`
+	Edition         string `json:"edition"`
+	Concurrency     int    `json:"concurrency"`
+	Timeout         int    `json:"timeout"`
+	RunID           string `json:"run_id"`
+	TargetTask      string `json:"target_task"`
+	OrganizationKey string `json:"organization_key"` // provisional, ignored
 }
 
 type sonarCloudBlock struct {
@@ -83,6 +126,26 @@ func parseConfigFile(path string) (configFileShape, error) {
 
 func (s configFileShape) toMigrateConfig() MigrateConfig {
 	switch {
+	case s.Source != nil || s.Target != nil:
+		// #266 unified shape. Migrate pulls from the "target"
+		// sub-object; top-level concurrency / timeout /
+		// export_directory supply defaults. The "source" block is
+		// ignored. organization_key is provisional and ignored.
+		var cfg MigrateConfig
+		if s.Target != nil {
+			cfg.URL = s.Target.URL
+			cfg.Token = s.Target.Token
+			cfg.EnterpriseKey = s.Target.EnterpriseKey
+			cfg.Edition = s.Target.Edition
+			cfg.RunID = s.Target.RunID
+			cfg.TargetTask = s.Target.TargetTask
+			cfg.Concurrency = s.Target.Concurrency
+		}
+		if cfg.Concurrency == 0 {
+			cfg.Concurrency = s.Concurrency
+		}
+		cfg.ExportDirectory = s.ExportDirectory
+		return cfg
 	case s.SonarCloud != nil:
 		return s.SonarCloud.toMigrateConfig(s.Settings)
 	case s.Migrate != nil:

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -153,3 +153,88 @@ func TestLoadConfigFileErrors(t *testing.T) {
 		}
 	})
 }
+
+// #266 unified shape: migrate pulls from "target", with top-level
+// concurrency / export_directory as defaults. "source" is ignored.
+func TestLoadMigrateConfigFileUnifiedShape(t *testing.T) {
+	body := `{
+  "concurrency": 15,
+  "timeout": 90,
+  "export_directory": "./out",
+  "source": {
+    "url": "ignored-by-migrate",
+    "token": "ignored"
+  },
+  "target": {
+    "url": "https://sonarcloud.io/",
+    "token": "sqc_token",
+    "enterprise_key": "ent-key",
+    "edition": "enterprise",
+    "run_id": "2026-05-31-01",
+    "target_task": "createProjects"
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/unified.json"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadMigrateConfigFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL != "https://sonarcloud.io/" || cfg.Token != "sqc_token" {
+		t.Errorf("URL/Token: %+v", cfg)
+	}
+	if cfg.EnterpriseKey != "ent-key" || cfg.Edition != "enterprise" {
+		t.Errorf("ent/edition: %+v", cfg)
+	}
+	if cfg.ExportDirectory != "./out" || cfg.Concurrency != 15 {
+		t.Errorf("globals: %+v", cfg)
+	}
+	if cfg.RunID != "2026-05-31-01" || cfg.TargetTask != "createProjects" {
+		t.Errorf("target fields: %+v", cfg)
+	}
+}
+
+// Target block overrides top-level concurrency when set.
+func TestLoadMigrateConfigFileUnifiedShape_TargetOverridesGlobals(t *testing.T) {
+	body := `{
+  "concurrency": 10,
+  "target": {
+    "url": "u", "token": "t",
+    "concurrency": 25
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/unified.json"
+	os.WriteFile(path, []byte(body), 0o644)
+	cfg, _ := LoadMigrateConfigFile(path)
+	if cfg.Concurrency != 25 {
+		t.Errorf("override: concurrency=%d", cfg.Concurrency)
+	}
+}
+
+// LoadResetConfigFile must also recognise the unified shape and pull
+// from "target".
+func TestLoadResetConfigFileUnifiedShape(t *testing.T) {
+	body := `{
+  "export_directory": "./out",
+  "target": {
+    "url": "https://sonarcloud.io/",
+    "token": "sqc_token",
+    "enterprise_key": "ent-key"
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/unified.json"
+	os.WriteFile(path, []byte(body), 0o644)
+	cfg, err := LoadResetConfigFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.URL != "https://sonarcloud.io/" || cfg.Token != "sqc_token" ||
+		cfg.EnterpriseKey != "ent-key" || cfg.ExportDirectory != "./out" {
+		t.Errorf("reset cfg: %+v", cfg)
+	}
+}

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/sonar-solutions/sonar-migration-tool/schemas/config.schema.json",
+  "title": "sonar-migration-tool unified configuration",
+  "description": "Unified config file shape consumed by every sonar-migration-tool command (extract, migrate, reset, predictive-report). Issue #266.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "concurrency": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 10,
+      "description": "Default max parallel HTTP calls. Overridden per command by source.concurrency / target.concurrency."
+    },
+    "timeout": {
+      "type": "integer",
+      "minimum": 1,
+      "default": 60,
+      "description": "Default HTTP request timeout in seconds. Overridden per command by source.timeout / target.timeout."
+    },
+    "export_directory": {
+      "type": "string",
+      "default": "./migration-files",
+      "description": "Root directory for extract / migrate output."
+    },
+    "source": {
+      "$ref": "#/$defs/sourceBlock",
+      "description": "SonarQube Server connection + extract-time options. Consumed by `extract` (and ignored by `migrate` / `reset`)."
+    },
+    "target": {
+      "$ref": "#/$defs/targetBlock",
+      "description": "SonarQube Cloud connection + migrate/reset-time options. Consumed by `migrate` and `reset` (and ignored by `extract`)."
+    }
+  },
+  "anyOf": [
+    { "required": ["source"] },
+    { "required": ["target"] }
+  ],
+  "$defs": {
+    "edition": {
+      "type": "string",
+      "enum": ["enterprise", "team", "foss"],
+      "default": "enterprise"
+    },
+    "sourceBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "token"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "SonarQube Server base URL. Mandatory."
+        },
+        "token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "SonarQube Server user token. Mandatory."
+        },
+        "extract_type": {
+          "type": "string",
+          "default": "all",
+          "description": "Extract scope. \"all\" extracts every available task; otherwise the name of a specific extract task."
+        },
+        "concurrency": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Override the top-level concurrency for extract calls."
+        },
+        "timeout": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Override the top-level timeout for extract HTTP calls."
+        },
+        "pem_file_path": {
+          "type": ["string", "null"],
+          "description": "Path to a client-side certificate PEM file for mTLS to SonarQube Server."
+        },
+        "key_file_path": {
+          "type": ["string", "null"],
+          "description": "Path to the private key matching pem_file_path."
+        },
+        "cert_password": {
+          "type": ["string", "null"],
+          "description": "Password for the client certificate, if any."
+        },
+        "target_task": {
+          "type": ["string", "null"],
+          "description": "Stop extract at a specific task (all its dependencies are still run)."
+        },
+        "extract_id": {
+          "type": ["string", "null"],
+          "description": "Reuse an existing extract directory ID instead of generating a new one."
+        },
+        "enterprise_key": {
+          "type": ["string", "null"],
+          "description": "PROVISIONAL — ignored today; reserved for future SQC-to-SQC migration source side."
+        },
+        "organization_key": {
+          "type": ["string", "null"],
+          "description": "PROVISIONAL — ignored today; reserved for future SQC-to-SQC migration source side."
+        },
+        "edition": {
+          "$ref": "#/$defs/edition",
+          "description": "PROVISIONAL — ignored today; the SQS edition is read live from /api/navigation/global."
+        },
+        "run_id": {
+          "type": ["string", "null"],
+          "description": "Ignored by extract (kept here for shape symmetry with target)."
+        }
+      }
+    },
+    "targetBlock": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["url", "token"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "SonarQube Cloud base URL (e.g. https://sonarcloud.io/). Mandatory."
+        },
+        "token": {
+          "type": "string",
+          "minLength": 1,
+          "description": "SonarQube Cloud user token. Mandatory."
+        },
+        "enterprise_key": {
+          "type": ["string", "null"],
+          "description": "SonarQube Cloud enterprise key used to scope create/list/delete enterprise endpoints."
+        },
+        "edition": {
+          "$ref": "#/$defs/edition",
+          "description": "SonarQube Cloud edition used to gate edition-specific tasks."
+        },
+        "concurrency": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Override the top-level concurrency for migrate/reset calls."
+        },
+        "timeout": {
+          "type": ["integer", "null"],
+          "minimum": 1,
+          "description": "Override the top-level timeout for migrate/reset HTTP calls."
+        },
+        "run_id": {
+          "type": ["string", "null"],
+          "description": "Resume an in-progress migrate run by ID. Null starts a fresh run."
+        },
+        "target_task": {
+          "type": ["string", "null"],
+          "description": "Stop migrate at a specific task (all its dependencies are still run)."
+        },
+        "organization_key": {
+          "type": ["string", "null"],
+          "description": "PROVISIONAL — ignored today; reserved for future SQC-org-to-SQC-org migration target side."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #266.

## Summary
Adds a fourth supported config-file shape so every command can read the same JSON:

```json
{
  "concurrency": 10,
  "timeout": 60,
  "export_directory": "./migration-files",
  "source": { "url": "...", "token": "...", "extract_type": "all", ... },
  "target": { "url": "...", "token": "...", "enterprise_key": "...", ... }
}
```

- Backwards-compatible: the three previous shapes still parse. The new shape kicks in when `source` or `target` is present at the top level.
- Extract reads `source`; migrate / reset read `target`. The opposite block is silently ignored.
- Top-level `concurrency`, `timeout`, `export_directory` supply defaults; per-section values override them when non-zero.
- Provisional fields per the issue checklist (`source.enterprise_key` / `source.organization_key` / `source.edition` / `target.organization_key`) parse without error but are not consumed yet — placeholders for SQC-to-SQC migration work.

## Files
- `internal/extract/config_file.go` — adds shape-4 detection + mapping; ignores the `target` block.
- `internal/migrate/config_file.go` — adds shape-4 detection + mapping; ignores the `source` block.
- `examples/config.unified.example.json` — documented example.
- New tests in both packages cover the happy path, per-section overrides, the ignored-block invariant, and the reset entry point.

## Test plan
- [x] `go test ./...` clean
- [ ] End-to-end: run `extract`, then `migrate`, then `reset` against the same unified config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
