### PR TITLE
Fix #295: align transfer with the unified config + source/target naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,23 +237,23 @@ Use `transfer` when you only need to move **one** project end-to-end in a single
 
 ```bash
 sonar-migration-tool transfer \
-  --sq-url   https://sonarqube.example.com \
-  --sq-token sqp_xxx \
-  --project-key my-project \
-  --sc-token squ_xxx \
-  --sc-org   my-sqc-org
+  --source-url   https://sonarqube.example.com \
+  --source-token sqp_xxx \
+  --project-key  my-project \
+  --target-token squ_xxx \
+  --default_organization my-sqc-org
 ```
 
-Or with a config file:
+Or with a config file (same shape as `extract` / `migrate`):
 
 ```bash
-sonar-migration-tool transfer -c transfer.json
+sonar-migration-tool transfer -c config.json --project-key my-project
 ```
 
 ```jsonc
 {
-  "sonarqube":  { "url": "https://...", "token": "sqp_xxx", "projectKey": "my-project" },
-  "sonarcloud": { "token": "squ_xxx",   "organization": "my-sqc-org" }
+  "source": { "url": "https://...", "token": "sqp_xxx" },
+  "target": { "token": "squ_xxx",  "default_organization": "my-sqc-org" }
 }
 ```
 

--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -23,7 +23,7 @@ The recommended shape ("unified config") carries one top-level block of defaults
 | `extract` | top-level + `source` |
 | `structure`, `mappings`, `predictive-report` | top-level only |
 | `migrate`, `reset` | top-level + `target` |
-| `transfer` | a dedicated shape (see below) |
+| `transfer` | top-level + `source` + `target` |
 
 Complete annotated example: [`examples/config.unified.example.json`](../examples/config.unified.example.json). Minimal example: [`examples/config.minimal.example.json`](../examples/config.minimal.example.json). JSON Schema for editor autocomplete: [`schemas/config.schema.json`](../schemas/config.schema.json).
 
@@ -147,26 +147,44 @@ Same flag set as `migrate`. Destructive — see the [README's Reset section](../
 
 ### `transfer`
 
-`transfer` takes a different config shape (one source + one project + one target):
+`transfer` reads the same unified shape as `extract` / `migrate` — both
+`source` and `target` blocks plus the shared top-level defaults. The
+project key is supplied on the CLI; everything else (credentials,
+mTLS, timeouts, concurrency, export directory) can live in the config
+file.
 
 ```jsonc
 {
-  "sonarqube":  { "url": "https://...", "token": "sqp_xxx", "projectKey": "my-project" },
-  "sonarcloud": { "token": "squ_xxx",   "organization": "my-sqc-org" }
+  "concurrency": 25,
+  "timeout": 60,
+  "export_directory": "./migration-files",
+  "source": { "url": "https://...", "token": "sqp_xxx",
+              "pem_file_path": "...", "key_file_path": "...", "cert_password": "..." },
+  "target": { "url": "https://sonarcloud.io/", "token": "squ_xxx",
+              "default_organization": "my-sqc-org",
+              "enterprise_key": "my-enterprise" }
 }
 ```
 
-| Flag | Description |
-|---|---|
-| `-c, --config <path>` | Path to JSON configuration file. |
-| `--sq-url <url>` | SonarQube Server URL. |
-| `--sq-token <token>` | SonarQube Server token. |
-| `--project-key <key>` | Project key to transfer (omit to transfer all projects in the source server). |
-| `--sc-token <token>` | SonarQube Cloud token. |
-| `--sc-org <key>` | SonarQube Cloud organization key. |
-| `--sc-enterprise-key <key>` | SonarQube Cloud enterprise key (defaults to `--sc-org`). |
-| `--export-dir <dir>` | Working directory (default `./migration-files/`). |
-| `--include-scan-history` | Extract + import full scan history. |
+| Flag | Config key | Description |
+|---|---|---|
+| `-c, --config <path>` | — | Path to JSON configuration file. |
+| `--source-url <url>` | `source.url` | SonarQube Server URL. |
+| `--source-token <token>` | `source.token` | SonarQube Server token. |
+| `--project-key <key>` | — | Project key to transfer (omit to transfer all projects). |
+| `--target-url <url>` | `target.url` | SonarQube Cloud URL. |
+| `--target-token <token>` | `target.token` | SonarQube Cloud token. |
+| `--default_organization <key>` | `target.default_organization` | SonarQube Cloud organization key. |
+| `--enterprise_key <key>` | `target.enterprise_key` | SonarQube Cloud enterprise key (defaults to `--default_organization`). |
+| `--export-dir <dir>` | `export_directory` | Working directory (default `./migration-files/`). |
+| `--concurrency <n>` | `concurrency` | Max concurrent HTTP requests. |
+| `--timeout <s>` | `timeout` | HTTP request timeout in seconds. |
+| `--pem_file_path <path>` | `source.pem_file_path` | Client mTLS PEM file. |
+| `--key_file_path <path>` | `source.key_file_path` | Client mTLS key file. |
+| `--cert_password <pw>` | `source.cert_password` | Client mTLS password. |
+| `--include-scan-history` | `include_scan_history` | Extract + import full scan history. |
+
+CLI flags always override the corresponding config-file value.
 
 ### `wizard` / `gui`
 
@@ -207,7 +225,7 @@ Three older shapes still parse so existing configs keep working. Prefer the unif
 }
 ```
 
-**Side-sectioned shape (used by `transfer`):**
+**Side-sectioned shape:**
 
 ```jsonc
 {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -219,47 +219,51 @@ All four pipelines implement the `Pipeline` interface; compile-time checks (`var
 ## Transfer Command (Single-Project Migration)
 <!-- updated: 2026-06-04_01:14:00.000 by Claude -->
 
-`go/cmd/transfer.go` provides a CloudVoyager-compatible single-command migration path. It
-chains the four manual phases automatically so users never touch a CSV file. Flag names
-are defined as package-level constants (e.g. `flagSQURL = "sq-url"`) to avoid duplicated
-string literals. Config resolution is handled by `resolveTransferConfig()` (loads file,
-applies flag overrides via `applyFlagString`/`applyFlagInt`/`applyFlagBool` helpers, applies
-defaults) and validation by `validateTransferConfig()`, keeping `runTransfer` focused on
-the four-phase orchestration.
+`go/cmd/transfer.go` provides a single-command migration path that chains the four
+manual phases automatically so users never touch a CSV file. Flag names are defined
+as package-level constants (e.g. `flagSourceURL = "source-url"`) to avoid duplicated
+string literals. Config resolution is handled by `resolveTransferConfig()` — it calls
+`loadTransferFileDefaults()` (which reuses `extract.LoadExtractConfigFile` and
+`migrate.LoadMigrateConfigFile` so transfer accepts the same unified config shape as
+the other actions, issue #295) and then applies CLI overrides via
+`applyFlagString`/`applyFlagInt`/`applyFlagBool` helpers. Validation lives in
+`validateTransferConfig()`, keeping `runTransfer` focused on four-phase orchestration.
 
 ```bash
 # Flags
 sonar-migration-tool transfer \
-  --sq-url https://sonarqube.example.com --sq-token sqp_xxx \
+  --source-url https://sonarqube.example.com --source-token sqp_xxx \
   --project-key my-project \
-  --sc-token squ_xxx --sc-org my-org
+  --target-token squ_xxx --default_organization my-org
 
 # Config file
-sonar-migration-tool transfer -c config.json
+sonar-migration-tool transfer -c config.json --project-key my-project
 ```
 
-**config.json** (CloudVoyager-compatible shape):
+**config.json** (same unified shape as `extract` / `migrate`):
 ```json
 {
-  "sonarqube": { "url": "...", "token": "...", "projectKey": "..." },
-  "sonarcloud": { "token": "...", "organization": "...", "enterpriseKey": "..." }
+  "source": { "url": "...", "token": "..." },
+  "target": { "url": "...", "token": "...",
+              "default_organization": "...", "enterprise_key": "..." }
 }
 ```
 
-`--project-key` is optional. When provided, the `/api/projects/search` call is filtered
-server-side via the `projects=` param, so only the target project and its data are
-extracted. When omitted, all projects on the server are migrated.
+`--project-key` is optional and lives on the CLI only. When provided, the
+`/api/projects/search` call is filtered server-side via the `projects=` param, so only
+the target project and its data are extracted. When omitted, all projects on the server
+are migrated.
 
 **Execution sequence:**
 1. `extract.RunExtract` — sets `ExtractConfig.ProjectKeys` when `--project-key` is given
-2. `structure.RunStructure(dir, scOrg)` — pre-populates `sonarcloud_org_key` in organizations.csv
+2. `structure.RunStructure(dir, defaultOrg)` — pre-populates `sonarcloud_org_key` in organizations.csv
 3. `structure.RunMappings(dir)` — generates gates/profiles/groups/templates CSVs
 4. `migrate.RunMigrate` — pushes everything to SonarQube Cloud
 5. `summary.GeneratePDFReport` — writes a PDF summary to the run directory
 
-`--sc-enterprise-key` is optional and defaults to `--sc-org`. Set it explicitly only when
-the SonarCloud enterprise key differs from the organization key (typically only needed for
-portfolio migration in large Enterprise deployments).
+`--enterprise_key` is optional and defaults to `--default_organization`. Set it explicitly
+only when the SonarCloud enterprise key differs from the organization key (typically only
+needed for portfolio migration in large Enterprise deployments).
 
 ## Version Detection
 <!-- updated: 2026-06-04_01:14:00.000 by Claude -->

--- a/docs/CLOUDVOYAGER-DELTA.md
+++ b/docs/CLOUDVOYAGER-DELTA.md
@@ -382,7 +382,7 @@ pattern.
 ### ~~FEAT-10: `--url` default silently targets production~~ **[FIXED]**
 <!-- updated: 2026-06-04_01:14:00.000 by Claude -->
 
-**Status**: FIXED — `--sc-url` flag was added to the transfer command. The default no longer silently targets production. Users can pass `--sc-url https://sc-staging.io` for staging.
+**Status**: FIXED — `--target-url` flag was added to the transfer command (renamed from `--sc-url` in #295). The default no longer silently targets production. Users can pass `--target-url https://sc-staging.io` for staging.
 
 ~~**File**: [go/internal/migrate/migrate.go:190](../go/internal/migrate/migrate.go#L190)~~
 
@@ -497,7 +497,7 @@ systematic wrong dates for projects with multiple issues of the same rule.~~
 | FEAT-07 | P2 | CLI | No `--only` selective migration flag |
 | FEAT-08 | P3 | CLI | No incremental transfer mode |
 | FEAT-09 | P2 | Issue Sync | `syncIssueMetadata` writes no per-project output file |
-| FEAT-10 | ~~P2~~ **FIXED** | CLI | ~~`--url` default silently targets production~~ Fixed: `--sc-url` flag added to transfer command |
+| FEAT-10 | ~~P2~~ **FIXED** | CLI | ~~`--url` default silently targets production~~ Fixed: `--target-url` flag added to transfer command (renamed from `--sc-url` in #295) |
 | BUG-12 | P1 | Extract | `getActiveProfileRules` missing from scan-history-only extract |
 | BUG-13 | P2 | Scan History | Analysis date is migration time, not extraction timestamp |
 | BUG-14 | P3 | Hotspot Sync | No inter-comment delay for rate-limit protection |
@@ -517,7 +517,7 @@ systematic wrong dates for projects with multiple issues of the same rule.~~
 7. **BUG-06** — Add source-link comments to both issue and hotspot sync
 8. **FEAT-09** — Add per-project output file to `syncIssueMetadata`
 9. **BUG-12** — Add `getActiveProfileRules` to scan-history extract task list
-10. ~~**FEAT-10**~~ — ~~Add URL default warning~~ **DONE** (`--sc-url` flag added to transfer command)
+10. ~~**FEAT-10**~~ — ~~Add URL default warning~~ **DONE** (`--target-url` flag added to transfer command (renamed from `--sc-url` in #295))
 11. **FEAT-05** — Add CE submission retry
 12. **BUG-13** — Use extraction timestamp for analysis date
 13. **FEAT-02** — Extract issue changelog data

--- a/docs/TRANSFER.md
+++ b/docs/TRANSFER.md
@@ -46,44 +46,42 @@ cd go && go run . transfer -c config.json
 sonar-migration-tool transfer -c config.json
 ```
 
-`config.json` shape — the required blocks are `sonarqube` and `sonarcloud`; the `settings` block is optional and has sensible defaults. See [CONFIG.md](CONFIG.md) for the full reference.
+`config.json` uses the **same unified shape** as `extract` and `migrate` — one top-level block of shared defaults plus `source` and `target` sub-objects. See [ADVANCED-CONFIG.md](ADVANCED-CONFIG.md) for the full reference.
 
 Minimal form:
 
 ```json
 {
-  "sonarqube": {
+  "source": {
     "url": "https://sonarqube.example.com",
-    "token": "sqp_xxx",
-    "projectKey": "my-project"
+    "token": "sqp_xxx"
   },
-  "sonarcloud": {
+  "target": {
     "token": "squ_xxx",
-    "organization": "my-org"
+    "default_organization": "my-org"
   }
 }
 ```
 
-Full form with optional `settings` block:
+Full form (pass `--project-key` on the CLI to scope to a single project):
 
 ```json
 {
-  "sonarqube": {
+  "concurrency": 25,
+  "timeout": 60,
+  "export_directory": "./migration-files",
+  "source": {
     "url": "https://sonarqube.example.com",
     "token": "sqp_xxx",
-    "projectKey": "my-project"
+    "pem_file_path": "/path/to/cert.pem",
+    "key_file_path": "/path/to/cert.key",
+    "cert_password": "optional"
   },
-  "sonarcloud": {
+  "target": {
     "url": "https://sonarcloud.io/",
     "token": "squ_xxx",
-    "organization": "my-org",
-    "enterpriseKey": "my-enterprise"
-  },
-  "settings": {
-    "exportDirectory": "./migration-files",
-    "concurrency": 25,
-    "includeScanHistory": false,
-    "debug": false
+    "default_organization": "my-org",
+    "enterprise_key": "my-enterprise"
   }
 }
 ```
@@ -93,19 +91,19 @@ Full form with optional `settings` block:
 ```bash
 # From source
 cd go && go run . transfer \
-  --sq-url https://sonarqube.example.com \
-  --sq-token sqp_xxx \
+  --source-url https://sonarqube.example.com \
+  --source-token sqp_xxx \
   --project-key my-project \
-  --sc-token squ_xxx \
-  --sc-org my-org
+  --target-token squ_xxx \
+  --default_organization my-org
 
 # Built binary
 sonar-migration-tool transfer \
-  --sq-url https://sonarqube.example.com \
-  --sq-token sqp_xxx \
+  --source-url https://sonarqube.example.com \
+  --source-token sqp_xxx \
   --project-key my-project \
-  --sc-token squ_xxx \
-  --sc-org my-org
+  --target-token squ_xxx \
+  --default_organization my-org
 ```
 
 Omit `--project-key` to transfer **every** project visible to the token (in which case the rest of the manual workflow applies — see [MIGRATE.md](MIGRATE.md) for the per-project `organizations.csv` mapping step).
@@ -114,17 +112,23 @@ Omit `--project-key` to transfer **every** project visible to the token (in whic
 
 ## Flags
 
-| Flag | Description |
-|------|-------------|
-| `-c, --config` | Path to a JSON configuration file (see [CONFIG.md](CONFIG.md)) |
-| `--sq-url` | SonarQube Server URL |
-| `--sq-token` | SonarQube Server token |
-| `--project-key` | Project key to transfer. Omit to transfer every project visible to the token. |
-| `--sc-token` | SonarQube Cloud token |
-| `--sc-org` | SonarQube Cloud organization key |
-| `--sc-enterprise-key` | SonarQube Cloud enterprise key (defaults to `--sc-org`) |
-| `--export-dir` | Working directory for intermediate files (default: `./migration-files/`) |
-| `--include-scan-history` | Extract and import full issue/hotspot scan history. Significantly slower and larger. |
+| Flag | Config key | Description |
+|------|------------|-------------|
+| `-c, --config` | — | Path to a JSON configuration file (see [ADVANCED-CONFIG.md](ADVANCED-CONFIG.md)) |
+| `--source-url` | `source.url` | SonarQube Server URL |
+| `--source-token` | `source.token` | SonarQube Server token |
+| `--project-key` | — | Project key to transfer. Omit to transfer every project visible to the token. |
+| `--target-url` | `target.url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
+| `--target-token` | `target.token` | SonarQube Cloud token |
+| `--default_organization` | `target.default_organization` | SonarQube Cloud organization key |
+| `--enterprise_key` | `target.enterprise_key` | SonarQube Cloud enterprise key (defaults to `--default_organization`) |
+| `--export-dir` | `export_directory` | Working directory for intermediate files (default: `./migration-files/`) |
+| `--concurrency` | `concurrency` | Max concurrent HTTP requests (default: `25`) |
+| `--timeout` | `timeout` | HTTP request timeout in seconds |
+| `--pem_file_path` | `source.pem_file_path` | Client mTLS PEM file for the source server |
+| `--key_file_path` | `source.key_file_path` | Client mTLS key file for the source server |
+| `--cert_password` | `source.cert_password` | Password for the source server mTLS client certificate |
+| `--include-scan-history` | `include_scan_history` | Extract and import full issue/hotspot scan history. Significantly slower and larger. |
 
 CLI flags override values from the config file when both are provided.
 
@@ -154,5 +158,5 @@ For more on post-migration steps, see the [After you migrate](MIGRATE.md#after-y
 ## Troubleshooting
 
 - **Token errors** — see the [Token permissions](MIGRATE.md#token-permissions) section in MIGRATE.md.
-- **Org not found** — confirm `--sc-org` matches an existing organization in your SonarQube Cloud enterprise.
+- **Org not found** — confirm `--default_organization` matches an existing organization in your SonarQube Cloud enterprise.
 - **Anything else** — [TROUBLESHOOTING.md](TROUBLESHOOTING.md) has the full list of common errors.

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -21,16 +20,20 @@ const (
 	scCloudName  = "SonarQube Cloud"
 
 	flagConfig             = "config"
-	flagSQURL              = "sq-url"
-	flagSQToken            = "sq-token"
+	flagSourceURL          = "source-url"
+	flagSourceToken        = "source-token"
 	flagProjectKey         = "project-key"
-	flagSCURL              = "sc-url"
-	flagSCToken            = "sc-token"
-	flagSCOrg              = "sc-org"
-	flagSCEnterpriseKey    = "sc-enterprise-key"
+	flagTargetURL          = "target-url"
+	flagTargetToken        = "target-token"
+	flagEnterpriseKey      = "enterprise_key"
+	flagDefaultOrg         = "default_organization"
 	flagExportDir          = "export-dir"
 	flagIncludeScanHistory = "include-scan-history"
 	flagConcurrency        = "concurrency"
+	flagTimeout            = "timeout"
+	flagPEMFilePath        = "pem_file_path"
+	flagKeyFilePath        = "key_file_path"
+	flagCertPassword       = "cert_password"
 	flagDebug              = "debug"
 )
 
@@ -44,91 +47,82 @@ the manual CSV-editing step. Credentials for both sides are required.
 
 Example (flags):
   sonar-migration-tool transfer \
-    --sq-url https://sonarqube.example.com \
-    --sq-token sqp_xxx \
+    --source-url https://sonarqube.example.com \
+    --source-token sqp_xxx \
     --project-key my-project \
-    --sc-token squ_xxx \
-    --sc-org my-org
+    --target-token squ_xxx \
+    --default_organization my-org
 
 Example (config file):
   sonar-migration-tool transfer -c config.json
 
-config.json format:
+config.json uses the common unified shape (same loader as extract /
+migrate), so every shared setting carries over — including
+concurrency, timeout, export_directory, pem_file_path, key_file_path,
+and cert_password:
   {
-    "sonarqube": { "url": "...", "token": "...", "projectKey": "..." },
-    "sonarcloud": { "url": "...", "token": "...", "organization": "...", "enterpriseKey": "..." }
+    "export_directory": "./migration-files",
+    "concurrency": 10,
+    "timeout": 60,
+    "source": {
+      "url": "https://sonarqube.example.com",
+      "token": "sqp_xxx",
+      "pem_file_path": "...", "key_file_path": "...", "cert_password": "..."
+    },
+    "target": {
+      "url": "https://sonarcloud.io/",
+      "token": "squ_xxx",
+      "default_organization": "my-org",
+      "enterprise_key": "my-org"
+    }
   }
 
-The sonarcloud.url defaults to https://sonarcloud.io/ when omitted.
+The target.url defaults to https://sonarcloud.io/ when omitted.
 
-The enterpriseKey is required for portfolio migration; for projects/gates/profiles
-it can be omitted and defaults to the organization key.`,
+The target.enterprise_key is required for portfolio migration; for
+projects/gates/profiles it can be omitted and defaults to the
+default_organization value.
+
+CLI flags always take precedence over values from the config file.`,
 	RunE: runTransfer,
 }
 
 func init() {
 	f := transferCmd.Flags()
-	f.StringP(flagConfig, "c", "", "Path to transfer config file")
-	f.String(flagSQURL, "", sqServerName+" URL")
-	f.String(flagSQToken, "", sqServerName+" token")
+	f.StringP(flagConfig, "c", "", "Path to JSON configuration file (common shape with source / target sections)")
+	f.String(flagSourceURL, "", sqServerName+" URL (maps to source.url)")
+	f.String(flagSourceToken, "", sqServerName+" token (maps to source.token)")
 	f.String(flagProjectKey, "", "Project key to transfer (omit to transfer all projects)")
-	f.String(flagSCURL, "", scCloudName+" URL (default: https://sonarcloud.io/)")
-	f.String(flagSCToken, "", scCloudName+" token")
-	f.String(flagSCOrg, "", scCloudName+" organization key")
-	f.String(flagSCEnterpriseKey, "", scCloudName+" enterprise key (defaults to --sc-org)")
-	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files")
-	f.Bool(flagIncludeScanHistory, false, "Extract and import full issue/hotspot scan history")
-	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25)")
+	f.String(flagTargetURL, "", scCloudName+" URL (maps to target.url, default: https://sonarcloud.io/)")
+	f.String(flagTargetToken, "", scCloudName+" token (maps to target.token)")
+	f.String(flagDefaultOrg, "", scCloudName+" organization key (maps to target.default_organization)")
+	f.String(flagEnterpriseKey, "", scCloudName+" enterprise key (maps to target.enterprise_key, defaults to --"+flagDefaultOrg+")")
+	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
+	f.Bool(flagIncludeScanHistory, false, "Extract and import full issue/hotspot scan history (maps to include_scan_history)")
+	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
+	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout)")
+	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
+	f.String(flagKeyFilePath, "", "Path to client mTLS key file for the source server (maps to source.key_file_path)")
+	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
 }
 
 // transferConfig holds the resolved configuration after merging file and flag values.
 type transferConfig struct {
-	sqURL              string
-	sqToken            string
-	projectKey         string
-	scURL              string
-	scToken            string
-	scOrg              string
-	scEnterpriseKey    string
-	exportDir          string
-	concurrency        int
-	includeScanHistory bool
-	debug              bool
-}
-
-// transferFileConfig is the transfer-specific config file shape (CloudVoyager-compatible).
-// This is intentionally separate from the existing extract/migrate config shapes to avoid
-// field-name conflicts with the existing side-sectioned parser.
-type transferFileConfig struct {
-	SonarQube struct {
-		URL        string `json:"url"`
-		Token      string `json:"token"`
-		ProjectKey string `json:"projectKey"`
-	} `json:"sonarqube"`
-	SonarCloud struct {
-		URL           string `json:"url"`
-		Token         string `json:"token"`
-		Organization  string `json:"organization"`
-		EnterpriseKey string `json:"enterpriseKey"`
-	} `json:"sonarcloud"`
-	Settings struct {
-		ExportDirectory    string `json:"exportDirectory"`
-		Concurrency        int    `json:"concurrency"`
-		IncludeScanHistory bool   `json:"includeScanHistory"`
-		Debug              bool   `json:"debug"`
-	} `json:"settings"`
-}
-
-func loadTransferConfigFile(path string) (transferFileConfig, error) {
-	var cfg transferFileConfig
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return cfg, fmt.Errorf("reading transfer config %q: %w", path, err)
-	}
-	if err := json.Unmarshal(data, &cfg); err != nil {
-		return cfg, fmt.Errorf("parsing transfer config %q: %w", path, err)
-	}
-	return cfg, nil
+	sourceURL           string
+	sourceToken         string
+	projectKey          string
+	targetURL           string
+	targetToken         string
+	defaultOrganization string
+	enterpriseKey       string
+	exportDir           string
+	concurrency         int
+	timeout             int
+	pemFilePath         string
+	keyFilePath         string
+	certPassword        string
+	includeScanHistory  bool
+	debug               bool
 }
 
 func applyFlagString(cmd *cobra.Command, name string, target *string) {
@@ -149,60 +143,95 @@ func applyFlagBool(cmd *cobra.Command, name string, target *bool) {
 	}
 }
 
+// loadTransferFileDefaults reads the shared --config file via the same
+// loaders extract / migrate use, so transfer accepts every supported
+// shape (flat, command-sectioned, side-sectioned, and the unified
+// source/target shape — #266). The transfer-specific dedicated shape
+// from earlier releases has been retired (#295).
+func loadTransferFileDefaults(path string) (transferConfig, error) {
+	var cfg transferConfig
+	extractCfg, err := extract.LoadExtractConfigFile(path)
+	if err != nil {
+		return cfg, err
+	}
+	migrateCfg, err := migrate.LoadMigrateConfigFile(path)
+	if err != nil {
+		return cfg, err
+	}
+
+	cfg.sourceURL = extractCfg.URL
+	cfg.sourceToken = extractCfg.Token
+	cfg.targetURL = migrateCfg.URL
+	cfg.targetToken = migrateCfg.Token
+	cfg.enterpriseKey = migrateCfg.EnterpriseKey
+	cfg.defaultOrganization = migrateCfg.DefaultOrganization
+
+	cfg.exportDir = extractCfg.ExportDirectory
+	if cfg.exportDir == "" {
+		cfg.exportDir = migrateCfg.ExportDirectory
+	}
+
+	switch {
+	case extractCfg.Concurrency != 0:
+		cfg.concurrency = extractCfg.Concurrency
+	case migrateCfg.Concurrency != 0:
+		cfg.concurrency = migrateCfg.Concurrency
+	}
+
+	cfg.timeout = extractCfg.Timeout
+	cfg.pemFilePath = extractCfg.PEMFilePath
+	cfg.keyFilePath = extractCfg.KeyFilePath
+	cfg.certPassword = extractCfg.CertPassword
+
+	cfg.includeScanHistory = extractCfg.IncludeScanHistory || migrateCfg.IncludeScanHistory
+	cfg.debug = migrateCfg.Debug
+	return cfg, nil
+}
+
 func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
-	var fileCfg transferFileConfig
+	var cfg transferConfig
 
 	configFile, _ := cmd.Flags().GetString(flagConfig)
 	if configFile != "" {
-		loaded, err := loadTransferConfigFile(configFile)
+		loaded, err := loadTransferFileDefaults(configFile)
 		if err != nil {
 			return transferConfig{}, err
 		}
-		fileCfg = loaded
+		cfg = loaded
 	}
 
-	cfg := transferConfig{
-		sqURL:              fileCfg.SonarQube.URL,
-		sqToken:            fileCfg.SonarQube.Token,
-		projectKey:         fileCfg.SonarQube.ProjectKey,
-		scURL:              fileCfg.SonarCloud.URL,
-		scToken:            fileCfg.SonarCloud.Token,
-		scOrg:              fileCfg.SonarCloud.Organization,
-		scEnterpriseKey:    fileCfg.SonarCloud.EnterpriseKey,
-		exportDir:          fileCfg.Settings.ExportDirectory,
-		concurrency:        fileCfg.Settings.Concurrency,
-		includeScanHistory: fileCfg.Settings.IncludeScanHistory,
-		debug:              fileCfg.Settings.Debug,
-	}
-
-	applyFlagString(cmd, flagSQURL, &cfg.sqURL)
-	applyFlagString(cmd, flagSQToken, &cfg.sqToken)
+	applyFlagString(cmd, flagSourceURL, &cfg.sourceURL)
+	applyFlagString(cmd, flagSourceToken, &cfg.sourceToken)
 	applyFlagString(cmd, flagProjectKey, &cfg.projectKey)
-	applyFlagString(cmd, flagSCURL, &cfg.scURL)
-	applyFlagString(cmd, flagSCToken, &cfg.scToken)
-	applyFlagString(cmd, flagSCOrg, &cfg.scOrg)
-	applyFlagString(cmd, flagSCEnterpriseKey, &cfg.scEnterpriseKey)
+	applyFlagString(cmd, flagTargetURL, &cfg.targetURL)
+	applyFlagString(cmd, flagTargetToken, &cfg.targetToken)
+	applyFlagString(cmd, flagDefaultOrg, &cfg.defaultOrganization)
+	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
 	applyFlagInt(cmd, flagConcurrency, &cfg.concurrency)
+	applyFlagInt(cmd, flagTimeout, &cfg.timeout)
+	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
+	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
+	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)
 	applyFlagBool(cmd, flagIncludeScanHistory, &cfg.includeScanHistory)
 	applyFlagBool(cmd, flagDebug, &cfg.debug)
 
 	if cfg.exportDir == "" {
 		cfg.exportDir = "./migration-files/"
 	}
-	if cfg.scEnterpriseKey == "" {
-		cfg.scEnterpriseKey = cfg.scOrg
+	if cfg.enterpriseKey == "" {
+		cfg.enterpriseKey = cfg.defaultOrganization
 	}
 
 	return cfg, nil
 }
 
 func validateTransferConfig(cfg transferConfig) error {
-	if cfg.sqURL == "" || cfg.sqToken == "" {
-		return fmt.Errorf("%s URL and token are required (--%s / --%s or config file)", sqServerName, flagSQURL, flagSQToken)
+	if cfg.sourceURL == "" || cfg.sourceToken == "" {
+		return fmt.Errorf("%s URL and token are required (--%s / --%s or source.url / source.token in config file)", sqServerName, flagSourceURL, flagSourceToken)
 	}
-	if cfg.scToken == "" || cfg.scOrg == "" {
-		return fmt.Errorf("%s token and organization key are required (--%s / --%s or config file)", scCloudName, flagSCToken, flagSCOrg)
+	if cfg.targetToken == "" || cfg.defaultOrganization == "" {
+		return fmt.Errorf("%s token and organization key are required (--%s / --%s or target.token / target.default_organization in config file)", scCloudName, flagTargetToken, flagDefaultOrg)
 	}
 	return nil
 }
@@ -267,12 +296,17 @@ func runTransferExtract(ctx context.Context, cfg transferConfig) ([]string, erro
 		projectKeys = []string{cfg.projectKey}
 	}
 	skipped, err := extract.RunExtract(ctx, extract.ExtractConfig{
-		URL:                cfg.sqURL,
-		Token:              cfg.sqToken,
+		URL:                cfg.sourceURL,
+		Token:              cfg.sourceToken,
 		ExportDirectory:    cfg.exportDir,
 		ProjectKeys:        projectKeys,
 		Concurrency:        cfg.concurrency,
+		Timeout:            cfg.timeout,
+		PEMFilePath:        cfg.pemFilePath,
+		KeyFilePath:        cfg.keyFilePath,
+		CertPassword:       cfg.certPassword,
 		IncludeScanHistory: cfg.includeScanHistory,
+		Debug:              cfg.debug,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("extract failed: %w", err)
@@ -282,7 +316,7 @@ func runTransferExtract(ctx context.Context, cfg transferConfig) ([]string, erro
 
 func runTransferStructure(cfg transferConfig) error {
 	printPhase(2, 4, "Building organization structure...")
-	if err := structure.RunStructure(cfg.exportDir, cfg.scOrg); err != nil {
+	if err := structure.RunStructure(cfg.exportDir, cfg.defaultOrganization); err != nil {
 		return fmt.Errorf("structure failed: %w", err)
 	}
 	return nil
@@ -298,10 +332,14 @@ func runTransferMappings(cfg transferConfig) error {
 
 func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error) {
 	printPhase(4, 4, "Migrating to "+scCloudName+"...")
+	// DefaultOrganization is intentionally left unset: structure has
+	// already pre-populated sonarcloud_org_key for every row using
+	// cfg.defaultOrganization, so passing it again would trigger the
+	// "mapping defined, default ignored" WARN in applyOrgMapping.
 	runID, err := migrate.RunMigrate(ctx, migrate.MigrateConfig{
-		URL:                cfg.scURL,
-		Token:              cfg.scToken,
-		EnterpriseKey:      cfg.scEnterpriseKey,
+		URL:                cfg.targetURL,
+		Token:              cfg.targetToken,
+		EnterpriseKey:      cfg.enterpriseKey,
 		ExportDirectory:    cfg.exportDir,
 		Concurrency:        cfg.concurrency,
 		IncludeScanHistory: cfg.includeScanHistory,

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -1,0 +1,230 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newTransferTestCmd mirrors transferCmd's flag set so resolveTransferConfig
+// can be exercised in isolation without invoking RunE.
+func newTransferTestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "transfer"}
+	f := cmd.Flags()
+	f.StringP(flagConfig, "c", "", "")
+	f.String(flagSourceURL, "", "")
+	f.String(flagSourceToken, "", "")
+	f.String(flagProjectKey, "", "")
+	f.String(flagTargetURL, "", "")
+	f.String(flagTargetToken, "", "")
+	f.String(flagDefaultOrg, "", "")
+	f.String(flagEnterpriseKey, "", "")
+	f.String(flagExportDir, "./migration-files/", "")
+	f.Bool(flagIncludeScanHistory, false, "")
+	f.Int(flagConcurrency, 0, "")
+	f.Int(flagTimeout, 0, "")
+	f.String(flagPEMFilePath, "", "")
+	f.String(flagKeyFilePath, "", "")
+	f.String(flagCertPassword, "", "")
+	f.Bool(flagDebug, false, "")
+	return cmd
+}
+
+func writeTransferConfig(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cfg.json")
+	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// Issue #295: transfer reads the common unified source/target config
+// shape just like extract and migrate do — same loader, same field
+// names. No transfer-specific keys.
+func TestResolveTransferConfig_UnifiedConfigShape(t *testing.T) {
+	path := writeTransferConfig(t, `{
+		"concurrency": 7,
+		"timeout": 42,
+		"export_directory": "/tmp/from-cfg",
+		"source": {
+			"url": "https://sq.example.com",
+			"token": "sq-token",
+			"pem_file_path": "/cert/pem",
+			"key_file_path": "/cert/key",
+			"cert_password": "p4ss"
+		},
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "sc-token",
+			"enterprise_key": "ent-key",
+			"default_organization": "my-org"
+		}
+	}`)
+
+	cmd := newTransferTestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveTransferConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveTransferConfig: %v", err)
+	}
+
+	want := transferConfig{
+		sourceURL:           "https://sq.example.com",
+		sourceToken:         "sq-token",
+		targetURL:           "https://sonarcloud.io/",
+		targetToken:         "sc-token",
+		defaultOrganization: "my-org",
+		enterpriseKey:       "ent-key",
+		exportDir:           "/tmp/from-cfg",
+		concurrency:         7,
+		timeout:             42,
+		pemFilePath:         "/cert/pem",
+		keyFilePath:         "/cert/key",
+		certPassword:        "p4ss",
+	}
+	if cfg != want {
+		t.Errorf("got %+v\nwant %+v", cfg, want)
+	}
+}
+
+// Issue #295: CLI flags must take precedence over config-file values
+// for every parameter, matching the contract documented for the other
+// actions.
+func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
+	path := writeTransferConfig(t, `{
+		"concurrency": 7,
+		"timeout": 42,
+		"export_directory": "/tmp/from-cfg",
+		"source": {
+			"url": "https://from-cfg",
+			"token": "cfg-source",
+			"pem_file_path": "/cfg/pem",
+			"key_file_path": "/cfg/key",
+			"cert_password": "cfg-pass"
+		},
+		"target": {
+			"url": "https://from-cfg",
+			"token": "cfg-target",
+			"enterprise_key": "cfg-ent",
+			"default_organization": "cfg-org"
+		}
+	}`)
+
+	cmd := newTransferTestCmd()
+	args := []string{
+		"-c", path,
+		"--source-url", "https://cli-source",
+		"--source-token", "cli-source-tok",
+		"--target-url", "https://cli-target",
+		"--target-token", "cli-target-tok",
+		"--default_organization", "cli-org",
+		"--enterprise_key", "cli-ent",
+		"--export-dir", "/tmp/cli",
+		"--concurrency", "11",
+		"--timeout", "99",
+		"--pem_file_path", "/cli/pem",
+		"--key_file_path", "/cli/key",
+		"--cert_password", "cli-pass",
+	}
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := resolveTransferConfig(cmd)
+	if err != nil {
+		t.Fatalf("resolveTransferConfig: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  any
+		want any
+	}{
+		{"sourceURL", cfg.sourceURL, "https://cli-source"},
+		{"sourceToken", cfg.sourceToken, "cli-source-tok"},
+		{"targetURL", cfg.targetURL, "https://cli-target"},
+		{"targetToken", cfg.targetToken, "cli-target-tok"},
+		{"defaultOrganization", cfg.defaultOrganization, "cli-org"},
+		{"enterpriseKey", cfg.enterpriseKey, "cli-ent"},
+		{"exportDir", cfg.exportDir, "/tmp/cli"},
+		{"concurrency", cfg.concurrency, 11},
+		{"timeout", cfg.timeout, 99},
+		{"pemFilePath", cfg.pemFilePath, "/cli/pem"},
+		{"keyFilePath", cfg.keyFilePath, "/cli/key"},
+		{"certPassword", cfg.certPassword, "cli-pass"},
+	}
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s: got %v, want %v", c.name, c.got, c.want)
+		}
+	}
+}
+
+// Issue #295: when --enterprise_key is absent, it falls back to
+// --default_organization so portfolio-less migrations stay one-flag.
+func TestResolveTransferConfig_EnterpriseKeyDefaultsToOrg(t *testing.T) {
+	cmd := newTransferTestCmd()
+	if err := cmd.ParseFlags([]string{
+		"--source-url", "https://sq",
+		"--source-token", "tok",
+		"--target-token", "ct",
+		"--default_organization", "my-org",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := resolveTransferConfig(cmd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.enterpriseKey != "my-org" {
+		t.Errorf("enterpriseKey: got %q, want %q", cfg.enterpriseKey, "my-org")
+	}
+}
+
+// Validation must error if either side is missing credentials, with a
+// message that names the new --source-* / --target-* flags so users
+// aren't pointed at the retired --sq-* / --sc-* names.
+func TestValidateTransferConfig_MissingCredentials(t *testing.T) {
+	cases := []struct {
+		name   string
+		cfg    transferConfig
+		errSub string
+	}{
+		{
+			name:   "missing source",
+			cfg:    transferConfig{targetToken: "t", defaultOrganization: "o"},
+			errSub: "--" + flagSourceURL,
+		},
+		{
+			name:   "missing target",
+			cfg:    transferConfig{sourceURL: "u", sourceToken: "t"},
+			errSub: "--" + flagTargetToken,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateTransferConfig(c.cfg)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !contains(err.Error(), c.errSub) {
+				t.Errorf("error %q does not mention %q", err.Error(), c.errSub)
+			}
+		})
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes #295. `transfer` was the odd one out — its CLI flags (`--sq-url` / `--sc-token` / `--sc-org` …) and its bespoke `{"sonarqube": ..., "sonarcloud": ...}` config shape both baked in the SQS→SQC direction, which the upcoming SQC→SQC migration path can't reuse.

This PR realigns `transfer` with the rest of the toolchain:

### CLI flag renames

| Old | New | Config key |
|---|---|---|
| `--sq-url` | `--source-url` | `source.url` |
| `--sq-token` | `--source-token` | `source.token` |
| `--sc-url` | `--target-url` | `target.url` |
| `--sc-token` | `--target-token` | `target.token` |
| `--sc-enterprise-key` | `--enterprise_key` | `target.enterprise_key` |
| `--sc-org` | `--default_organization` | `target.default_organization` |

### Config file

`transfer` now reads the **same** unified config file as `extract` / `migrate` / `reset`. All shared knobs are honored — `concurrency`, `timeout`, `export_directory`, mTLS (`pem_file_path` / `key_file_path` / `cert_password`) — either via the JSON file or via CLI flags. CLI flags retain precedence, matching every other command.

### Docs touched

- `README.md` — transfer section updated to show the new flag names + unified config
- `docs/TRANSFER.md` — full rewrite matching the new shape
- `docs/ADVANCED-CONFIG.md` — transfer CLI / config reference updated to the unified shape
- `docs/ARCHITECTURE.md` — transfer command surface updated
- `docs/CLOUDVOYAGER-DELTA.md` — sample commands brought in line

## Test plan

- [x] `cd go && go test ./cmd/...` — new `transfer_test.go` covers config resolution, CLI override precedence, and the enterprise-key-defaults-to-org behaviour. All green.
- [ ] Run `transfer` against a live SQS source with `--config` only — confirm both sides authenticate, the project migrates end-to-end, and the export directory and concurrency knobs from the config file are picked up.
- [ ] Run `transfer` with only CLI flags (no config) — confirm the new flag names work and the resulting migration is identical.

Generated with [Claude Code](https://claude.com/claude-code)
