### PR TITLE
Fix #269: map SQS sonar-users to SQC Members for permission grants

### DIFF
--- a/go/internal/migrate/builtin_groups.go
+++ b/go/internal/migrate/builtin_groups.go
@@ -13,6 +13,19 @@ var builtInGroupSkipNotes = map[string]string{
 	"sonar-users": "Built-in group on SonarQube Server; replaced by the implicit 'Members' group on SonarQube Cloud.",
 }
 
+// builtInGroupCloudAliases maps SQS built-in group names to their
+// SonarQube Cloud equivalents for permission-granting purposes.
+// Issue #269: SQS's `sonar-users` is the "everyone in this server"
+// group; SQC's equivalent is `Members`. Permissions granted to
+// `sonar-users` on SQS should be re-granted to `Members` on SQC so
+// the migration tool doesn't try to add permissions to a non-existent
+// group (404 from /api/permissions/add_group).
+//
+// Empty target = "don't re-grant on SQC" (no equivalent group exists).
+var builtInGroupCloudAliases = map[string]string{
+	"sonar-users": "Members",
+}
+
 // IsBuiltInGroup reports whether the named group is a SonarQube Server
 // built-in that should be skipped during migration.
 func IsBuiltInGroup(name string) bool {
@@ -26,4 +39,21 @@ func IsBuiltInGroup(name string) bool {
 func BuiltInGroupSkipNote(name string) (string, bool) {
 	note, ok := builtInGroupSkipNotes[name]
 	return note, ok
+}
+
+// MapGroupNameToCloud returns the SQC-side group name to use when
+// granting a permission originally held by the named SQS group. For
+// most groups this is just the input — only built-in groups with a
+// known SQC counterpart (today: `sonar-users` → `Members`) are
+// remapped. Returns (name, true) when a permission should actually be
+// granted; returns ("", false) when no SQC equivalent exists and the
+// caller should skip the grant entirely.
+func MapGroupNameToCloud(name string) (string, bool) {
+	if alias, ok := builtInGroupCloudAliases[name]; ok {
+		if alias == "" {
+			return "", false
+		}
+		return alias, true
+	}
+	return name, true
 }

--- a/go/internal/migrate/builtin_groups_test.go
+++ b/go/internal/migrate/builtin_groups_test.go
@@ -1,0 +1,32 @@
+package migrate
+
+import "testing"
+
+func TestMapGroupNameToCloud_RegularGroupPassesThrough(t *testing.T) {
+	got, ok := MapGroupNameToCloud("devs")
+	if !ok || got != "devs" {
+		t.Errorf("regular group should pass through unchanged, got (%q, %v)", got, ok)
+	}
+}
+
+func TestMapGroupNameToCloud_SonarUsersBecomesMembers(t *testing.T) {
+	// Issue #269: permissions granted to SQS's built-in `sonar-users`
+	// must be re-applied to SQC's built-in `Members` group, which is
+	// the closest equivalent.
+	got, ok := MapGroupNameToCloud("sonar-users")
+	if !ok {
+		t.Fatal("sonar-users should be remapped, not skipped")
+	}
+	if got != "Members" {
+		t.Errorf("sonar-users should map to Members, got %q", got)
+	}
+}
+
+func TestIsBuiltInGroup_SonarUsersStillSkippedForCreation(t *testing.T) {
+	// IsBuiltInGroup gates createGroups: even though sonar-users now
+	// has a permission-target alias, we must NOT try to create it as
+	// a custom group on SQC.
+	if !IsBuiltInGroup("sonar-users") {
+		t.Error("sonar-users must remain on the built-in skip list for createGroups")
+	}
+}

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -256,15 +256,27 @@ func runSetProjectGroupPermissions(ctx context.Context, e *Executor) error {
 
 func applyGroupPermissions(ctx context.Context, e *Executor, data json.RawMessage, pm projectMapping, w *common.ChunkWriter, counter *TaskCounter) {
 	name := extractField(data, "name")
+	// Issue #269: remap SQS built-in groups to their SQC equivalents
+	// (today: sonar-users → Members). The write to the task output is
+	// still done with the source name so downstream / report code can
+	// correlate back to the SQS data; only the SQC API call uses the
+	// remapped name.
+	cloudName, ok := MapGroupNameToCloud(name)
+	if !ok {
+		_ = w.WriteOne(common.EnrichRaw(data, map[string]any{
+			"cloud_project_key": pm.CloudKey,
+		}))
+		return
+	}
 	permsRaw := extractPermissions(data)
 	for _, perm := range permsRaw {
 		if !validPermissions[perm] {
 			continue
 		}
-		if err := e.Cloud.Permissions.AddGroup(ctx, name, perm, pm.OrgKey, pm.CloudKey); err != nil {
+		if err := e.Cloud.Permissions.AddGroup(ctx, cloudName, perm, pm.OrgKey, pm.CloudKey); err != nil {
 			counter.Fail()
 			logAPIWarn(e.Logger, "setProjectGroupPermissions failed", err,
-				"project", pm.CloudKey, "group", name, "perm", perm)
+				"project", pm.CloudKey, "group", cloudName, "perm", perm)
 		} else {
 			counter.Success()
 		}

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -256,15 +256,22 @@ func runSetOrgGroupPermissions(ctx context.Context, e *Executor) error {
 }
 
 func applyOrgPermissions(ctx context.Context, e *Executor, data json.RawMessage, name, orgKey string, counter *TaskCounter) {
+	// Issue #269: remap SQS built-in groups to their SQC equivalents
+	// (today: sonar-users → Members). Skip the grant if no equivalent
+	// exists.
+	cloudName, ok := MapGroupNameToCloud(name)
+	if !ok {
+		return
+	}
 	perms := extractPermissions(data)
 	for _, perm := range perms {
 		if !validPermissions[perm] {
 			continue
 		}
-		err := e.Cloud.Permissions.AddGroup(ctx, name, perm, orgKey, "")
+		err := e.Cloud.Permissions.AddGroup(ctx, cloudName, perm, orgKey, "")
 		if err != nil {
 			counter.Fail()
-			logAPIWarn(e.Logger, "setOrgGroupPermissions failed", err, "group", name, "perm", perm)
+			logAPIWarn(e.Logger, "setOrgGroupPermissions failed", err, "group", cloudName, "perm", perm)
 		} else {
 			counter.Success()
 		}
@@ -289,13 +296,18 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			profileKey := extractField(item.Data, "profileKey")
 			groupName := extractField(item.Data, "name")
+			// Issue #269: remap SQS built-in groups (sonar-users → Members).
+			cloudGroup, ok := MapGroupNameToCloud(groupName)
+			if !ok {
+				return nil
+			}
 			refs := profileInfo[profileKey]
 			for _, ref := range refs {
-				err := e.Cloud.QualityProfiles.AddGroup(ctx, ref.Language, ref.Name, groupName, ref.OrgKey)
+				err := e.Cloud.QualityProfiles.AddGroup(ctx, ref.Language, ref.Name, cloudGroup, ref.OrgKey)
 				if err != nil {
 					counter.Fail()
 					logAPIWarn(e.Logger, "setProfileGroupPermissions failed", err,
-						"profile", ref.Name, "group", groupName)
+						"profile", ref.Name, "group", cloudGroup)
 				} else {
 					counter.Success()
 				}
@@ -363,8 +375,10 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 		}
 	}
 
+	// sonar-users is intentionally NOT in skipGroups (issue #269): the
+	// apply closure remaps it to SQC's built-in `Members` group via
+	// MapGroupNameToCloud and grants the permission there.
 	skipGroups := map[string]bool{
-		"sonar-users":          true,
 		"sonar-administrators": true,
 		migrationScanners:      true,
 		migrationViewers:       true,
@@ -389,7 +403,16 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 		if !ok || tmpl.cloudID == "" || tmpl.org == "" {
 			return
 		}
-		if !groupExists[tmpl.org+"\x00"+groupName] {
+		// Issue #269: remap SQS built-in groups (sonar-users → Members).
+		// Aliased built-ins exist on SQC by default and won't appear in
+		// the createGroups output, so the groupExists check is skipped
+		// for them.
+		cloudGroup, mapOK := MapGroupNameToCloud(groupName)
+		if !mapOK {
+			return
+		}
+		aliased := cloudGroup != groupName
+		if !aliased && !groupExists[tmpl.org+"\x00"+groupName] {
 			return
 		}
 		perms := extractStringArray(data, "permissions")
@@ -397,7 +420,7 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 			if perm == "" {
 				continue
 			}
-			k := triple{tmpl.cloudID, groupName, perm}
+			k := triple{tmpl.cloudID, cloudGroup, perm}
 			appliedMu.Lock()
 			if applied[k] {
 				appliedMu.Unlock()
@@ -405,10 +428,10 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 			}
 			applied[k] = true
 			appliedMu.Unlock()
-			if err := e.Cloud.Permissions.AddGroupToTemplate(ctx, tmpl.cloudID, groupName, perm, tmpl.org); err != nil {
+			if err := e.Cloud.Permissions.AddGroupToTemplate(ctx, tmpl.cloudID, cloudGroup, perm, tmpl.org); err != nil {
 				counter.Fail()
 				logAPIWarn(e.Logger, "setTemplateGroupPermissions failed", err,
-					"template", tmpl.cloudID, "group", groupName, "perm", perm)
+					"template", tmpl.cloudID, "group", cloudGroup, "perm", perm)
 			} else {
 				counter.Success()
 			}

--- a/go/internal/migrate/tasks_scanhistory_test.go
+++ b/go/internal/migrate/tasks_scanhistory_test.go
@@ -198,7 +198,7 @@ func TestBuildChangesetMap(t *testing.T) {
 	cr.Get("p1:src/Empty.java")
 
 	now := time.Now()
-	result := buildChangesetMap(cr, components, now)
+	result := buildChangesetMap(cr, components, nil, now)
 
 	// Lines > 0 should produce changesets.
 	mainRef, _ := cr.Refs()["p1:src/Main.java"]


### PR DESCRIPTION
## Summary

Fixes #269. SonarQube Server's built-in `sonar-users` group ("everyone with an account on this server") has no namesake on SonarQube Cloud — the analogous group is `Members`. Without a remap the migrate task hit `POST /api/permissions/add_group` with `name=sonar-users` for every project/org/profile/template and got 404 each time, so permissions granted to the implicit "all users" group were silently lost.

## Changes

- New `MapGroupNameToCloud` helper in `builtin_groups.go`, backed by a `builtInGroupCloudAliases` map (today: `sonar-users → Members`)
- Applied at the four permission-grant call sites:
  - `applyOrgPermissions` (`tasks_permissions.go`)
  - `applyGroupPermissions` (project-level, `tasks_associate.go`)
  - `runSetProfileGroupPermissions` (`tasks_permissions.go`)
  - `runSetTemplateGroupPermissions` (`tasks_permissions.go`) — `sonar-users` removed from the hard-skip list so the remap fires; the `groupExists` check is skipped for aliased built-ins since they exist on SQC by default
- `IsBuiltInGroup("sonar-users")` is unchanged — `createGroups` still won't try to create a custom group with that name
- Drive-by: fix pre-existing migrate-package test compile error in `tasks_scanhistory_test.go` (`buildChangesetMap` signature change). Without this the package tests don't even compile, blocking validation of permission tests.

## Test plan

- [x] `cd go && go test ./internal/migrate/...` — passes (the new `builtin_groups_test.go` covers passthrough, remap, and the still-skipped-for-creation invariant)
- [ ] Run migrate against a live SQS source with a `sonar-users` permission, confirm no more `Group with name 'sonar-users' ... not found` 404 warnings and that the corresponding permissions are visible on SQC's `Members` group

Generated with [Claude Code](https://claude.com/claude-code)
