### PR TITLE
docs: align README + transfer example with the unified transfer flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,16 @@ The tool ships with several commands. Pick the workflow that matches your situat
 
 Use `transfer`. It runs the whole migration in a single command — extracting from SonarQube Server, mapping the configuration, importing source code and issues, and pushing everything to SonarQube Cloud — then writes a PDF summary you can hand to your team.
 
+`transfer` shares the same `--config` file and the same direction-neutral CLI flags as `extract` / `migrate` / `reset` — `--source-*` for the SonarQube Server side, `--target-*` for the SonarQube Cloud side. Anything you don't pass on the CLI is read from the config file; CLI flags always win.
+
 ```bash
 ./sonar-migration-tool transfer \
-  --sq-url https://sonarqube.example.com \
-  --sq-token sqp_xxx \
+  --source-url https://sonarqube.example.com \
+  --source-token sqp_xxx \
   --project-key my-project \
-  --sc-token squ_xxx \
-  --sc-org my-org \
-  --include-scan-history
+  --target-token squ_xxx \
+  --default_organization my-org \
+  --include_scan_history
 ```
 
 Or use a **config file** to keep tokens out of your shell history:
@@ -98,10 +100,12 @@ Or use a **config file** to keep tokens out of your shell history:
 ```bash
 cp examples/config-transfer.example.json my-config.json
 # Edit my-config.json with your SonarQube Server and SonarQube Cloud credentials
-./sonar-migration-tool transfer -c my-config.json
+./sonar-migration-tool transfer -c my-config.json --project-key my-project
 ```
 
-Add `--sc-url` to target a different SonarQube Cloud instance (e.g. `--sc-url https://sc-staging.io` for staging).
+The config file uses the same unified shape as every other command — one top-level block of shared defaults plus `source` and `target` sub-objects. `concurrency`, `timeout`, `export_directory`, mTLS (`pem_file_path` / `key_file_path` / `cert_password`), and `--default_organization` / `--enterprise_key` are all honored either via the JSON file or as CLI overrides.
+
+Add `--target-url` to target a different SonarQube Cloud instance (e.g. `--target-url https://sc-staging.io` for staging).
 
 Full reference, more examples, and the config-file format:
 👉 **[Using `transfer` — Transfer One Project](docs/TRANSFER.md)**

--- a/examples/config-transfer.example.json
+++ b/examples/config-transfer.example.json
@@ -1,19 +1,19 @@
 {
-  "sonarqube": {
+  "concurrency": 10,
+  "timeout": 60,
+  "export_directory": "./migration-files",
+  "source": {
     "url": "https://sonarqube.example.com",
     "token": "sqp_YOUR_SONARQUBE_SERVER_TOKEN",
-    "projectKey": "my-project-key"
+    "pem_file_path": null,
+    "key_file_path": null,
+    "cert_password": null
   },
-  "sonarcloud": {
+  "target": {
     "url": "https://sonarcloud.io/",
     "token": "YOUR_SONARCLOUD_TOKEN",
-    "organization": "my-org",
-    "enterpriseKey": "my-enterprise"
-  },
-  "settings": {
-    "exportDirectory": "./migration-files",
-    "concurrency": 10,
-    "includeScanHistory": true,
-    "debug": false
+    "default_organization": "my-org",
+    "enterprise_key": "my-enterprise",
+    "include_scan_history": true
   }
 }


### PR DESCRIPTION
## Summary

Follow-up cleanup to PR #296 (issue #295). The transfer command was switched to the direction-neutral `--source-*` / `--target-*` flags and to the unified `source` / `target` config shape, but two artefacts still showed the old SQS-locked names:

- **`README.md`** — the "Migrating one project" section still pasted `--sq-url` / `--sq-token` / `--sc-token` / `--sc-org` / `--sc-url`. Updated to use the new flag names plus a short note explaining that `transfer` now shares the unified config file and that every shared knob (`concurrency`, `timeout`, `export_directory`, mTLS, `default_organization`, `enterprise_key`) can come from the config or the CLI.
- **`examples/config-transfer.example.json`** — still used the legacy `{"sonarqube": ..., "sonarcloud": ..., "settings": ...}` shape. Rewritten to mirror `config.unified.example.json`: top-level `concurrency` / `timeout` / `export_directory`, `source` and `target` sub-blocks, mTLS fields, `default_organization` and `enterprise_key` under `target`.

`docs/TRANSFER.md` and `docs/ADVANCED-CONFIG.md` were already up to date — no changes there.

## Test plan

- [x] `grep` for `--sq-` / `--sc-` in `*.md` returns no real callouts (only historical "renamed from `--sc-url` in #295" notes remain).
- [x] `cd go && go test ./cmd/... -run Transfer` — green.
- [ ] Copy the new `config-transfer.example.json` to a working copy, plug in real tokens, and run `transfer -c …` against a live SQS to confirm the example actually parses.

Generated with [Claude Code](https://claude.com/claude-code)
