### PR TITLE
Fix #303: make project data migration optional

### DIFF
--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -39,10 +39,11 @@ All optional.
 | `timeout` | `60` | Default HTTP request timeout in seconds. |
 | `export_directory` | `./migration-files` | Root directory for extract / migrate output. |
 | `skip-issue-sync` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the final per-issue and per-hotspot metadata sync that runs after scan history is replayed. Defaults to `false` so the sync happens. Accepted aliases are case-insensitive. Issue #299. |
+| `skip-project-data-migration` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the entire project-data migration: the scan-history import AND the trailing issue + hotspot sync. Useful when customers cut over to SonarQube Cloud by re-scanning rather than importing historical state. Implies `skip-issue-sync` — there's nothing to sync against. Same FlexibleBool aliases. Issue #303. |
 
 `concurrency` and `timeout` can also be set inside `source` / `target` — those values override the top-level default for that command only.
 
-The CLI flag `--skip-issue-sync` on `migrate` / `transfer` is the one-way equivalent of the config field — passing the flag forces the trailing sync off, regardless of the config-file value.
+The CLI flags `--skip-issue-sync` and `--skip-project-data-migration` on `migrate` / `transfer` are the one-way equivalents of the config fields — passing a flag forces the matching opt-out on regardless of the config-file value.
 
 ---
 
@@ -140,6 +141,7 @@ sonar-migration-tool migrate [token] [enterprise_key] [flags]
 | `--skip_profiles` | Skip quality profile migration / provisioning. |
 | `--include_scan_history` | Import scan history into SQC projects. |
 | `--skip-issue-sync` | Skip the final per-issue / per-hotspot metadata sync (#299). One-way: setting this on the CLI forces the sync off, overriding the `skip-issue-sync` config field. |
+| `--skip-project-data-migration` | Skip the entire project-data migration: `importScanHistory` plus the trailing sync pair. Implies `--skip-issue-sync`. One-way override of the `skip-project-data-migration` config field. Issue #303. |
 | `--exclude_branches <pattern>` | Glob pattern for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
 | `--default_organization <key>` | SonarCloud org applied to every project when `organizations.csv` has no mapping defined. |
 | `--concurrency <n>` | Max concurrent requests. |
@@ -191,6 +193,7 @@ file.
 | `--cert_password <pw>` | `source.cert_password` | Client mTLS password. |
 | `--include-scan-history` | `include_scan_history` | Extract + import full scan history. |
 | `--skip-issue-sync` | top-level `skip-issue-sync` | Skip the final per-issue / per-hotspot metadata sync (#299). |
+| `--skip-project-data-migration` | top-level `skip-project-data-migration` | Skip the entire project-data migration (importScanHistory + trailing syncs). #303. |
 | `--exclude-branches <pattern>` | `target.exclude_branches` | Glob pattern for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
 
 CLI flags always override the corresponding config-file value.

--- a/examples/config-migrate.example.json
+++ b/examples/config-migrate.example.json
@@ -4,5 +4,6 @@
   "url": "https://sonarcloud.io/",
   "export_directory": "./files",
   "concurrency": 10,
-  "skip-issue-sync": false
+  "skip-issue-sync": false,
+  "skip-project-data-migration": false
 }

--- a/examples/config-transfer.example.json
+++ b/examples/config-transfer.example.json
@@ -3,6 +3,7 @@
   "timeout": 60,
   "export_directory": "./migration-files",
   "skip-issue-sync": false,
+  "skip-project-data-migration": false,
   "project_key": "my-project-key",
   "source": {
     "url": "https://sonarqube.example.com",

--- a/examples/config.example.json
+++ b/examples/config.example.json
@@ -25,6 +25,7 @@
     "concurrency": 10,
     "run_id": null,
     "target_task": null,
-    "skip-issue-sync": false
+    "skip-issue-sync": false,
+    "skip-project-data-migration": false
   }
 }

--- a/examples/config.unified.example.json
+++ b/examples/config.unified.example.json
@@ -3,6 +3,7 @@
   "timeout": 60,
   "export_directory": "./migration-files",
   "skip-issue-sync": false,
+  "skip-project-data-migration": false,
   "source": {
     "url": "https://sonarqube.example.com",
     "token": "squ_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -53,6 +53,7 @@ func init() {
 	f.Bool("skip_profiles", false, "Skip quality profile migration/provisioning in SonarQube Cloud")
 	f.Bool("include_scan_history", false, "Import scan history (issues, metrics) into SonarQube Cloud projects")
 	f.Bool("skip-issue-sync", false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip-issue-sync config-file field — defaults to false (sync happens); pass the flag to skip.")
+	f.Bool("skip-project-data-migration", false, "Skip the entire project-data migration: importScanHistory and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.String("default_organization", "", "SonarQube Cloud organization to migrate every project into when organizations.csv has no mapping defined. Ignored if any mapping is present.")
 	f.StringSlice("exclude_branches", nil, "Glob patterns for non-main branches to skip during scan history import (e.g. feature/*,bugfix/*)")
 }
@@ -101,6 +102,15 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 		v, _ := cmd.Flags().GetBool("skip-issue-sync")
 		if v {
 			cfg.SkipIssueSync = true
+		}
+	}
+	// --skip-project-data-migration is the wider opt-out: it covers
+	// importScanHistory AND the trailing sync pair. Same one-way
+	// override semantics. #303.
+	if cmd.Flags().Changed("skip-project-data-migration") {
+		v, _ := cmd.Flags().GetBool("skip-project-data-migration")
+		if v {
+			cfg.SkipProjectDataMigration = true
 		}
 	}
 	if cmd.Flags().Changed("debug") {

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -33,9 +33,10 @@ const (
 	flagEnterpriseKey      = "enterprise_key"
 	flagDefaultOrg         = "default_organization"
 	flagExportDir          = "export-dir"
-	flagIncludeScanHistory = "include-scan-history"
-	flagSkipIssueSync      = "skip-issue-sync"
-	flagConcurrency        = "concurrency"
+	flagIncludeScanHistory       = "include-scan-history"
+	flagSkipIssueSync            = "skip-issue-sync"
+	flagSkipProjectDataMigration = "skip-project-data-migration"
+	flagConcurrency              = "concurrency"
 	flagTimeout            = "timeout"
 	flagPEMFilePath        = "pem_file_path"
 	flagKeyFilePath        = "key_file_path"
@@ -155,6 +156,7 @@ func init() {
 	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
 	f.Bool(flagIncludeScanHistory, false, "Accepted for compatibility; scan history (issues + hotspots) is always extracted and imported for transfer (maps to include_scan_history)")
 	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip-issue-sync config-file field — defaults to false (sync happens); pass the flag to skip.")
+	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importScanHistory and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
 	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout)")
 	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
@@ -179,7 +181,8 @@ type transferConfig struct {
 	keyFilePath         string
 	certPassword        string
 	includeScanHistory  bool
-	skipIssueSync       bool
+	skipIssueSync            bool
+	skipProjectDataMigration bool
 	debug               bool
 	excludeBranches     []string
 }
@@ -267,6 +270,7 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 
 	cfg.includeScanHistory = extractCfg.IncludeScanHistory || migrateCfg.IncludeScanHistory
 	cfg.skipIssueSync = migrateCfg.SkipIssueSync
+	cfg.skipProjectDataMigration = migrateCfg.SkipProjectDataMigration
 	cfg.debug = migrateCfg.Debug
 	cfg.excludeBranches = migrateCfg.ExcludeBranches
 	return cfg, nil
@@ -305,6 +309,14 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 		v, _ := cmd.Flags().GetBool(flagSkipIssueSync)
 		if v {
 			cfg.skipIssueSync = true
+		}
+	}
+	// --skip-project-data-migration is the wider opt-out. Same
+	// one-way semantics as --skip-issue-sync. #303.
+	if cmd.Flags().Changed(flagSkipProjectDataMigration) {
+		v, _ := cmd.Flags().GetBool(flagSkipProjectDataMigration)
+		if v {
+			cfg.skipProjectDataMigration = true
 		}
 	}
 	applyFlagBool(cmd, flagDebug, &cfg.debug)
@@ -445,11 +457,12 @@ func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error)
 		// Project-scoped migration: run only the leaf tasks for the project,
 		// its quality gate/profiles, permissions, and issue/hotspot history.
 		// Their dependencies are resolved automatically.
-		TargetTasks:        transferTargetTasks,
-		IncludeScanHistory: true,
-		SkipIssueSync:      cfg.skipIssueSync,
-		Debug:              cfg.debug,
-		ExcludeBranches:    cfg.excludeBranches,
+		TargetTasks:              transferTargetTasks,
+		IncludeScanHistory:       true,
+		SkipIssueSync:            cfg.skipIssueSync,
+		SkipProjectDataMigration: cfg.skipProjectDataMigration,
+		Debug:                    cfg.debug,
+		ExcludeBranches:          cfg.excludeBranches,
 	})
 	if err != nil {
 		return "", fmt.Errorf("migrate failed: %w", err)

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -241,7 +241,7 @@ func TestTransferTargetTasksResolveToProjectScopedPlan(t *testing.T) {
 		common.EditionEnterprise,
 	)
 
-	targets := migrate.MigrateTargetTasks(reg, "", false, false, false, transferTargetTasks)
+	targets := migrate.MigrateTargetTasks(reg, "", false, false, false, false, transferTargetTasks)
 	if len(targets) != len(transferTargetTasks) {
 		t.Fatalf("explicit transfer targets not honored verbatim: got %v", targets)
 	}

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -38,9 +38,15 @@ type configFileShape struct {
 	// Defaults to false (sync happens); set to true (or on / yes) to
 	// skip the sync. Pointer + custom unmarshaller so we can
 	// distinguish "absent" from "explicit false".
-	SkipIssueSync   *FlexibleBool `json:"skip-issue-sync"`
-	Debug           bool          `json:"debug"`
-	ExcludeBranches []string      `json:"exclude_branches"`
+	SkipIssueSync *FlexibleBool `json:"skip-issue-sync"`
+	// SkipProjectDataMigration disables the entire project-data import:
+	// importScanHistory plus the trailing issue + hotspot syncs (#303).
+	// Defaults to false (data is migrated). Setting true (or on/yes)
+	// implies SkipIssueSync — there's nothing to sync against. Same
+	// FlexibleBool semantics as skip-issue-sync.
+	SkipProjectDataMigration *FlexibleBool `json:"skip-project-data-migration"`
+	Debug                    bool          `json:"debug"`
+	ExcludeBranches          []string      `json:"exclude_branches"`
 
 	// Shape 2 (command-sectioned).
 	Migrate *configFileShape `json:"migrate"`
@@ -166,11 +172,17 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value
 		}
+		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
+			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
+		}
 		return cfg
 	case s.SonarCloud != nil:
 		cfg := s.SonarCloud.toMigrateConfig(s.Settings)
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value
+		}
+		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
+			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
 		}
 		return cfg
 	case s.Migrate != nil:
@@ -179,6 +191,9 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		// set it (#299). If only outer is set, propagate it down.
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value
+		}
+		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
+			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
 		}
 		return cfg
 	default:
@@ -198,6 +213,9 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		}
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value
+		}
+		if s.SkipProjectDataMigration != nil && s.SkipProjectDataMigration.Set {
+			cfg.SkipProjectDataMigration = s.SkipProjectDataMigration.Value
 		}
 		return cfg
 	}

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -312,3 +312,47 @@ func TestLoadResetConfigFileUnifiedShape(t *testing.T) {
 		t.Errorf("reset cfg: %+v", cfg)
 	}
 }
+
+// Issue #303: top-level `skip-project-data-migration` parses into
+// MigrateConfig.SkipProjectDataMigration one-for-one (no inversion).
+// Defaults to false (data is migrated). Every FlexibleBool alias is
+// accepted, case-insensitive.
+func TestLoadMigrateConfigFile_SkipProjectDataMigration(t *testing.T) {
+	cases := []struct {
+		name      string
+		bodyField string
+		wantSkip  bool
+	}{
+		{"absent (default)", "", false},
+		{"true", `"skip-project-data-migration": true,`, true},
+		{"false", `"skip-project-data-migration": false,`, false},
+		{"string on", `"skip-project-data-migration": "on",`, true},
+		{"string OFF", `"skip-project-data-migration": "OFF",`, false},
+		{"string Yes", `"skip-project-data-migration": "Yes",`, true},
+		{"numeric 1", `"skip-project-data-migration": 1,`, true},
+		{"numeric 0", `"skip-project-data-migration": 0,`, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			body := `{
+  ` + c.bodyField + `
+  "target": {
+    "url": "https://sonarcloud.io/",
+    "token": "t"
+  }
+}`
+			dir := t.TempDir()
+			path := dir + "/skip-project-data.json"
+			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadMigrateConfigFile(path)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if cfg.SkipProjectDataMigration != c.wantSkip {
+				t.Errorf("SkipProjectDataMigration: got %v, want %v", cfg.SkipProjectDataMigration, c.wantSkip)
+			}
+		})
+	}
+}

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -38,10 +38,11 @@ type MigrateConfig struct {
 	// command for project-scoped migration. Takes precedence over TargetTask.
 	TargetTasks []string
 
-	SkipProfiles       bool
-	IncludeScanHistory bool
-	SkipIssueSync      bool // Skip the final issue / hotspot metadata sync (#299).
-	Debug              bool // Enable slog.LevelDebug + verbose request payload logs
+	SkipProfiles             bool
+	IncludeScanHistory       bool
+	SkipIssueSync            bool // Skip the final issue / hotspot metadata sync (#299).
+	SkipProjectDataMigration bool // Skip importScanHistory + the trailing sync tasks (#303).
+	Debug                    bool // Enable slog.LevelDebug + verbose request payload logs
 
 	// DefaultOrganization, when set, is used as the SonarCloud org for
 	// every row in organizations.csv if none have a sonarcloud_org_key.
@@ -147,20 +148,30 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	registry := BuildMigrateRegistry(allDefs)
 	registry = FilterByEdition(registry, edition)
 
+	// Project-data migration covers importScanHistory + the trailing
+	// issue/hotspot sync pair. Skipping it necessarily skips the
+	// sync as well — propagate the flag so the existing SkipIssueSync
+	// logging surfaces both halves of the decision. #303.
+	if cfg.SkipProjectDataMigration {
+		cfg.SkipIssueSync = true
+		logger.Info("project data migration disabled: skipping importScanHistory")
+		logger.Info("project data migration disabled: issue + hotspot sync also skipped")
+	}
+
 	// Announce the skipped sync tasks explicitly so an operator who
-	// passed --no-issue-sync (or set issue-sync: false in the config)
-	// sees them named in the log alongside the rest of the plan. The
-	// gating itself happens inside MigrateTargetTasks. Always emitted
-	// when SkipIssueSync is true so the operator gets acknowledgement
-	// of their setting, even when --include_scan_history wasn't set
-	// (in which case the two tasks are also dropped by the scan-
-	// history gate; the log clarifies both paths). #299.
+	// passed --skip-issue-sync (or set skip-issue-sync: true in the
+	// config) sees them named in the log alongside the rest of the
+	// plan. The gating itself happens inside MigrateTargetTasks.
+	// Always emitted when SkipIssueSync is true so the operator gets
+	// acknowledgement of their setting, even when --include_scan_history
+	// wasn't set (in which case the two tasks are also dropped by
+	// the scan-history gate; the log clarifies both paths). #299.
 	if cfg.SkipIssueSync {
 		logger.Info("issue-sync disabled: skipping syncIssueMetadata")
 		logger.Info("issue-sync disabled: skipping syncHotspotMetadata")
 	}
 
-	targets := MigrateTargetTasks(registry, cfg.TargetTask, cfg.SkipProfiles, cfg.IncludeScanHistory, cfg.SkipIssueSync, cfg.TargetTasks)
+	targets := MigrateTargetTasks(registry, cfg.TargetTask, cfg.SkipProfiles, cfg.IncludeScanHistory, cfg.SkipIssueSync, cfg.SkipProjectDataMigration, cfg.TargetTasks)
 	taskSet := ResolveDependencies(targets, registry)
 	if taskSet == nil {
 		return "", fmt.Errorf("cannot resolve dependencies for target tasks")

--- a/go/internal/migrate/migrate_test.go
+++ b/go/internal/migrate/migrate_test.go
@@ -29,7 +29,7 @@ func TestRegisterAllCountsAndDependencies(t *testing.T) {
 func TestMigrateTargetTasks(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
 
-	targets := MigrateTargetTasks(reg, "", false, false, false, nil)
+	targets := MigrateTargetTasks(reg, "", false, false, false, false, nil)
 	// Should exclude get*, delete*, reset* tasks.
 	for _, name := range targets {
 		if name[:3] == "get" || name[:6] == "delete" || name[:5] == "reset" {
@@ -43,7 +43,7 @@ func TestMigrateTargetTasks(t *testing.T) {
 
 func TestMigrateTargetTasksSingle(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
-	targets := MigrateTargetTasks(reg, "createProjects", false, false, false, nil)
+	targets := MigrateTargetTasks(reg, "createProjects", false, false, false, false, nil)
 	if len(targets) != 1 || targets[0] != "createProjects" {
 		t.Errorf("expected [createProjects], got %v", targets)
 	}
@@ -56,7 +56,7 @@ func TestMigrateTargetTasksExplicitList(t *testing.T) {
 	// resolved later by ResolveDependencies). This is how the transfer
 	// command requests a project-scoped migration.
 	explicit := []string{"setProjectGates", "importScanHistory", "syncIssueMetadata"}
-	targets := MigrateTargetTasks(reg, "createProjects", false, false, false, explicit)
+	targets := MigrateTargetTasks(reg, "createProjects", false, false, false, false, explicit)
 	if len(targets) != len(explicit) {
 		t.Fatalf("expected %d explicit targets, got %v", len(explicit), targets)
 	}
@@ -78,7 +78,7 @@ func TestMigrateTargetTasksExplicitList(t *testing.T) {
 
 func TestMigrateTargetTasksSkipProfiles(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
-	targets := MigrateTargetTasks(reg, "", true, false, false, nil)
+	targets := MigrateTargetTasks(reg, "", true, false, false, false, nil)
 	for _, name := range targets {
 		if name == "createProfiles" || name == "setProfileParent" || name == "restoreProfiles" ||
 			name == "setDefaultProfiles" || name == "setProjectProfiles" || name == "setProfileGroupPermissions" {
@@ -93,7 +93,7 @@ func TestMigrateTargetTasksSkipProfiles(t *testing.T) {
 // touch-up. #299.
 func TestMigrateTargetTasksSkipIssueSync(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
-	targets := MigrateTargetTasks(reg, "", false, true /*includeScanHistory*/, true /*skipIssueSync*/, nil)
+	targets := MigrateTargetTasks(reg, "", false, true /*includeScanHistory*/, true /*skipIssueSync*/, false /*skipProjectDataMigration*/, nil)
 
 	var sawImport, sawIssue, sawHotspot bool
 	for _, name := range targets {
@@ -122,7 +122,7 @@ func TestMigrateTargetTasksSkipIssueSync(t *testing.T) {
 // The flag must not accidentally let them through.
 func TestMigrateTargetTasksSkipIssueSyncWithoutScanHistory(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
-	targets := MigrateTargetTasks(reg, "", false, false, true, nil)
+	targets := MigrateTargetTasks(reg, "", false, false, true, false, nil)
 	for _, name := range targets {
 		if name == "syncIssueMetadata" || name == "syncHotspotMetadata" {
 			t.Errorf("scan-history-gated task %q must stay excluded without --include_scan_history", name)
@@ -133,7 +133,7 @@ func TestMigrateTargetTasksSkipIssueSyncWithoutScanHistory(t *testing.T) {
 func TestPlanPhasesNoCycles(t *testing.T) {
 	all := RegisterAll()
 	reg := BuildMigrateRegistry(all)
-	targets := MigrateTargetTasks(reg, "", false, false, false, nil)
+	targets := MigrateTargetTasks(reg, "", false, false, false, false, nil)
 	taskSet := ResolveDependencies(targets, reg)
 	if taskSet == nil {
 		t.Fatal("cannot resolve dependencies")
@@ -218,5 +218,36 @@ func TestExtractAnyStr(t *testing.T) {
 	raw = json.RawMessage(`{"other":"x"}`)
 	if got := extractAnyStr(raw, "value"); got != "" {
 		t.Errorf("expected empty, got %q", got)
+	}
+}
+
+// --skip-project-data-migration must drop importScanHistory along
+// with the two trailing sync tasks, even when --include-scan-history
+// is explicitly set. #303.
+func TestMigrateTargetTasksSkipProjectDataMigration(t *testing.T) {
+	reg := BuildMigrateRegistry(RegisterAll())
+	targets := MigrateTargetTasks(reg, "", false, true /*includeScanHistory*/, false /*skipIssueSync*/, true /*skipProjectDataMigration*/, nil)
+	for _, name := range targets {
+		switch name {
+		case "importScanHistory", "syncIssueMetadata", "syncHotspotMetadata":
+			t.Errorf("project data migration disabled: task %q must be excluded", name)
+		}
+	}
+}
+
+// Without --skip-project-data-migration but with --include-scan-history,
+// all three project-data tasks should run. Regression guard so the
+// new gate doesn't accidentally always exclude.
+func TestMigrateTargetTasksProjectDataMigrationEnabledByDefault(t *testing.T) {
+	reg := BuildMigrateRegistry(RegisterAll())
+	targets := MigrateTargetTasks(reg, "", false, true /*includeScanHistory*/, false /*skipIssueSync*/, false /*skipProjectDataMigration*/, nil)
+	got := map[string]bool{}
+	for _, name := range targets {
+		got[name] = true
+	}
+	for _, name := range []string{"importScanHistory", "syncIssueMetadata", "syncHotspotMetadata"} {
+		if !got[name] {
+			t.Errorf("expected %q in the plan when project data migration is enabled", name)
+		}
 	}
 }

--- a/go/internal/migrate/planner.go
+++ b/go/internal/migrate/planner.go
@@ -72,20 +72,22 @@ func RegisterAll() []TaskDef {
 	return all
 }
 
-// migrateScanHistoryTasks lists task names that require the --include-scan-history flag.
-var migrateScanHistoryTasks = map[string]bool{
+// migrateProjectDataTasks lists every task that imports or syncs
+// per-project data after the configuration migration finishes — the
+// scan-history import plus the trailing issue + hotspot metadata
+// syncs. All three are gated by --include-scan-history (only run
+// when extracted data is available) AND by --skip-project-data-
+// migration (operator opt-out, #303).
+var migrateProjectDataTasks = map[string]bool{
 	"importScanHistory":   true,
 	"syncHotspotMetadata": true,
 	"syncIssueMetadata":   true,
 }
 
 // migrateIssueSyncTasks lists the final per-issue / per-hotspot
-// metadata sync tasks that --no-issue-sync (or config issue-sync:
-// false) excludes. The two are bundled together — issue #299 treats
-// "issue sync" as both the issue-status pass AND the hotspot-status
-// pass, since they're the same kind of post-import touch-up step.
-// importScanHistory itself stays included; only the trailing sync
-// pair is skipped.
+// metadata sync tasks that --skip-issue-sync (or config skip-issue-
+// sync: true) excludes. importScanHistory itself stays included;
+// only the trailing sync pair is skipped. #299.
 var migrateIssueSyncTasks = map[string]bool{
 	"syncHotspotMetadata": true,
 	"syncIssueMetadata":   true,
@@ -100,7 +102,9 @@ var migrateIssueSyncTasks = map[string]bool{
 //
 // skipIssueSync (#299) drops the trailing per-issue / per-hotspot metadata
 // sync tasks from the default set while keeping importScanHistory itself.
-func MigrateTargetTasks(reg map[string]*TaskDef, targetTask string, skipProfiles, includeScanHistory, skipIssueSync bool, targetTasks []string) []string {
+// skipProjectDataMigration (#303) is the wider opt-out: it drops
+// importScanHistory AND the two trailing sync tasks together.
+func MigrateTargetTasks(reg map[string]*TaskDef, targetTask string, skipProfiles, includeScanHistory, skipIssueSync, skipProjectDataMigration bool, targetTasks []string) []string {
 	if len(targetTasks) > 0 {
 		return slices.Clone(targetTasks)
 	}
@@ -109,7 +113,7 @@ func MigrateTargetTasks(reg map[string]*TaskDef, targetTask string, skipProfiles
 	}
 	var tasks []string
 	for name := range reg {
-		if isExcludedTask(name, skipProfiles, includeScanHistory, skipIssueSync) {
+		if isExcludedTask(name, skipProfiles, includeScanHistory, skipIssueSync, skipProjectDataMigration) {
 			continue
 		}
 		tasks = append(tasks, name)
@@ -120,7 +124,7 @@ func MigrateTargetTasks(reg map[string]*TaskDef, targetTask string, skipProfiles
 
 var excludePrefixes = []string{"get", "delete", "reset"}
 
-func isExcludedTask(name string, skipProfiles, includeScanHistory, skipIssueSync bool) bool {
+func isExcludedTask(name string, skipProfiles, includeScanHistory, skipIssueSync, skipProjectDataMigration bool) bool {
 	for _, prefix := range excludePrefixes {
 		if strings.HasPrefix(name, prefix) {
 			return true
@@ -129,7 +133,15 @@ func isExcludedTask(name string, skipProfiles, includeScanHistory, skipIssueSync
 	if skipProfiles && (strings.Contains(name, "Profile") || strings.Contains(name, "profile")) {
 		return true
 	}
-	if migrateScanHistoryTasks[name] && !includeScanHistory {
+	// Project-data migration is the wider gate: it covers the whole
+	// importScanHistory + sync trio. Checked before --include-scan-
+	// history so a config with both set still surfaces a single
+	// "skipped" outcome rather than a confusing "include then skip"
+	// no-op.
+	if skipProjectDataMigration && migrateProjectDataTasks[name] {
+		return true
+	}
+	if migrateProjectDataTasks[name] && !includeScanHistory {
 		return true
 	}
 	if skipIssueSync && migrateIssueSyncTasks[name] {

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -32,6 +32,15 @@
       "default": false,
       "description": "When true (or on / yes / 1), skip the final per-issue and per-hotspot metadata sync after scan history is replayed. Defaults to false so the sync happens. Issue #299."
     },
+    "skip-project-data-migration": {
+      "oneOf": [
+        { "type": "boolean" },
+        { "type": "integer", "enum": [0, 1] },
+        { "type": "string", "pattern": "^(?i)(true|false|on|off|yes|no|0|1)$" }
+      ],
+      "default": false,
+      "description": "When true (or on / yes / 1), skip the entire project-data migration: the scan-history import AND the trailing issue + hotspot sync. Implies skip-issue-sync. Defaults to false so the data is migrated. Issue #303."
+    },
     "source": {
       "$ref": "#/$defs/sourceBlock",
       "description": "SonarQube Server connection + extract-time options. Consumed by `extract` (and ignored by `migrate` / `reset`)."


### PR DESCRIPTION
## Summary

Fixes #303. Adds an opt-out for the entire **project-data** migration — `importScanHistory` plus the trailing per-issue and per-hotspot metadata syncs. Some customers cut over to SonarQube Cloud by re-pointing CI at the new instance and skip the synthesized import altogether; for them the import adds latency and risk without delivering value.

### Two equivalent ways to turn it off

| Surface | Form | Default |
|---|---|---|
| CLI | `--skip-project-data-migration` on `migrate` and `transfer` | off (data is migrated) |
| Config file | top-level `skip-project-data-migration` | `false` (data is migrated) |

CLI is one-way (passing the flag forces opt-out; absence does not undo a config-file `true`). Same FlexibleBool aliases as `skip-issue-sync` from #299: `true/false`, `on/off`, `yes/no`, `1/0`, case-insensitive.

### What gets skipped

When `SkipProjectDataMigration=true`:
- `importScanHistory` — excluded
- `syncIssueMetadata` — excluded
- `syncHotspotMetadata` — excluded

`SkipProjectDataMigration` implies `SkipIssueSync` — the trailing syncs have nothing to sync against without the import. `RunMigrate` propagates the cascade so the existing `--skip-issue-sync` log lines fire in addition to the new ones.

### Log output on opt-in

```
INFO  project data migration disabled: skipping importScanHistory
INFO  project data migration disabled: issue + hotspot sync also skipped
INFO  issue-sync disabled: skipping syncIssueMetadata
INFO  issue-sync disabled: skipping syncHotspotMetadata
```

### Files touched

- `internal/migrate/migrate.go` — `MigrateConfig.SkipProjectDataMigration`; cascade + INFO logs in `RunMigrate`.
- `internal/migrate/config_file.go` — top-level `skip-project-data-migration` field translated into `SkipProjectDataMigration` across all four config-file shapes.
- `internal/migrate/planner.go` — renamed `migrateScanHistoryTasks` → `migrateProjectDataTasks`; new `skipProjectDataMigration` arg on `MigrateTargetTasks` / `isExcludedTask` checked **before** the include-scan-history gate.
- `cmd/migrate.go`, `cmd/transfer.go` — new `--skip-project-data-migration` flag with one-way override; transfer threads the resolved value into the inner `MigrateConfig`.
- `docs/ADVANCED-CONFIG.md` — new top-level field row + per-command flag rows.
- `examples/config.unified.example.json`, `config-migrate.example.json`, `config-transfer.example.json`, `config.example.json` — new field with its default.
- `schemas/config.schema.json` — new `skip-project-data-migration` property with the boolean / numeric / string-alias oneOf union.

### Tests

- `migrate_test.go` — 2 new planner tests: `SkipProjectDataMigration=true` drops all three tasks; default keeps them.
- `config_file_test.go` — 8 new alias roundtrip tests (`true`, `false`, `on`, `OFF`, `Yes`, `1`, `0`, absent).
- All existing tests updated for the new `MigrateTargetTasks` arity.

## Test plan

- [x] `cd go && go test ./...` — green.
- [ ] Live `migrate --skip-project-data-migration --include_scan_history` against a real SQS / SQC — confirm:
  - Plan excludes all three project-data tasks even with `--include_scan_history` set.
  - All four INFO log lines appear near the start of the run.
  - Resulting `migration_summary.pdf` has no scan-history rows.
- [ ] Config-only path: `{"skip-project-data-migration": true, ...}` with no CLI flag — confirm same outcome.
- [ ] Confirm aliases (`"on"`, `"YES"`, `1`) all parse and produce the same skip.

Generated with [Claude Code](https://claude.com/claude-code)
