### PR TITLE
Issue #275: support --config in structure and mappings commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,15 @@ go run . structure --export_directory ./files/
 
 # Built binary
 sonar-migration-tool structure --export_directory ./files/
+
+# Or, reuse the extract config (export_directory is read from it)
+sonar-migration-tool structure --config extract-config.json
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--export_directory` | Root directory containing the extract output (default: `./migration-files`) |
+| `--config` | Path to JSON config file (same shape as `extract --config`). `export_directory` is read from it; when exactly one SonarCloud organization is defined, its key pre-populates `sonarcloud_org_key`. `--export_directory` on the CLI overrides the config value. |
 
 Then edit `files/organizations.csv` — fill in `sonarcloud_org_key` for each row before continuing.
 
@@ -281,7 +289,15 @@ go run . mappings --export_directory ./files/
 
 # Built binary
 sonar-migration-tool mappings --export_directory ./files/
+
+# Or, reuse the extract config (export_directory is read from it)
+sonar-migration-tool mappings --config extract-config.json
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--export_directory` | Root directory containing the extract output (default: `./migration-files`) |
+| `--config` | Path to JSON config file (same shape as `extract --config`); `export_directory` is read from it. `--export_directory` on the CLI overrides the config value. |
 
 Outputs `gates.csv`, `profiles.csv`, `groups.csv`, `templates.csv`, `portfolios.csv`.
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -116,6 +116,27 @@ Usage:
 | `run_id` | string | `null` | ID of run to resume |
 | `target_task` | string | `null` | Specific migration task |
 
+### Structure and Mappings Commands
+
+Both `structure` and `mappings` accept `--config` pointing at the same JSON
+file used by `extract`. They read **only `export_directory`** from it — every
+other field is ignored. `structure` additionally pre-populates the
+`sonarcloud_org_key` column in `organizations.csv` when exactly one
+SonarCloud organization is defined in the config (under `target.organizations`
+in the unified shape, or `organizations` in the migrate shape).
+
+```bash
+# Reuse the extract config — export_directory comes from the JSON
+./sonar-migration-tool structure --config extract-config.json
+./sonar-migration-tool mappings  --config extract-config.json
+```
+
+Precedence (same as `extract`, `migrate`, and `predictive-report`):
+
+1. `--export_directory` on the CLI wins when explicitly set.
+2. Otherwise `export_directory` from `--config` is used.
+3. Otherwise the default `./migration-files` is used.
+
 ## Combining Config Files and CLI Arguments
 
 Command-line arguments **override** config file values. This allows you to:
@@ -231,10 +252,10 @@ Create `prod-config.json`:
 ./sonar-migration-tool extract --config extract-config.json
 
 # Generate structure
-./sonar-migration-tool structure --export_directory ./migration-data
+./sonar-migration-tool structure --config extract-config.json
 
 # Generate mappings
-./sonar-migration-tool mappings --export_directory ./migration-data
+./sonar-migration-tool mappings --config extract-config.json
 
 # Edit organizations.csv to add SonarCloud org keys
 # Then migrate

--- a/docs/MANUAL-MIGRATION.md
+++ b/docs/MANUAL-MIGRATION.md
@@ -98,7 +98,15 @@ cd go && go run . structure --export_directory ../files/
 
 # Built binary
 sonar-migration-tool structure --export_directory ./files/
+
+# Or, reuse the same JSON config you passed to extract
+sonar-migration-tool structure --config extract-config.json
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--export_directory` | Directory containing the extract output |
+| `--config` | JSON config file (same shape as `extract --config`). `export_directory` is read from it; when exactly one SonarCloud organization is defined, its key pre-populates `sonarcloud_org_key`. `--export_directory` on the CLI overrides the config value. |
 
 ---
 
@@ -127,7 +135,15 @@ cd go && go run . mappings --export_directory ../files/
 
 # Built binary
 sonar-migration-tool mappings --export_directory ./files/
+
+# Or, reuse the same JSON config you passed to extract
+sonar-migration-tool mappings --config extract-config.json
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--export_directory` | Directory containing the extract output |
+| `--config` | JSON config file (same shape as `extract --config`); `export_directory` is read from it. `--export_directory` on the CLI overrides the config value. |
 
 This produces the following files in your `files/` directory:
 

--- a/go/cmd/mappings.go
+++ b/go/cmd/mappings.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 	"github.com/spf13/cobra"
 )
@@ -8,9 +11,16 @@ import (
 var mappingsCmd = &cobra.Command{
 	Use:   "mappings",
 	Short: "Map entities to organizations",
-	Long:  "Maps groups, permission templates, quality profiles, quality gates, and portfolios to relevant organizations. Outputs CSVs for each entity type.",
+	Long: `Maps groups, permission templates, quality profiles, quality gates, and portfolios to relevant organizations. Outputs CSVs for each entity type.
+
+The export directory can be supplied directly via --export_directory or
+read from the same JSON config file the extract / migrate commands use
+via --config (issue #275).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		exportDir, _ := cmd.Flags().GetString("export_directory")
+		exportDir, err := resolveMappingsExportDir(cmd)
+		if err != nil {
+			return err
+		}
 		if err := structure.RunMappings(exportDir); err != nil {
 			return err
 		}
@@ -20,5 +30,33 @@ var mappingsCmd = &cobra.Command{
 }
 
 func init() {
-	mappingsCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory containing all SonarQube exports")
+	f := mappingsCmd.Flags()
+	f.String("config", "", "Path to JSON configuration file (same shape as extract --config); export_directory is read from it")
+	f.String("export_directory", "", "Root directory containing all SonarQube exports")
+}
+
+// resolveMappingsExportDir applies the same config-vs-flag precedence
+// the extract, migrate, and predictive-report commands use:
+//
+//   - --config <path> loads export_directory from the JSON file (#275).
+//   - --export_directory always wins when explicitly set on the CLI.
+//   - Empty result falls back to DefaultExportDirectory.
+func resolveMappingsExportDir(cmd *cobra.Command) (string, error) {
+	exportDir, _ := cmd.Flags().GetString("export_directory")
+	configFile, _ := cmd.Flags().GetString("config")
+
+	if configFile != "" {
+		cfg, err := extract.LoadExtractConfigFile(configFile)
+		if err != nil {
+			return "", fmt.Errorf("loading config %s: %w", configFile, err)
+		}
+		if !cmd.Flags().Changed("export_directory") {
+			exportDir = cfg.ExportDirectory
+		}
+	}
+
+	if exportDir == "" {
+		exportDir = DefaultExportDirectory
+	}
+	return exportDir, nil
 }

--- a/go/cmd/mappings_test.go
+++ b/go/cmd/mappings_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newMappingsTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "mappings"}
+	f := cmd.Flags()
+	f.String("config", "", "")
+	f.String("export_directory", "", "")
+	return cmd
+}
+
+func writeMappingsConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "mappings-cfg-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// Issue #275: --config should populate export_directory from the JSON.
+func TestMappings_ConfigFileSuppliesExportDirectory(t *testing.T) {
+	path := writeMappingsConfigFile(t, `{
+		"url": "https://sqs.example.com",
+		"token": "ignored",
+		"export_directory": "/cfg/files"
+	}`)
+
+	cmd := newMappingsTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	got, err := resolveMappingsExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolveMappingsExportDir: %v", err)
+	}
+	if got != "/cfg/files" {
+		t.Errorf("ExportDirectory: got %q, want /cfg/files", got)
+	}
+}
+
+// Issue #275: --export_directory on the CLI takes precedence over the
+// value in --config.
+func TestMappings_FlagOverridesConfigFile(t *testing.T) {
+	path := writeMappingsConfigFile(t, `{
+		"export_directory": "/cfg/files"
+	}`)
+
+	cmd := newMappingsTestCmd()
+	_ = cmd.Flags().Set("config", path)
+	_ = cmd.Flags().Set("export_directory", "/cli/files")
+
+	got, err := resolveMappingsExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolveMappingsExportDir: %v", err)
+	}
+	if got != "/cli/files" {
+		t.Errorf("ExportDirectory: CLI flag should win, got %q", got)
+	}
+}
+
+// Without --config and without --export_directory, the command falls
+// back to the implicit default.
+func TestMappings_DefaultsExportDir(t *testing.T) {
+	cmd := newMappingsTestCmd()
+	got, err := resolveMappingsExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolveMappingsExportDir: %v", err)
+	}
+	if got != DefaultExportDirectory {
+		t.Errorf("got %q, want %q", got, DefaultExportDirectory)
+	}
+}
+
+// Pointing --config at a non-existent file should produce a wrapped
+// error so the operator can act on it.
+func TestMappings_MissingConfigFileError(t *testing.T) {
+	cmd := newMappingsTestCmd()
+	_ = cmd.Flags().Set("config", "/path/that/does/not/exist.json")
+
+	if _, err := resolveMappingsExportDir(cmd); err == nil {
+		t.Error("expected error when --config points at a missing file")
+	}
+}

--- a/go/cmd/structure.go
+++ b/go/cmd/structure.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 	"github.com/spf13/cobra"
@@ -9,12 +12,18 @@ import (
 var structureCmd = &cobra.Command{
 	Use:   "structure",
 	Short: "Group projects into organizations",
-	Long:  "Groups projects into organizations based on DevOps Bindings and Server Urls. Outputs organizations and projects as CSVs.",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		exportDir, _ := cmd.Flags().GetString("export_directory")
+	Long: `Groups projects into organizations based on DevOps Bindings and Server Urls. Outputs organizations and projects as CSVs.
 
-		// When a config file is provided, pre-populate sonarcloud_org_key if
-		// exactly one SonarCloud organization is defined.
+The export directory can be supplied directly via --export_directory or
+read from the same JSON config file the extract / migrate commands use
+via --config (issue #275). When --config defines exactly one SonarCloud
+organization, its key is pre-populated as sonarcloud_org_key.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		exportDir, err := resolveStructureExportDir(cmd)
+		if err != nil {
+			return err
+		}
+
 		configFile, _ := cmd.Flags().GetString("config")
 		if configFile != "" {
 			orgs, err := migrate.LoadSonarCloudOrgsFromConfigFile(configFile)
@@ -39,6 +48,32 @@ var structureCmd = &cobra.Command{
 }
 
 func init() {
-	structureCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory containing all SonarQube exports")
-	structureCmd.Flags().String("config", "", "Path to JSON configuration file (pre-populates sonarcloud_org_key when one org is defined)")
+	structureCmd.Flags().String("export_directory", "", "Root directory containing all SonarQube exports")
+	structureCmd.Flags().String("config", "", "Path to JSON configuration file (same shape as extract --config); export_directory is read from it, and sonarcloud_org_key is pre-populated when one org is defined")
+}
+
+// resolveStructureExportDir applies the same config-vs-flag precedence
+// the extract, mappings, and predictive-report commands use:
+//
+//   - --config <path> loads export_directory from the JSON file (#275).
+//   - --export_directory always wins when explicitly set on the CLI.
+//   - Empty result falls back to DefaultExportDirectory.
+func resolveStructureExportDir(cmd *cobra.Command) (string, error) {
+	exportDir, _ := cmd.Flags().GetString("export_directory")
+	configFile, _ := cmd.Flags().GetString("config")
+
+	if configFile != "" {
+		cfg, err := extract.LoadExtractConfigFile(configFile)
+		if err != nil {
+			return "", fmt.Errorf("loading config %s: %w", configFile, err)
+		}
+		if !cmd.Flags().Changed("export_directory") {
+			exportDir = cfg.ExportDirectory
+		}
+	}
+
+	if exportDir == "" {
+		exportDir = DefaultExportDirectory
+	}
+	return exportDir, nil
 }

--- a/go/cmd/structure_test.go
+++ b/go/cmd/structure_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newStructureTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "structure"}
+	f := cmd.Flags()
+	f.String("config", "", "")
+	f.String("export_directory", "", "")
+	return cmd
+}
+
+func writeStructureConfigFile(t *testing.T, contents string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "structure-cfg-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(contents); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	return f.Name()
+}
+
+// Issue #275: --config should populate export_directory from the JSON.
+func TestStructure_ConfigFileSuppliesExportDirectory(t *testing.T) {
+	path := writeStructureConfigFile(t, `{
+		"url": "https://sqs.example.com",
+		"token": "ignored",
+		"export_directory": "/cfg/files"
+	}`)
+
+	cmd := newStructureTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	got, err := resolveStructureExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolveStructureExportDir: %v", err)
+	}
+	if got != "/cfg/files" {
+		t.Errorf("ExportDirectory: got %q, want /cfg/files", got)
+	}
+}
+
+// Issue #275: --export_directory on the CLI takes precedence over the
+// value in --config.
+func TestStructure_FlagOverridesConfigFile(t *testing.T) {
+	path := writeStructureConfigFile(t, `{
+		"export_directory": "/cfg/files"
+	}`)
+
+	cmd := newStructureTestCmd()
+	_ = cmd.Flags().Set("config", path)
+	_ = cmd.Flags().Set("export_directory", "/cli/files")
+
+	got, err := resolveStructureExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolveStructureExportDir: %v", err)
+	}
+	if got != "/cli/files" {
+		t.Errorf("ExportDirectory: CLI flag should win, got %q", got)
+	}
+}
+
+// Without --config and without --export_directory, the command falls
+// back to the implicit default.
+func TestStructure_DefaultsExportDir(t *testing.T) {
+	cmd := newStructureTestCmd()
+	got, err := resolveStructureExportDir(cmd)
+	if err != nil {
+		t.Fatalf("resolveStructureExportDir: %v", err)
+	}
+	if got != DefaultExportDirectory {
+		t.Errorf("got %q, want %q", got, DefaultExportDirectory)
+	}
+}
+
+// Pointing --config at a non-existent file should produce a wrapped
+// error so the operator can act on it.
+func TestStructure_MissingConfigFileError(t *testing.T) {
+	cmd := newStructureTestCmd()
+	_ = cmd.Flags().Set("config", "/path/that/does/not/exist.json")
+
+	if _, err := resolveStructureExportDir(cmd); err == nil {
+		t.Error("expected error when --config points at a missing file")
+	}
+}


### PR DESCRIPTION
## Summary

- `mappings` now accepts `--config` and reads `export_directory` from the JSON config file (resolves #275).
- `structure` now also honors `export_directory` from `--config`; previously it only read `sonarcloud_org_key`. The existing single-org pre-population behavior is preserved.
- Both commands use the same precedence as `extract`, `migrate`, and `predictive-report`: CLI flag > config file > `DefaultExportDirectory`.

## Test plan

- [x] `go test ./cmd/` passes — 8 new unit tests covering config-supplies-export-dir, flag-overrides-config, default fallback, and missing-config error for each command
- [x] `go run . structure --help` and `go run . mappings --help` show the new `--config` flag and updated long descriptions
- [x] Documentation updated: README.md, docs/CONFIG.md, docs/MANUAL-MIGRATION.md

Closes #275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
