### PR TITLE
Issue #283: abort migrate with exit 3 when a referenced SQC org is missing

### DIFF
--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -71,7 +71,8 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	// Validate the SQC org mapping and apply --default_organization
 	// fallback if requested (issues #279 + #281). Done before any API
 	// client setup so the failure or warning surfaces immediately.
-	if err := applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger); err != nil {
+	appliedDefault, err := applyOrgMapping(cfg.ExportDirectory, cfg.DefaultOrganization, logger)
+	if err != nil {
 		return "", err
 	}
 
@@ -93,6 +94,13 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	apiClient := sqapi.NewCloudClient(apiURL, cfg.Token, clientOpts...)
 	cc := cloud.New(cloudClient)
 	apiCC := cloud.New(apiClient)
+
+	// Verify every SQC organization the migration will touch exists and
+	// is visible to the token (issue #283). Done early so a typo aborts
+	// the run before any extract data is touched.
+	if err := validateOrgsExist(ctx, cc.Organizations, cfg.ExportDirectory, cfg.EnterpriseKey, cfg.DefaultOrganization, appliedDefault); err != nil {
+		return "", err
+	}
 
 	// Create RawClients for read operations.
 	raw := common.NewRawClient(cloudClient.HTTPClient(), cloudClient.BaseURL())

--- a/go/internal/migrate/org_existence_test.go
+++ b/go/internal/migrate/org_existence_test.go
@@ -1,0 +1,163 @@
+package migrate
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	sqcTypes "github.com/sonar-solutions/sq-api-go/types"
+)
+
+// fakeOrgLookup stubs the SQC Organizations.Search call so we can
+// exercise validateOrgsExist without hitting the network. Pass the set
+// of keys that "exist"; any other key will be reported as missing.
+type fakeOrgLookup struct {
+	existing map[string]bool
+	calls    [][]string
+}
+
+func newFakeOrgs(existing ...string) *fakeOrgLookup {
+	set := make(map[string]bool, len(existing))
+	for _, k := range existing {
+		set[k] = true
+	}
+	return &fakeOrgLookup{existing: set}
+}
+
+func (f *fakeOrgLookup) Search(ctx context.Context, keys ...string) ([]sqcTypes.Organization, error) {
+	f.calls = append(f.calls, append([]string(nil), keys...))
+	var out []sqcTypes.Organization
+	for _, k := range keys {
+		if f.existing[k] {
+			out = append(out, sqcTypes.Organization{Key: k, Name: k})
+		}
+	}
+	return out, nil
+}
+
+// Issue #283: default org missing → exit 3 + "Default organization"
+// message naming the enterprise.
+func TestValidateOrgsExist_DefaultMissingReturnsExit3(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,nonexistent-default
+`)
+	lookup := newFakeOrgs("some-other-org")
+
+	err := validateOrgsExist(context.Background(), lookup, dir, "my-enterprise", "nonexistent-default", true /* appliedDefault */)
+	if err == nil {
+		t.Fatal("expected an error for missing default org")
+	}
+	var ec *common.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 3 {
+		t.Fatalf("expected exit code 3, got %v (%T)", err, err)
+	}
+	want := `Default organization "nonexistent-default" does not exists in SonarQube Cloud, or is not part of Enterprise "my-enterprise"`
+	if err.Error() != want {
+		t.Errorf("error message:\n got:  %q\n want: %q", err.Error(), want)
+	}
+}
+
+// Default exists → no error.
+func TestValidateOrgsExist_DefaultExistsPasses(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,real-default
+`)
+	lookup := newFakeOrgs("real-default")
+	if err := validateOrgsExist(context.Background(), lookup, dir, "ent", "real-default", true); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+// CSV org missing → exit 3 + "Organization X specified in <csv>"
+// message naming both the file and the enterprise.
+func TestValidateOrgsExist_CSVOrgMissingReturnsExit3(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,real-org
+org-b,nonexistent-org
+`)
+	lookup := newFakeOrgs("real-org")
+
+	err := validateOrgsExist(context.Background(), lookup, dir, "my-enterprise", "" /* default */, false /* appliedDefault */)
+	if err == nil {
+		t.Fatal("expected an error for missing CSV org")
+	}
+	var ec *common.ExitCodeError
+	if !errors.As(err, &ec) || ec.Code != 3 {
+		t.Fatalf("expected exit code 3, got %v (%T)", err, err)
+	}
+	csvPath := filepath.Join(dir, "organizations.csv")
+	want := `Organization "nonexistent-org" specified in "` + csvPath + `" does not exists in SonarQube Cloud, or does not belong to Enterprise "my-enterprise"`
+	if err.Error() != want {
+		t.Errorf("error message:\n got:  %q\n want: %q", err.Error(), want)
+	}
+}
+
+// All CSV orgs exist → no error. SKIPPED and empty rows are ignored.
+func TestValidateOrgsExist_AllCSVOrgsExistPasses(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,real-a
+org-b,SKIPPED
+org-c,real-c
+org-d,
+`)
+	lookup := newFakeOrgs("real-a", "real-c")
+	if err := validateOrgsExist(context.Background(), lookup, dir, "ent", "", false); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+}
+
+// Duplicate keys across CSV rows are looked up once.
+func TestValidateOrgsExist_DeduplicatesKeys(t *testing.T) {
+	dir := t.TempDir()
+	writeOrgCSV(t, dir, `sonarqube_org_key,sonarcloud_org_key
+org-a,shared
+org-b,shared
+org-c,shared
+`)
+	lookup := newFakeOrgs("shared")
+	if err := validateOrgsExist(context.Background(), lookup, dir, "ent", "", false); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if len(lookup.calls) != 1 {
+		t.Errorf("expected 1 lookup call, got %d (%v)", len(lookup.calls), lookup.calls)
+	}
+	if len(lookup.calls[0]) != 1 || lookup.calls[0][0] != "shared" {
+		t.Errorf("expected one key 'shared', got %v", lookup.calls[0])
+	}
+}
+
+// Empty default + appliedDefault=true is treated as a no-op rather
+// than a failure (the caller is responsible for not calling us in this
+// shape, but be defensive).
+func TestValidateOrgsExist_EmptyDefaultNoOp(t *testing.T) {
+	dir := t.TempDir()
+	lookup := newFakeOrgs()
+	if err := validateOrgsExist(context.Background(), lookup, dir, "ent", "", true); err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if len(lookup.calls) != 0 {
+		t.Errorf("must not query SQC when defaultOrg is empty")
+	}
+}
+
+// Sanity: the spec'd CSV-variant message contains both the org key
+// and the enterprise key.
+func TestCSVOrgMissingError_MessageShape(t *testing.T) {
+	err := csvOrgMissingError("my-org", "/tmp/migration/organizations.csv", "my-ent")
+	if !strings.Contains(err.Error(), `"my-org"`) {
+		t.Error("missing org key in message")
+	}
+	if !strings.Contains(err.Error(), `"/tmp/migration/organizations.csv"`) {
+		t.Error("missing CSV path in message")
+	}
+	if !strings.Contains(err.Error(), `"my-ent"`) {
+		t.Error("missing enterprise key in message")
+	}
+}

--- a/go/internal/migrate/org_mapping.go
+++ b/go/internal/migrate/org_mapping.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"log/slog"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+	sqcTypes "github.com/sonar-solutions/sq-api-go/types"
 )
 
 // applyOrgMapping checks organizations.csv has at least one row with a
@@ -27,17 +29,21 @@ import (
 //
 // SKIPPED rows count as "mapped" — the user has deliberately chosen to
 // exclude them, distinct from forgetting to fill in the file at all.
-func applyOrgMapping(exportDir, defaultOrg string, logger *slog.Logger) error {
-	rows, err := structure.LoadCSV(exportDir, "organizations.csv")
-	if err != nil {
-		return fmt.Errorf("loading organizations.csv: %w", err)
+//
+// Returns appliedDefault=true when the CSV was rewritten with the
+// default; this drives the message variant produced by
+// validateOrgsExist for issue #283.
+func applyOrgMapping(exportDir, defaultOrg string, logger *slog.Logger) (appliedDefault bool, err error) {
+	rows, loadErr := structure.LoadCSV(exportDir, "organizations.csv")
+	if loadErr != nil {
+		return false, fmt.Errorf("loading organizations.csv: %w", loadErr)
 	}
 	csvPath := filepath.Join(exportDir, "organizations.csv")
 
 	if len(rows) == 0 {
 		// No file at all → cannot synthesize even with defaultOrg
 		// because the columns/rows aren't there yet.
-		return missingMappingError(csvPath)
+		return false, missingMappingError(csvPath)
 	}
 
 	hasMapping := false
@@ -54,21 +60,21 @@ func applyOrgMapping(exportDir, defaultOrg string, logger *slog.Logger) error {
 			logger.Warn("Since organizations.csv mapping is defined, the provided default organization parameter is ignored",
 				"default_organization", defaultOrg, "file", csvPath)
 		}
-		return nil
+		return false, nil
 	}
 
 	// No mapping defined.
 	if defaultOrg == "" {
-		return missingMappingError(csvPath)
+		return false, missingMappingError(csvPath)
 	}
 
 	// Apply defaultOrg to every row and write back.
 	if err := writeOrgCSVWithDefault(csvPath, rows, defaultOrg); err != nil {
-		return fmt.Errorf("applying default_organization to organizations.csv: %w", err)
+		return false, fmt.Errorf("applying default_organization to organizations.csv: %w", err)
 	}
 	logger.Info("organizations.csv was empty — every project will migrate to the provided default organization",
 		"default_organization", defaultOrg, "rows", len(rows))
-	return nil
+	return true, nil
 }
 
 func missingMappingError(csvPath string) error {
@@ -121,6 +127,109 @@ func writeOrgCSVWithDefault(path string, rows []map[string]any, defaultOrg strin
 		return err
 	}
 	return os.Rename(tmpPath, path)
+}
+
+// orgLookup is the contract validateOrgsExist needs from the SQC SDK.
+// Defined as an interface so unit tests can stub it without spinning
+// up a full client. Production code passes cc.Organizations.
+type orgLookup interface {
+	Search(ctx context.Context, keys ...string) ([]sqcTypes.Organization, error)
+}
+
+// validateOrgsExist checks that every SonarQube Cloud organization the
+// migration is about to use actually exists / is visible to the
+// authenticated token. The two failure modes from issue #283:
+//
+//   - appliedDefault=true: the only org in play is defaultOrg; missing
+//     org → "Default organization …" message.
+//   - appliedDefault=false: every distinct non-empty/non-SKIPPED
+//     sonarcloud_org_key in organizations.csv is checked. Missing
+//     org → "Organization X specified in <csv>" message.
+//
+// Returns an *common.ExitCodeError with code 3 on failure.
+func validateOrgsExist(ctx context.Context, lookup orgLookup, exportDir, enterpriseKey, defaultOrg string, appliedDefault bool) error {
+	csvPath := filepath.Join(exportDir, "organizations.csv")
+
+	if appliedDefault {
+		if defaultOrg == "" {
+			return nil
+		}
+		known, err := orgsByKey(ctx, lookup, []string{defaultOrg})
+		if err != nil {
+			return fmt.Errorf("looking up default organization in SonarQube Cloud: %w", err)
+		}
+		if _, ok := known[defaultOrg]; !ok {
+			return defaultOrgMissingError(defaultOrg, enterpriseKey)
+		}
+		return nil
+	}
+
+	rows, err := structure.LoadCSV(exportDir, "organizations.csv")
+	if err != nil {
+		return fmt.Errorf("loading organizations.csv: %w", err)
+	}
+	seen := make(map[string]bool)
+	ordered := make([]string, 0)
+	for _, row := range rows {
+		k, _ := row["sonarcloud_org_key"].(string)
+		k = strings.TrimSpace(k)
+		if k == "" || k == "SKIPPED" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		ordered = append(ordered, k)
+	}
+	if len(ordered) == 0 {
+		return nil
+	}
+	known, err := orgsByKey(ctx, lookup, ordered)
+	if err != nil {
+		return fmt.Errorf("looking up organizations in SonarQube Cloud: %w", err)
+	}
+	for _, k := range ordered {
+		if _, ok := known[k]; !ok {
+			return csvOrgMissingError(k, csvPath, enterpriseKey)
+		}
+	}
+	return nil
+}
+
+// orgsByKey returns a set of organization keys that the SQC search
+// endpoint confirmed exist and are visible to the caller. Chunks the
+// request at 50 keys per call to stay under SonarCloud's URL-length
+// limit on /api/organizations/search?organizations=...
+func orgsByKey(ctx context.Context, lookup orgLookup, keys []string) (map[string]bool, error) {
+	out := make(map[string]bool, len(keys))
+	const chunkSize = 50
+	for i := 0; i < len(keys); i += chunkSize {
+		end := i + chunkSize
+		if end > len(keys) {
+			end = len(keys)
+		}
+		batch := keys[i:end]
+		orgs, err := lookup.Search(ctx, batch...)
+		if err != nil {
+			return nil, err
+		}
+		for _, o := range orgs {
+			if o.Key != "" {
+				out[o.Key] = true
+			}
+		}
+	}
+	return out, nil
+}
+
+func defaultOrgMissingError(defaultOrg, enterpriseKey string) error {
+	return common.NewExitError(3, fmt.Errorf(
+		`Default organization %q does not exists in SonarQube Cloud, or is not part of Enterprise %q`,
+		defaultOrg, enterpriseKey))
+}
+
+func csvOrgMissingError(orgKey, csvPath, enterpriseKey string) error {
+	return common.NewExitError(3, fmt.Errorf(
+		`Organization %q specified in %q does not exists in SonarQube Cloud, or does not belong to Enterprise %q`,
+		orgKey, csvPath, enterpriseKey))
 }
 
 func readOrgCSVHeaders(path string) ([]string, error) {

--- a/go/internal/migrate/org_mapping_test.go
+++ b/go/internal/migrate/org_mapping_test.go
@@ -34,7 +34,7 @@ org-a,
 org-b,
 org-c,
 `)
-	err := applyOrgMapping(dir, "", discardLogger())
+	_, err := applyOrgMapping(dir, "", discardLogger())
 	if err == nil {
 		t.Fatal("expected an error when no mapping is defined and no default")
 	}
@@ -55,8 +55,12 @@ func TestApplyOrgMapping_AllEmptyWithDefaultFillsRows(t *testing.T) {
 org-a,,https://sqs-a.example.com
 org-b,,https://sqs-b.example.com
 `)
-	if err := applyOrgMapping(dir, "my-cloud-org", discardLogger()); err != nil {
+	applied, err := applyOrgMapping(dir, "my-cloud-org", discardLogger())
+	if err != nil {
 		t.Fatalf("expected success with default_organization, got %v", err)
+	}
+	if !applied {
+		t.Error("appliedDefault must be true when CSV was empty and default was applied")
 	}
 
 	// CSV must now carry the default for every row, original columns preserved.
@@ -93,8 +97,12 @@ org-b,
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	if err := applyOrgMapping(dir, "default-cloud-org", logger); err != nil {
+	applied, err := applyOrgMapping(dir, "default-cloud-org", logger)
+	if err != nil {
 		t.Fatalf("expected nil with mapped CSV + default, got %v", err)
+	}
+	if applied {
+		t.Error("appliedDefault must be false when CSV already has mappings")
 	}
 	// CSV must be unchanged.
 	got, _ := os.ReadFile(filepath.Join(dir, "organizations.csv"))
@@ -120,7 +128,7 @@ org-b,real-cloud-org
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	if err := applyOrgMapping(dir, "", logger); err != nil {
+	if _, err := applyOrgMapping(dir, "", logger); err != nil {
 		t.Errorf("expected nil for partial mapping, got %v", err)
 	}
 	if strings.Contains(buf.String(), "level=WARN") {
@@ -135,7 +143,7 @@ func TestApplyOrgMapping_OnlySkippedRowsPass(t *testing.T) {
 org-a,SKIPPED
 org-b,SKIPPED
 `)
-	if err := applyOrgMapping(dir, "", discardLogger()); err != nil {
+	if _, err := applyOrgMapping(dir, "", discardLogger()); err != nil {
 		t.Errorf("expected nil when all rows are SKIPPED, got %v", err)
 	}
 }
@@ -144,7 +152,7 @@ org-b,SKIPPED
 // without rows).
 func TestApplyOrgMapping_MissingFileReturnsExit2(t *testing.T) {
 	dir := t.TempDir()
-	if err := applyOrgMapping(dir, "any-default", discardLogger()); err == nil {
+	if _, err := applyOrgMapping(dir, "any-default", discardLogger()); err == nil {
 		t.Fatal("expected error when organizations.csv is missing")
 	}
 }


### PR DESCRIPTION
## Summary

A typo in `--default_organization` or in `organizations.csv` used to fail deep inside the first SQC API call that needed the org, producing a generic 404. `migrate` now validates every referenced organization up front and aborts with exit code 3 and the spec'd error message.

| Scenario | Exit | Message |
|---|---|---|
| `--default_organization X` missing in SQC | **3** | `Default organization "X" does not exists in SonarQube Cloud, or is not part of Enterprise "Y"` |
| `sonarcloud_org_key X` from `organizations.csv` missing in SQC | **3** | `Organization "X" specified in "<organizations.csv>" does not exists in SonarQube Cloud, or does not belong to Enterprise "Y"` |

### Implementation

- `applyOrgMapping` now returns `(appliedDefault, error)` so the validator knows which message variant to produce. When the default was applied to a previously-empty CSV, only the default key is checked; otherwise every distinct non-empty/non-SKIPPED `sonarcloud_org_key` is.
- `validateOrgsExist(ctx, lookup, exportDir, enterpriseKey, defaultOrg, appliedDefault)` lives in `internal/migrate/org_mapping.go`. Looks orgs up via `cc.Organizations.Search`, dedups keys, batches at 50 to stay under SonarCloud's URL-length limit.
- Small `orgLookup` interface lets unit tests stub the SDK without spinning up a real client.

## Test plan

- [x] `go test ./...` passes — 7 new tests in `org_existence_test.go`:
  - Default missing → exit 3 + verbatim message
  - Default exists → pass
  - CSV org missing → exit 3 + verbatim message (paths quoted)
  - All-existing → pass
  - SKIPPED and empty rows ignored
  - Duplicate keys collapsed to a single lookup call
  - Empty-default no-op
- [x] Existing `applyOrgMapping` tests updated for the new signature and assert the `appliedDefault` flag flip
- [x] `go build ./...` clean

Closes #283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
