### PR TITLE
Issue #279: migrate fails fast with exit 2 when no org mapping is defined

### DIFF
--- a/go/internal/common/exit_error.go
+++ b/go/internal/common/exit_error.go
@@ -1,0 +1,33 @@
+package common
+
+import "fmt"
+
+// ExitCodeError is an error that carries a specific process exit code.
+// main.go unwraps it via errors.As to translate the carried code into
+// the process exit status, so a command can fail with a meaningful
+// non-zero code (e.g. "missing org mapping" = 2) rather than the
+// catch-all 1.
+type ExitCodeError struct {
+	Code int
+	Err  error
+}
+
+func (e *ExitCodeError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("exit code %d", e.Code)
+	}
+	return e.Err.Error()
+}
+
+func (e *ExitCodeError) Unwrap() error {
+	return e.Err
+}
+
+// NewExitError wraps err with the given exit code. Returns the bare
+// error when err is nil to avoid producing an empty-message wrapper.
+func NewExitError(code int, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ExitCodeError{Code: code, Err: err}
+}

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -56,6 +56,13 @@ type Executor struct {
 func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	cfg.applyDefaults()
 
+	// Fail fast when no SQC org mapping has been defined — otherwise the
+	// run would complete with nothing migrated, which is indistinguishable
+	// from a successful no-op (issue #279).
+	if err := validateOrgMapping(cfg.ExportDirectory); err != nil {
+		return "", err
+	}
+
 	level := slog.LevelInfo
 	if cfg.Debug {
 		level = slog.LevelDebug

--- a/go/internal/migrate/org_mapping.go
+++ b/go/internal/migrate/org_mapping.go
@@ -1,0 +1,39 @@
+package migrate
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+)
+
+// validateOrgMapping checks organizations.csv has at least one row with a
+// non-empty sonarcloud_org_key. A migrate run with all rows unmapped used
+// to exit 0 with nothing migrated, which silently looked like a successful
+// no-op (issue #279).
+//
+// Returns an *common.ExitCodeError with code 2 when no mapping is defined,
+// matching the contract from #279. SKIPPED rows count as "mapped" — the
+// user has deliberately chosen to exclude them, distinct from forgetting
+// to fill in the file at all.
+func validateOrgMapping(exportDir string) error {
+	rows, err := structure.LoadCSV(exportDir, "organizations.csv")
+	if err != nil {
+		return fmt.Errorf("loading organizations.csv: %w", err)
+	}
+	csvPath := filepath.Join(exportDir, "organizations.csv")
+	if len(rows) == 0 {
+		return common.NewExitError(2, fmt.Errorf(
+			`No organization mapping has been defined, please review the %q file`, csvPath))
+	}
+	for _, row := range rows {
+		val, _ := row["sonarcloud_org_key"].(string)
+		if strings.TrimSpace(val) != "" {
+			return nil
+		}
+	}
+	return common.NewExitError(2, fmt.Errorf(
+		`No organization mapping has been defined, please review the %q file`, csvPath))
+}

--- a/go/internal/migrate/org_mapping_test.go
+++ b/go/internal/migrate/org_mapping_test.go
@@ -1,0 +1,103 @@
+package migrate
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+func writeOrgCSV(t *testing.T, dir, contents string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "organizations.csv"), []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Issue #279: when every sonarcloud_org_key column is empty, migrate
+// should fail fast with the specified message and exit code 2 instead
+// of "succeeding" while doing nothing.
+func TestValidateOrgMapping_AllEmptyReturnsExit2(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,
+org-b,
+org-c,
+`)
+	err := validateOrgMapping(dir)
+	if err == nil {
+		t.Fatal("expected an error when no mapping is defined")
+	}
+	var ec *common.ExitCodeError
+	if !errors.As(err, &ec) {
+		t.Fatalf("expected *ExitCodeError, got %T", err)
+	}
+	if ec.Code != 2 {
+		t.Errorf("exit code: got %d, want 2", ec.Code)
+	}
+	expected := "No organization mapping has been defined, please review the"
+	if !strings.Contains(err.Error(), expected) {
+		t.Errorf("error message: got %q, want it to contain %q", err.Error(), expected)
+	}
+	if !strings.Contains(err.Error(), filepath.Join(dir, "organizations.csv")) {
+		t.Errorf("error should include the CSV path, got %q", err.Error())
+	}
+}
+
+// At least one mapped row → no error.
+func TestValidateOrgMapping_OneMappedPasses(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,
+org-b,my-cloud-org
+org-c,
+`)
+	if err := validateOrgMapping(dir); err != nil {
+		t.Errorf("expected nil for partial mapping, got %v", err)
+	}
+}
+
+// SKIPPED rows count as deliberately mapped — they do not trigger the
+// "no mapping defined" error even if every other row is empty. The
+// sentinel is the user's explicit choice; an empty cell is the
+// forgotten-to-fill case.
+func TestValidateOrgMapping_OnlySkippedRowsPass(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,SKIPPED
+org-b,SKIPPED
+`)
+	if err := validateOrgMapping(dir); err != nil {
+		t.Errorf("expected nil when all rows are SKIPPED, got %v", err)
+	}
+}
+
+// Whitespace-only cells are still "empty" — the user did not type a
+// real key, so the error must fire.
+func TestValidateOrgMapping_WhitespaceCountsAsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,
+org-b,
+`)
+	if err := validateOrgMapping(dir); err == nil {
+		t.Error("expected error when all sonarcloud_org_key values are whitespace")
+	}
+}
+
+// Missing file → also surfaces the same error so the operator hears
+// about a misconfigured working directory immediately.
+func TestValidateOrgMapping_MissingFileReturnsExit2(t *testing.T) {
+	dir := t.TempDir()
+	err := validateOrgMapping(dir)
+	if err == nil {
+		t.Fatal("expected error when organizations.csv is missing")
+	}
+	var ec *common.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Errorf("expected exit code 2 error, got %v (%T)", err, err)
+	}
+}

--- a/go/main.go
+++ b/go/main.go
@@ -1,15 +1,21 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/sonar-solutions/sonar-migration-tool/cmd"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
 
 func main() {
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		var ec *common.ExitCodeError
+		if errors.As(err, &ec) {
+			os.Exit(ec.Code)
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

When `organizations.csv` has every `sonarcloud_org_key` empty, `migrate` used to run to completion with nothing migrated — indistinguishable from a successful no-op. It now exits immediately with **code 2** and the spec'd message naming the CSV path.

- `SKIPPED` rows count as deliberately mapped and do not trigger the check.
- Missing `organizations.csv` surfaces the same code-2 error so operators hear about a misconfigured working directory immediately.
- New `common.ExitCodeError` type carries a process exit code; `main.go` unwraps via `errors.As` so future validations can surface their own codes (1 stays the catch-all).

## Test plan

- [x] `go test ./...` passes (5 new tests: all-empty, one-mapped passes, SKIPPED-only passes, whitespace counts as empty, missing-file → code 2)
- [x] Live smoke: `./sonar-migration-tool migrate --export_directory /tmp/empty-mig …` prints `Error: No organization mapping has been defined, please review the "/tmp/empty-mig/organizations.csv" file` and exits with status `2`

Closes #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
