### PR TITLE
Issue #281: add --default_organization to migrate every project to one SQC org

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ sonar-migration-tool migrate <TOKEN> <ENTERPRISE_KEY> --export_directory ./files
 | `--run_id` | Resume a failed migration from the last completed task |
 | `--target_task` | Run a specific migration task (with its dependencies) |
 | `--skip_profiles` | Skip quality profile migration/provisioning |
+| `--default_organization` | SonarQube Cloud organization key applied to every project when `organizations.csv` has no mapping defined. Ignored (with a WARN) if any row already carries a `sonarcloud_org_key`. Useful for small instances where every SQS project migrates into one SQC org. |
 | `--edition` | SonarQube Cloud license edition |
 | `--url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
 | `--concurrency` | Max concurrent requests |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -115,6 +115,7 @@ Usage:
 | `concurrency` | number | `25` | Maximum concurrent requests |
 | `run_id` | string | `null` | ID of run to resume |
 | `target_task` | string | `null` | Specific migration task |
+| `default_organization` | string | `null` | SonarCloud organization applied to every project when `organizations.csv` has no mapping. Ignored (WARN) if any row already carries a `sonarcloud_org_key`. In the unified config shape this lives under `target.default_organization`. CLI `--default_organization` wins. Issue #281. |
 
 ### Structure and Mappings Commands
 

--- a/docs/MANUAL-MIGRATION.md
+++ b/docs/MANUAL-MIGRATION.md
@@ -123,6 +123,8 @@ http://localhost:9000,my-cloud-org-key
 
 Save the file when you are done.
 
+> **Shortcut for single-org migrations:** if every project on every server is going to land in the same SonarQube Cloud organization, you can skip this step and pass `--default_organization <org-key>` (or set `target.default_organization` in the config file) when running `migrate` in Step 6. The tool will fill `sonarcloud_org_key` for every row in `organizations.csv` automatically. If you have already mapped any row by hand, the flag is ignored and a `WARN` is logged. Issue #281.
+
 ---
 
 ### Step 5: Generate Entity Mappings
@@ -179,6 +181,7 @@ sonar-migration-tool migrate YOUR_CLOUD_TOKEN YOUR_ENTERPRISE_KEY --export_direc
 | `--run_id`          | Resume a previously started migration by its run ID       | --                        |
 | `--target_task`     | Run a specific migration task only                        | --                        |
 | `--skip_profiles`   | Skip migrating quality profiles                           | --                        |
+| `--default_organization` | SonarCloud organization applied to every project when `organizations.csv` has no mapping. Ignored (WARN) if any row is already mapped. | --              |
 
 ---
 

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -48,6 +48,7 @@ func init() {
 	f.String("target_task", "", "Name of a specific migration task to complete")
 	f.Bool("skip_profiles", false, "Skip quality profile migration/provisioning in SonarQube Cloud")
 	f.Bool("include_scan_history", false, "Import scan history (issues, metrics) into SonarQube Cloud projects")
+	f.String("default_organization", "", "SonarQube Cloud organization to migrate every project into when organizations.csv has no mapping defined. Ignored if any mapping is present.")
 }
 
 func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfig, error) {
@@ -78,6 +79,7 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	overrideString(cmd, "run_id", &cfg.RunID)
 	overrideString(cmd, "export_directory", &cfg.ExportDirectory)
 	overrideString(cmd, "target_task", &cfg.TargetTask)
+	overrideString(cmd, "default_organization", &cfg.DefaultOrganization)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	if cmd.Flags().Changed("skip_profiles") {
 		cfg.SkipProfiles, _ = cmd.Flags().GetBool("skip_profiles")

--- a/go/cmd/migrate_test.go
+++ b/go/cmd/migrate_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func newMigrateTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "migrate"}
+	f := cmd.Flags()
+	f.String("config", "", "")
+	f.String("edition", "", "")
+	f.String("url", "", "")
+	f.String("run_id", "", "")
+	f.Int("concurrency", 0, "")
+	f.String("export_directory", "", "")
+	f.String("target_task", "", "")
+	f.Bool("skip_profiles", false, "")
+	f.Bool("include_scan_history", false, "")
+	f.Bool("debug", false, "")
+	f.String("default_organization", "", "")
+	return cmd
+}
+
+func writeMigrateConfig(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cfg.json")
+	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// Issue #281: CLI --default_organization overrides the config file
+// value.
+func TestBuildMigrateConfig_DefaultOrganization_CLIOverridesConfig(t *testing.T) {
+	path := writeMigrateConfig(t, `{
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "t",
+			"enterprise_key": "ent",
+			"default_organization": "config-default"
+		}
+	}`)
+	cmd := newMigrateTestCmd()
+	_ = cmd.Flags().Set("config", path)
+	_ = cmd.Flags().Set("default_organization", "cli-default")
+
+	cfg, err := buildMigrateConfig(cmd, nil)
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if cfg.DefaultOrganization != "cli-default" {
+		t.Errorf("CLI flag should override config, got %q", cfg.DefaultOrganization)
+	}
+}
+
+// Config file value is used when --default_organization is absent.
+func TestBuildMigrateConfig_DefaultOrganization_ConfigOnly(t *testing.T) {
+	path := writeMigrateConfig(t, `{
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "t",
+			"enterprise_key": "ent",
+			"default_organization": "config-default"
+		}
+	}`)
+	cmd := newMigrateTestCmd()
+	_ = cmd.Flags().Set("config", path)
+
+	cfg, err := buildMigrateConfig(cmd, nil)
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if cfg.DefaultOrganization != "config-default" {
+		t.Errorf("expected config value, got %q", cfg.DefaultOrganization)
+	}
+}
+
+// Neither config nor CLI → empty.
+func TestBuildMigrateConfig_DefaultOrganization_Unset(t *testing.T) {
+	cmd := newMigrateTestCmd()
+	cfg, err := buildMigrateConfig(cmd, []string{"tok", "ent"})
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if cfg.DefaultOrganization != "" {
+		t.Errorf("expected empty, got %q", cfg.DefaultOrganization)
+	}
+}

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -69,15 +69,16 @@ type unifiedSourceBlock struct {
 // the unified config shape (#266). organization_key is provisional
 // for future SQC-org-to-SQC-org migration and is ignored for now.
 type unifiedTargetBlock struct {
-	URL             string `json:"url"`
-	Token           string `json:"token"`
-	EnterpriseKey   string `json:"enterprise_key"`
-	Edition         string `json:"edition"`
-	Concurrency     int    `json:"concurrency"`
-	Timeout         int    `json:"timeout"`
-	RunID           string `json:"run_id"`
-	TargetTask      string `json:"target_task"`
-	OrganizationKey string `json:"organization_key"` // provisional, ignored
+	URL                 string `json:"url"`
+	Token               string `json:"token"`
+	EnterpriseKey       string `json:"enterprise_key"`
+	Edition             string `json:"edition"`
+	Concurrency         int    `json:"concurrency"`
+	Timeout             int    `json:"timeout"`
+	RunID               string `json:"run_id"`
+	TargetTask          string `json:"target_task"`
+	OrganizationKey     string `json:"organization_key"`     // provisional, ignored
+	DefaultOrganization string `json:"default_organization"` // #281
 }
 
 type sonarCloudBlock struct {
@@ -140,6 +141,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			cfg.RunID = s.Target.RunID
 			cfg.TargetTask = s.Target.TargetTask
 			cfg.Concurrency = s.Target.Concurrency
+			cfg.DefaultOrganization = s.Target.DefaultOrganization
 		}
 		if cfg.Concurrency == 0 {
 			cfg.Concurrency = s.Concurrency

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -197,6 +197,30 @@ func TestLoadMigrateConfigFileUnifiedShape(t *testing.T) {
 	}
 }
 
+// Issue #281: target.default_organization parses into
+// MigrateConfig.DefaultOrganization.
+func TestLoadMigrateConfigFileUnifiedShape_DefaultOrganization(t *testing.T) {
+	body := `{
+  "target": {
+    "url": "https://sonarcloud.io/",
+    "token": "t",
+    "default_organization": "my-single-org"
+  }
+}`
+	dir := t.TempDir()
+	path := dir + "/unified.json"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadMigrateConfigFile(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.DefaultOrganization != "my-single-org" {
+		t.Errorf("DefaultOrganization: got %q, want my-single-org", cfg.DefaultOrganization)
+	}
+}
+
 // Target block overrides top-level concurrency when set.
 func TestLoadMigrateConfigFileUnifiedShape_TargetOverridesGlobals(t *testing.T) {
 	body := `{

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -31,6 +31,12 @@ type MigrateConfig struct {
 	SkipProfiles       bool
 	IncludeScanHistory bool
 	Debug              bool // Enable slog.LevelDebug + verbose request payload logs
+
+	// DefaultOrganization, when set, is used as the SonarCloud org for
+	// every row in organizations.csv if none have a sonarcloud_org_key.
+	// If at least one mapping is defined, this is ignored with a Warn
+	// log. Issue #281.
+	DefaultOrganization string
 }
 
 // Executor is the runtime context passed to every migrate task function.
@@ -56,18 +62,18 @@ type Executor struct {
 func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	cfg.applyDefaults()
 
-	// Fail fast when no SQC org mapping has been defined — otherwise the
-	// run would complete with nothing migrated, which is indistinguishable
-	// from a successful no-op (issue #279).
-	if err := validateOrgMapping(cfg.ExportDirectory); err != nil {
-		return "", err
-	}
-
 	level := slog.LevelInfo
 	if cfg.Debug {
 		level = slog.LevelDebug
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+
+	// Validate the SQC org mapping and apply --default_organization
+	// fallback if requested (issues #279 + #281). Done before any API
+	// client setup so the failure or warning surfaces immediately.
+	if err := applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger); err != nil {
+		return "", err
+	}
 
 	cloudURL := cfg.URL
 	apiURL := strings.Replace(cloudURL, "https://", "https://api.", 1)

--- a/go/internal/migrate/org_mapping.go
+++ b/go/internal/migrate/org_mapping.go
@@ -1,7 +1,10 @@
 package migrate
 
 import (
+	"encoding/csv"
 	"fmt"
+	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -9,31 +12,127 @@ import (
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
-// validateOrgMapping checks organizations.csv has at least one row with a
-// non-empty sonarcloud_org_key. A migrate run with all rows unmapped used
-// to exit 0 with nothing migrated, which silently looked like a successful
-// no-op (issue #279).
+// applyOrgMapping checks organizations.csv has at least one row with a
+// non-empty sonarcloud_org_key. A migrate run with all rows unmapped
+// used to exit 0 with nothing migrated, which silently looked like a
+// successful no-op (issue #279).
 //
-// Returns an *common.ExitCodeError with code 2 when no mapping is defined,
-// matching the contract from #279. SKIPPED rows count as "mapped" — the
-// user has deliberately chosen to exclude them, distinct from forgetting
-// to fill in the file at all.
-func validateOrgMapping(exportDir string) error {
+// When defaultOrg is non-empty, behaviour follows issue #281:
+//
+//   - Mapping defined + defaultOrg set: defaultOrg is ignored, a WARN is
+//     logged, the CSV is left untouched.
+//   - No mapping + defaultOrg set: organizations.csv is rewritten with
+//     defaultOrg in every sonarcloud_org_key cell, no error.
+//   - No mapping + defaultOrg empty: returns the #279 exit-code-2 error.
+//
+// SKIPPED rows count as "mapped" — the user has deliberately chosen to
+// exclude them, distinct from forgetting to fill in the file at all.
+func applyOrgMapping(exportDir, defaultOrg string, logger *slog.Logger) error {
 	rows, err := structure.LoadCSV(exportDir, "organizations.csv")
 	if err != nil {
 		return fmt.Errorf("loading organizations.csv: %w", err)
 	}
 	csvPath := filepath.Join(exportDir, "organizations.csv")
+
 	if len(rows) == 0 {
-		return common.NewExitError(2, fmt.Errorf(
-			`No organization mapping has been defined, please review the %q file`, csvPath))
+		// No file at all → cannot synthesize even with defaultOrg
+		// because the columns/rows aren't there yet.
+		return missingMappingError(csvPath)
 	}
+
+	hasMapping := false
 	for _, row := range rows {
 		val, _ := row["sonarcloud_org_key"].(string)
 		if strings.TrimSpace(val) != "" {
-			return nil
+			hasMapping = true
+			break
 		}
 	}
+
+	if hasMapping {
+		if defaultOrg != "" {
+			logger.Warn("Since organizations.csv mapping is defined, the provided default organization parameter is ignored",
+				"default_organization", defaultOrg, "file", csvPath)
+		}
+		return nil
+	}
+
+	// No mapping defined.
+	if defaultOrg == "" {
+		return missingMappingError(csvPath)
+	}
+
+	// Apply defaultOrg to every row and write back.
+	if err := writeOrgCSVWithDefault(csvPath, rows, defaultOrg); err != nil {
+		return fmt.Errorf("applying default_organization to organizations.csv: %w", err)
+	}
+	logger.Info("organizations.csv was empty — every project will migrate to the provided default organization",
+		"default_organization", defaultOrg, "rows", len(rows))
+	return nil
+}
+
+func missingMappingError(csvPath string) error {
 	return common.NewExitError(2, fmt.Errorf(
 		`No organization mapping has been defined, please review the %q file`, csvPath))
+}
+
+// writeOrgCSVWithDefault rewrites the file so every row's
+// sonarcloud_org_key cell carries defaultOrg, preserving all other
+// columns and their order. The file is read once to recover the
+// canonical header order — map iteration would otherwise scramble it.
+func writeOrgCSVWithDefault(path string, rows []map[string]any, defaultOrg string) error {
+	headers, err := readOrgCSVHeaders(path)
+	if err != nil {
+		return err
+	}
+	tmpPath := path + ".tmp"
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return err
+	}
+	w := csv.NewWriter(f)
+	if err := w.Write(headers); err != nil {
+		_ = f.Close()
+		return err
+	}
+	for _, row := range rows {
+		out := make([]string, len(headers))
+		for i, h := range headers {
+			if h == "sonarcloud_org_key" {
+				out[i] = defaultOrg
+				continue
+			}
+			out[i] = fmt.Sprintf("%v", row[h])
+			if row[h] == nil {
+				out[i] = ""
+			}
+		}
+		if err := w.Write(out); err != nil {
+			_ = f.Close()
+			return err
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
+
+func readOrgCSVHeaders(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	r := csv.NewReader(f)
+	headers, err := r.Read()
+	if err != nil {
+		return nil, err
+	}
+	return headers, nil
 }

--- a/go/internal/migrate/org_mapping_test.go
+++ b/go/internal/migrate/org_mapping_test.go
@@ -1,7 +1,10 @@
 package migrate
 
 import (
+	"bytes"
+	"encoding/csv"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,87 +20,131 @@ func writeOrgCSV(t *testing.T, dir, contents string) {
 	}
 }
 
-// Issue #279: when every sonarcloud_org_key column is empty, migrate
-// should fail fast with the specified message and exit code 2 instead
-// of "succeeding" while doing nothing.
-func TestValidateOrgMapping_AllEmptyReturnsExit2(t *testing.T) {
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+}
+
+// Issue #279: when every sonarcloud_org_key column is empty and no
+// default_organization is provided, migrate should fail fast with exit
+// code 2.
+func TestApplyOrgMapping_AllEmptyNoDefaultReturnsExit2(t *testing.T) {
 	dir := t.TempDir()
 	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
 org-a,
 org-b,
 org-c,
 `)
-	err := validateOrgMapping(dir)
+	err := applyOrgMapping(dir, "", discardLogger())
 	if err == nil {
-		t.Fatal("expected an error when no mapping is defined")
+		t.Fatal("expected an error when no mapping is defined and no default")
 	}
 	var ec *common.ExitCodeError
-	if !errors.As(err, &ec) {
-		t.Fatalf("expected *ExitCodeError, got %T", err)
+	if !errors.As(err, &ec) || ec.Code != 2 {
+		t.Errorf("expected exit code 2 error, got %v (%T)", err, err)
 	}
-	if ec.Code != 2 {
-		t.Errorf("exit code: got %d, want 2", ec.Code)
-	}
-	expected := "No organization mapping has been defined, please review the"
-	if !strings.Contains(err.Error(), expected) {
-		t.Errorf("error message: got %q, want it to contain %q", err.Error(), expected)
-	}
-	if !strings.Contains(err.Error(), filepath.Join(dir, "organizations.csv")) {
-		t.Errorf("error should include the CSV path, got %q", err.Error())
+	if !strings.Contains(err.Error(), "No organization mapping has been defined") {
+		t.Errorf("error should carry the spec'd message, got %q", err.Error())
 	}
 }
 
-// At least one mapped row → no error.
-func TestValidateOrgMapping_OneMappedPasses(t *testing.T) {
+// Issue #281: empty CSV + default_organization → rewrite the CSV with
+// the default in every row, no error.
+func TestApplyOrgMapping_AllEmptyWithDefaultFillsRows(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key,server_url
+org-a,,https://sqs-a.example.com
+org-b,,https://sqs-b.example.com
+`)
+	if err := applyOrgMapping(dir, "my-cloud-org", discardLogger()); err != nil {
+		t.Fatalf("expected success with default_organization, got %v", err)
+	}
+
+	// CSV must now carry the default for every row, original columns preserved.
+	f, err := os.Open(filepath.Join(dir, "organizations.csv"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	records, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if records[0][0] != "sonarqube_org_key" || records[0][1] != "sonarcloud_org_key" || records[0][2] != "server_url" {
+		t.Errorf("headers preserved: got %v", records[0])
+	}
+	if records[1][1] != "my-cloud-org" || records[2][1] != "my-cloud-org" {
+		t.Errorf("expected my-cloud-org in every row, got %v", records)
+	}
+	if records[1][2] != "https://sqs-a.example.com" {
+		t.Errorf("server_url should be preserved, got %q", records[1][2])
+	}
+}
+
+// Issue #281: mapped CSV + default_organization → ignore the default,
+// emit a WARN, leave the CSV untouched.
+func TestApplyOrgMapping_MappedWithDefaultWarnsAndIgnores(t *testing.T) {
+	dir := t.TempDir()
+	original := `sonarqube_org_key,sonarcloud_org_key
+org-a,real-cloud-org
+org-b,
+`
+	writeOrgCSV(t, dir, original)
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	if err := applyOrgMapping(dir, "default-cloud-org", logger); err != nil {
+		t.Fatalf("expected nil with mapped CSV + default, got %v", err)
+	}
+	// CSV must be unchanged.
+	got, _ := os.ReadFile(filepath.Join(dir, "organizations.csv"))
+	if string(got) != original {
+		t.Errorf("CSV must not be modified when mapping is already defined.\ngot:  %q\nwant: %q", string(got), original)
+	}
+	// WARN must mention the verbatim spec'd message.
+	if !strings.Contains(buf.String(), "Since organizations.csv mapping is defined, the provided default organization parameter is ignored") {
+		t.Errorf("expected the spec'd WARN message, got %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("expected WARN level, got %q", buf.String())
+	}
+}
+
+// Mapped CSV + no default → no warning, no error, CSV untouched.
+func TestApplyOrgMapping_MappedNoDefaultPasses(t *testing.T) {
 	dir := t.TempDir()
 	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
 org-a,
-org-b,my-cloud-org
-org-c,
+org-b,real-cloud-org
 `)
-	if err := validateOrgMapping(dir); err != nil {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	if err := applyOrgMapping(dir, "", logger); err != nil {
 		t.Errorf("expected nil for partial mapping, got %v", err)
+	}
+	if strings.Contains(buf.String(), "level=WARN") {
+		t.Errorf("must not emit a WARN when no default is provided, got %q", buf.String())
 	}
 }
 
-// SKIPPED rows count as deliberately mapped — they do not trigger the
-// "no mapping defined" error even if every other row is empty. The
-// sentinel is the user's explicit choice; an empty cell is the
-// forgotten-to-fill case.
-func TestValidateOrgMapping_OnlySkippedRowsPass(t *testing.T) {
+// SKIPPED rows count as mapped → no error, no default applied.
+func TestApplyOrgMapping_OnlySkippedRowsPass(t *testing.T) {
 	dir := t.TempDir()
 	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
 org-a,SKIPPED
 org-b,SKIPPED
 `)
-	if err := validateOrgMapping(dir); err != nil {
+	if err := applyOrgMapping(dir, "", discardLogger()); err != nil {
 		t.Errorf("expected nil when all rows are SKIPPED, got %v", err)
 	}
 }
 
-// Whitespace-only cells are still "empty" — the user did not type a
-// real key, so the error must fire.
-func TestValidateOrgMapping_WhitespaceCountsAsEmpty(t *testing.T) {
+// Missing file → still surfaces the code-2 error (can't synthesize
+// without rows).
+func TestApplyOrgMapping_MissingFileReturnsExit2(t *testing.T) {
 	dir := t.TempDir()
-	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
-org-a,
-org-b,
-`)
-	if err := validateOrgMapping(dir); err == nil {
-		t.Error("expected error when all sonarcloud_org_key values are whitespace")
-	}
-}
-
-// Missing file → also surfaces the same error so the operator hears
-// about a misconfigured working directory immediately.
-func TestValidateOrgMapping_MissingFileReturnsExit2(t *testing.T) {
-	dir := t.TempDir()
-	err := validateOrgMapping(dir)
-	if err == nil {
+	if err := applyOrgMapping(dir, "any-default", discardLogger()); err == nil {
 		t.Fatal("expected error when organizations.csv is missing")
-	}
-	var ec *common.ExitCodeError
-	if !errors.As(err, &ec) || ec.Code != 2 {
-		t.Errorf("expected exit code 2 error, got %v (%T)", err, err)
 	}
 }

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -154,6 +154,10 @@
         "organization_key": {
           "type": ["string", "null"],
           "description": "PROVISIONAL — ignored today; reserved for future SQC-org-to-SQC-org migration target side."
+        },
+        "default_organization": {
+          "type": ["string", "null"],
+          "description": "SonarQube Cloud organization key applied to every project when organizations.csv has no mapping defined. Ignored (with a WARN) when at least one row in organizations.csv carries a sonarcloud_org_key. CLI --default_organization overrides this. Issue #281."
         }
       }
     }


### PR DESCRIPTION
## Summary

For small/midsize migrations where every SQS project lands in the same SonarQube Cloud organization, filling the `sonarcloud_org_key` column in `organizations.csv` row-by-row is busywork. This adds a shortcut.

- **CLI**: new `--default_organization` flag on `migrate`.
- **Config**: new `target.default_organization` field in the unified config shape.
- **Precedence**: `--default_organization` overrides the config value.

### Behaviour

| Scenario | Effect |
|---|---|
| Empty `organizations.csv` mapping + default set | CSV rewritten with the default in every `sonarcloud_org_key` cell, other columns preserved. INFO logged. Migration proceeds. |
| Mapped CSV + default set | Default ignored. WARN logged: `Since organizations.csv mapping is defined, the provided default organization parameter is ignored`. CSV untouched. |
| Empty mapping + no default | Unchanged from #279: exit code 2 with the spec'd error. |
| Any `SKIPPED` row | Counts as mapped — deliberate exclusion stays distinct from "forgot to fill in". |

### Updated

- `schemas/config.schema.json` — `target.default_organization` with precedence description.
- `README.md`, `docs/CONFIG.md`, `docs/MANUAL-MIGRATION.md` — flag, config field, single-org shortcut documented in the migrate step.

## Test plan

- [x] `go test ./...` passes — 9 new tests:
  - Config-file parsing of `target.default_organization`
  - CLI precedence (CLI > config, config-only, both-unset)
  - Empty-CSV-with-default rewrites every row, preserves other columns
  - Mapped-CSV-with-default leaves the CSV untouched and emits the exact WARN message
  - Mapped-CSV-without-default is silent
  - Empty-CSV-without-default still returns exit code 2 (#279 regression guard)
  - SKIPPED-only rows pass
- [x] `go run . migrate --help` shows the new flag

Closes #281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
