### PR TITLE
Add SonarSource license headers to all source fil All source files should have the SonarSource official license headers  #270 es

### DIFF
--- a/go/cmd/analysis_report.go
+++ b/go/cmd/analysis_report.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/defaults.go
+++ b/go/cmd/defaults.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import "fmt"

--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/gui.go
+++ b/go/cmd/gui.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/mappings.go
+++ b/go/cmd/mappings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/mappings_test.go
+++ b/go/cmd/mappings_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/migrate_test.go
+++ b/go/cmd/migrate_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/predictive_report.go
+++ b/go/cmd/predictive_report.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/predictive_report_test.go
+++ b/go/cmd/predictive_report_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/regtest.go
+++ b/go/cmd/regtest.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/report.go
+++ b/go/cmd/report.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/reset_test.go
+++ b/go/cmd/reset_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/root.go
+++ b/go/cmd/root.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/root_test.go
+++ b/go/cmd/root_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/structure.go
+++ b/go/cmd/structure.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/structure_test.go
+++ b/go/cmd/structure_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/cmd/wizard.go
+++ b/go/cmd/wizard.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cmd
 
 import (

--- a/go/internal/analysis/analysis_report.go
+++ b/go/internal/analysis/analysis_report.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package analysis
 
 import (

--- a/go/internal/analysis/analysis_report_test.go
+++ b/go/internal/analysis/analysis_report_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package analysis
 
 import (

--- a/go/internal/common/common_test.go
+++ b/go/internal/common/common_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/edition.go
+++ b/go/internal/common/edition.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/exit_error.go
+++ b/go/internal/common/exit_error.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import "fmt"

--- a/go/internal/common/helpers.go
+++ b/go/internal/common/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/httpdebug.go
+++ b/go/internal/common/httpdebug.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/httpdebug_test.go
+++ b/go/internal/common/httpdebug_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/planner.go
+++ b/go/internal/common/planner.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/rawclient.go
+++ b/go/internal/common/rawclient.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/store.go
+++ b/go/internal/common/store.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/version.go
+++ b/go/internal/common/version.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/common/version_test.go
+++ b/go/internal/common/version_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import "testing"

--- a/go/internal/common/writer.go
+++ b/go/internal/common/writer.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/extract/compat.go
+++ b/go/internal/extract/compat.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 // Forwarded symbols from common for backward compatibility within the extract package.

--- a/go/internal/extract/config_file.go
+++ b/go/internal/extract/config_file.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/config_file_test.go
+++ b/go/internal/extract/config_file_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/debug_test.go
+++ b/go/internal/extract/debug_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/extract.go
+++ b/go/internal/extract/extract.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/extract_test.go
+++ b/go/internal/extract/extract_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/helpers.go
+++ b/go/internal/extract/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/helpers_test.go
+++ b/go/internal/extract/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/planner.go
+++ b/go/internal/extract/planner.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/planner_test.go
+++ b/go/internal/extract/planner_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/rawclient.go
+++ b/go/internal/extract/rawclient.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import "github.com/sonar-solutions/sonar-migration-tool/internal/common"

--- a/go/internal/extract/store.go
+++ b/go/internal/extract/store.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import "github.com/sonar-solutions/sonar-migration-tool/internal/common"

--- a/go/internal/extract/store_test.go
+++ b/go/internal/extract/store_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_branches.go
+++ b/go/internal/extract/tasks_branches.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 func branchTasks() []TaskDef {

--- a/go/internal/extract/tasks_gates.go
+++ b/go/internal/extract/tasks_gates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_issues.go
+++ b/go/internal/extract/tasks_issues.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_issues_test.go
+++ b/go/internal/extract/tasks_issues_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_misc.go
+++ b/go/internal/extract/tasks_misc.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_misc_test.go
+++ b/go/internal/extract/tasks_misc_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_profiles.go
+++ b/go/internal/extract/tasks_profiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_projects.go
+++ b/go/internal/extract/tasks_projects.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_projects_metric_test.go
+++ b/go/internal/extract/tasks_projects_metric_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_projects_test.go
+++ b/go/internal/extract/tasks_projects_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_rules.go
+++ b/go/internal/extract/tasks_rules.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_scanhistory.go
+++ b/go/internal/extract/tasks_scanhistory.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_scanhistory_test.go
+++ b/go/internal/extract/tasks_scanhistory_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_system.go
+++ b/go/internal/extract/tasks_system.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_templates.go
+++ b/go/internal/extract/tasks_templates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_users.go
+++ b/go/internal/extract/tasks_users.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_views.go
+++ b/go/internal/extract/tasks_views.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/tasks_webhooks.go
+++ b/go/internal/extract/tasks_webhooks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/extract/writer.go
+++ b/go/internal/extract/writer.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import "github.com/sonar-solutions/sonar-migration-tool/internal/common"

--- a/go/internal/extract/writer_test.go
+++ b/go/internal/extract/writer_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package extract
 
 import (

--- a/go/internal/gui/browser.go
+++ b/go/internal/gui/browser.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/history.go
+++ b/go/internal/gui/history.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/history_test.go
+++ b/go/internal/gui/history_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/markdown.go
+++ b/go/internal/gui/markdown.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/markdown_test.go
+++ b/go/internal/gui/markdown_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/page_handlers.go
+++ b/go/internal/gui/page_handlers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/page_handlers_test.go
+++ b/go/internal/gui/page_handlers_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/protocol.go
+++ b/go/internal/gui/protocol.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import "github.com/sonar-solutions/sonar-migration-tool/internal/wizard"

--- a/go/internal/gui/protocol_test.go
+++ b/go/internal/gui/protocol_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/server.go
+++ b/go/internal/gui/server.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/server_test.go
+++ b/go/internal/gui/server_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/static/app.css
+++ b/go/internal/gui/static/app.css
@@ -1,3 +1,8 @@
+/* Copyright (C) SonarSource Sàrl
+ * For more information, see https://sonarsource.com/legal/
+ * mailto:info AT sonarsource DOT com
+ */
+
 :root {
 	--color-bg: #f8f9fa;
 	--color-surface: #ffffff;

--- a/go/internal/gui/templates.go
+++ b/go/internal/gui/templates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/templates/base.html
+++ b/go/internal/gui/templates/base.html
@@ -1,3 +1,8 @@
+{{/*
+  Copyright (C) SonarSource Sàrl
+  For more information, see https://sonarsource.com/legal/
+  mailto:info AT sonarsource DOT com
+*/}}
 <!doctype html>
 <html lang="en" data-theme="dark">
 <head>

--- a/go/internal/gui/templates/history.html
+++ b/go/internal/gui/templates/history.html
@@ -1,3 +1,8 @@
+{{/*
+  Copyright (C) SonarSource Sàrl
+  For more information, see https://sonarsource.com/legal/
+  mailto:info AT sonarsource DOT com
+*/}}
 {{define "title"}}History - SQ Migration{{end}}
 
 {{define "content"}}

--- a/go/internal/gui/templates/report.html
+++ b/go/internal/gui/templates/report.html
@@ -1,3 +1,8 @@
+{{/*
+  Copyright (C) SonarSource Sàrl
+  For more information, see https://sonarsource.com/legal/
+  mailto:info AT sonarsource DOT com
+*/}}
 {{define "title"}}Report - SQ Migration{{end}}
 
 {{define "content"}}

--- a/go/internal/gui/templates/run_detail.html
+++ b/go/internal/gui/templates/run_detail.html
@@ -1,3 +1,8 @@
+{{/*
+  Copyright (C) SonarSource Sàrl
+  For more information, see https://sonarsource.com/legal/
+  mailto:info AT sonarsource DOT com
+*/}}
 {{define "title"}}Run Detail - SQ Migration{{end}}
 
 {{define "content"}}

--- a/go/internal/gui/templates/wizard.html
+++ b/go/internal/gui/templates/wizard.html
@@ -1,3 +1,8 @@
+{{/*
+  Copyright (C) SonarSource Sàrl
+  For more information, see https://sonarsource.com/legal/
+  mailto:info AT sonarsource DOT com
+*/}}
 {{define "title"}}Wizard - SQ Migration{{end}}
 
 {{define "content"}}

--- a/go/internal/gui/templates_test.go
+++ b/go/internal/gui/templates_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/web_prompter.go
+++ b/go/internal/gui/web_prompter.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/web_prompter_test.go
+++ b/go/internal/gui/web_prompter_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/websocket.go
+++ b/go/internal/gui/websocket.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/gui/websocket_test.go
+++ b/go/internal/gui/websocket_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package gui
 
 import (

--- a/go/internal/migrate/ai_codefix.go
+++ b/go/internal/migrate/ai_codefix.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/ai_codefix_test.go
+++ b/go/internal/migrate/ai_codefix_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/builtin_groups.go
+++ b/go/internal/migrate/builtin_groups.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 // builtInGroupSkipNotes lists SonarQube Server built-in groups that

--- a/go/internal/migrate/builtin_groups_test.go
+++ b/go/internal/migrate/builtin_groups_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import "testing"

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/create_lookup.go
+++ b/go/internal/migrate/create_lookup.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/create_lookup_test.go
+++ b/go/internal/migrate/create_lookup_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/dbcleaner_branches.go
+++ b/go/internal/migrate/dbcleaner_branches.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/dbcleaner_branches_test.go
+++ b/go/internal/migrate/dbcleaner_branches_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/flexible_bool.go
+++ b/go/internal/migrate/flexible_bool.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/flexible_bool_test.go
+++ b/go/internal/migrate/flexible_bool_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/gate_conditions_resolver.go
+++ b/go/internal/migrate/gate_conditions_resolver.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import "strconv"

--- a/go/internal/migrate/gate_conditions_resolver_test.go
+++ b/go/internal/migrate/gate_conditions_resolver_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/gate_metric_mapping.go
+++ b/go/internal/migrate/gate_metric_mapping.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 // ReplacementCondition describes how a single SonarQube Cloud condition is

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/internal_settings.go
+++ b/go/internal/migrate/internal_settings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import "strings"

--- a/go/internal/migrate/internal_settings_test.go
+++ b/go/internal/migrate/internal_settings_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import "testing"

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/migrate_test.go
+++ b/go/internal/migrate/migrate_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/org_existence_test.go
+++ b/go/internal/migrate/org_existence_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/org_mapping.go
+++ b/go/internal/migrate/org_mapping.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/org_mapping_test.go
+++ b/go/internal/migrate/org_mapping_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/planner.go
+++ b/go/internal/migrate/planner.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/portfolio_analysis.go
+++ b/go/internal/migrate/portfolio_analysis.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import "strings"

--- a/go/internal/migrate/portfolio_analysis_test.go
+++ b/go/internal/migrate/portfolio_analysis_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/profile_rule_analysis.go
+++ b/go/internal/migrate/profile_rule_analysis.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/profile_rule_analysis_test.go
+++ b/go/internal/migrate/profile_rule_analysis_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/reset_test.go
+++ b/go/internal/migrate/reset_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/setup_test.go
+++ b/go/internal/migrate/setup_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/sqs_only_global_settings_test.go
+++ b/go/internal/migrate/sqs_only_global_settings_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_alm.go
+++ b/go/internal/migrate/tasks_alm.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_analyze_profiles.go
+++ b/go/internal/migrate/tasks_analyze_profiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_gate_override_test.go
+++ b/go/internal/migrate/tasks_gate_override_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_newcode_test.go
+++ b/go/internal/migrate/tasks_newcode_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_portfolios_test.go
+++ b/go/internal/migrate/tasks_portfolios_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_read.go
+++ b/go/internal/migrate/tasks_read.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_read_test.go
+++ b/go/internal/migrate/tasks_read_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_rules.go
+++ b/go/internal/migrate/tasks_rules.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_scanhistory.go
+++ b/go/internal/migrate/tasks_scanhistory.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_scanhistory_test.go
+++ b/go/internal/migrate/tasks_scanhistory_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_settings_helpers.go
+++ b/go/internal/migrate/tasks_settings_helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/migrate/tasks_setup.go
+++ b/go/internal/migrate/tasks_setup.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import "context"

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migrate
 
 import (

--- a/go/internal/pipeline/helpers.go
+++ b/go/internal/pipeline/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/helpers_test.go
+++ b/go/internal/pipeline/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/pipeline.go
+++ b/go/internal/pipeline/pipeline.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package pipeline provides the version-specific extraction interface and four
 // concrete implementations covering SQ 9.9 LTS, SQ 10.0-10.3, SQ 10.4-10.8,
 // and SQ 2025.1+. A version router selects the correct pipeline at startup.

--- a/go/internal/pipeline/router.go
+++ b/go/internal/pipeline/router.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/router_test.go
+++ b/go/internal/pipeline/router_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/shared.go
+++ b/go/internal/pipeline/shared.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/shared_test.go
+++ b/go/internal/pipeline/shared_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/sq100.go
+++ b/go/internal/pipeline/sq100.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import sqapi "github.com/sonar-solutions/sq-api-go"

--- a/go/internal/pipeline/sq104.go
+++ b/go/internal/pipeline/sq104.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import sqapi "github.com/sonar-solutions/sq-api-go"

--- a/go/internal/pipeline/sq2025.go
+++ b/go/internal/pipeline/sq2025.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/sq2025_test.go
+++ b/go/internal/pipeline/sq2025_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import (

--- a/go/internal/pipeline/sq99.go
+++ b/go/internal/pipeline/sq99.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package pipeline
 
 import sqapi "github.com/sonar-solutions/sq-api-go"

--- a/go/internal/predict/gate_notes.go
+++ b/go/internal/predict/gate_notes.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package predict
 
 import (

--- a/go/internal/predict/global_settings.go
+++ b/go/internal/predict/global_settings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package predict
 
 import (

--- a/go/internal/predict/new_code_periods.go
+++ b/go/internal/predict/new_code_periods.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package predict
 
 import (

--- a/go/internal/predict/predict_test.go
+++ b/go/internal/predict/predict_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package predict
 
 import (

--- a/go/internal/predict/profile_notes.go
+++ b/go/internal/predict/profile_notes.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package predict
 
 import (

--- a/go/internal/predict/report.go
+++ b/go/internal/predict/report.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package predict
 
 import (

--- a/go/internal/predict/synthesize.go
+++ b/go/internal/predict/synthesize.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package predict produces a migration summary PDF before any migrate
 // step has run. It synthesises the JSONL outputs the summary pipeline
 // expects (generate*Mappings + create* + addGateConditions.notes) from

--- a/go/internal/regtest/checks.go
+++ b/go/internal/regtest/checks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package regtest
 
 import (

--- a/go/internal/regtest/checks_test.go
+++ b/go/internal/regtest/checks_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package regtest
 
 import (

--- a/go/internal/regtest/helpers.go
+++ b/go/internal/regtest/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package regtest
 
 import (

--- a/go/internal/regtest/report.go
+++ b/go/internal/regtest/report.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package regtest
 
 import (

--- a/go/internal/regtest/suite.go
+++ b/go/internal/regtest/suite.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package regtest
 
 import (

--- a/go/internal/report/common/applications.go
+++ b/go/internal/report/common/applications.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/bindings.go
+++ b/go/internal/report/common/bindings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/common_test.go
+++ b/go/internal/report/common/common_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/gates.go
+++ b/go/internal/report/common/gates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/groups.go
+++ b/go/internal/report/common/groups.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/measures.go
+++ b/go/internal/report/common/measures.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/permissions.go
+++ b/go/internal/report/common/permissions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/pipelines.go
+++ b/go/internal/report/common/pipelines.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/plugins.go
+++ b/go/internal/report/common/plugins.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/portfolios.go
+++ b/go/internal/report/common/portfolios.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/profiles.go
+++ b/go/internal/report/common/profiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/projects.go
+++ b/go/internal/report/common/projects.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/servers.go
+++ b/go/internal/report/common/servers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/tasks.go
+++ b/go/internal/report/common/tasks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/tokens.go
+++ b/go/internal/report/common/tokens.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/types.go
+++ b/go/internal/report/common/types.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/users.go
+++ b/go/internal/report/common/users.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/common/webhooks.go
+++ b/go/internal/report/common/webhooks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package common
 
 import (

--- a/go/internal/report/helpers.go
+++ b/go/internal/report/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package report
 
 import (

--- a/go/internal/report/helpers_test.go
+++ b/go/internal/report/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package report
 
 import (

--- a/go/internal/report/jsonpath.go
+++ b/go/internal/report/jsonpath.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package report
 
 import (

--- a/go/internal/report/jsonpath_test.go
+++ b/go/internal/report/jsonpath_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package report
 
 import (

--- a/go/internal/report/markdown.go
+++ b/go/internal/report/markdown.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package report
 
 import (

--- a/go/internal/report/markdown_test.go
+++ b/go/internal/report/markdown_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package report
 
 import (

--- a/go/internal/report/maturity/coverage.go
+++ b/go/internal/report/maturity/coverage.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/gates.go
+++ b/go/internal/report/maturity/gates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/generate.go
+++ b/go/internal/report/maturity/generate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/ide.go
+++ b/go/internal/report/maturity/ide.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import "github.com/sonar-solutions/sonar-migration-tool/internal/report"

--- a/go/internal/report/maturity/issues.go
+++ b/go/internal/report/maturity/issues.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/languages.go
+++ b/go/internal/report/maturity/languages.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/maturity_test.go
+++ b/go/internal/report/maturity/maturity_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/permissions.go
+++ b/go/internal/report/maturity/permissions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/portfolios.go
+++ b/go/internal/report/maturity/portfolios.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/profiles.go
+++ b/go/internal/report/maturity/profiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/scans.go
+++ b/go/internal/report/maturity/scans.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/maturity/usage.go
+++ b/go/internal/report/maturity/usage.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package maturity
 
 import (

--- a/go/internal/report/migration/generate.go
+++ b/go/internal/report/migration/generate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migration
 
 import (

--- a/go/internal/report/migration/generate_test.go
+++ b/go/internal/report/migration/generate_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package migration
 
 import (

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/fonts.go
+++ b/go/internal/report/summary/fonts.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import _ "embed"

--- a/go/internal/report/summary/gate_condition_format.go
+++ b/go/internal/report/summary/gate_condition_format.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/gate_condition_format_test.go
+++ b/go/internal/report/summary/gate_condition_format_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import "testing"

--- a/go/internal/report/summary/gate_notes.go
+++ b/go/internal/report/summary/gate_notes.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/generate.go
+++ b/go/internal/report/summary/generate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/global_failures.go
+++ b/go/internal/report/summary/global_failures.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/partial.go
+++ b/go/internal/report/summary/partial.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/portfolio_failures.go
+++ b/go/internal/report/summary/portfolio_failures.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/portfolio_hierarchy.go
+++ b/go/internal/report/summary/portfolio_hierarchy.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/profile_notes.go
+++ b/go/internal/report/summary/profile_notes.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/project_failures.go
+++ b/go/internal/report/summary/project_failures.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/project_failures_test.go
+++ b/go/internal/report/summary/project_failures_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package summary
 
 import (

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package summary generates a PDF migration summary report from task outputs.
 package summary
 

--- a/go/internal/scanreport/backdate.go
+++ b/go/internal/scanreport/backdate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package scanreport builds and submits SonarScanner-compatible reports
 // to SonarCloud's Compute Engine for scan history migration.
 package scanreport

--- a/go/internal/scanreport/backdate_test.go
+++ b/go/internal/scanreport/backdate_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/scanreport/builder.go
+++ b/go/internal/scanreport/builder.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/scanreport/builder_test.go
+++ b/go/internal/scanreport/builder_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/scanreport/packager.go
+++ b/go/internal/scanreport/packager.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/scanreport/packager_test.go
+++ b/go/internal/scanreport/packager_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/scanreport/proto/generate.go
+++ b/go/internal/scanreport/proto/generate.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package proto contains generated protobuf types for SonarScanner report submission.
 //
 // To regenerate after modifying .proto files:

--- a/go/internal/scanreport/submit.go
+++ b/go/internal/scanreport/submit.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/scanreport/submit_test.go
+++ b/go/internal/scanreport/submit_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package scanreport
 
 import (

--- a/go/internal/structure/csv.go
+++ b/go/internal/structure/csv.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/csv_test.go
+++ b/go/internal/structure/csv_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/extract.go
+++ b/go/internal/structure/extract.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/gates.go
+++ b/go/internal/structure/gates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/groups.go
+++ b/go/internal/structure/groups.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/organizations.go
+++ b/go/internal/structure/organizations.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 // MapOrganizationStructure converts bindings to organizations.

--- a/go/internal/structure/portfolios.go
+++ b/go/internal/structure/portfolios.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/profiles.go
+++ b/go/internal/structure/profiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/projects.go
+++ b/go/internal/structure/projects.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/projects_test.go
+++ b/go/internal/structure/projects_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/structure.go
+++ b/go/internal/structure/structure.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import "fmt"

--- a/go/internal/structure/structure_test.go
+++ b/go/internal/structure/structure_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/templates.go
+++ b/go/internal/structure/templates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 import (

--- a/go/internal/structure/types.go
+++ b/go/internal/structure/types.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package structure
 
 // Organization represents a SonarQube Cloud organization derived from DevOps bindings.

--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package version
 
 const Version = "0.2.0"

--- a/go/internal/wizard/cli_prompter.go
+++ b/go/internal/wizard/cli_prompter.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/cli_prompter_test.go
+++ b/go/internal/wizard/cli_prompter_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import "testing"

--- a/go/internal/wizard/helpers.go
+++ b/go/internal/wizard/helpers.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/helpers_test.go
+++ b/go/internal/wizard/helpers_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/phases.go
+++ b/go/internal/wizard/phases.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/phases_test.go
+++ b/go/internal/wizard/phases_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/prompter.go
+++ b/go/internal/wizard/prompter.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import "errors"

--- a/go/internal/wizard/state.go
+++ b/go/internal/wizard/state.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/state_test.go
+++ b/go/internal/wizard/state_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/wizard.go
+++ b/go/internal/wizard/wizard.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/internal/wizard/wizard_test.go
+++ b/go/internal/wizard/wizard_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package wizard
 
 import (

--- a/go/main.go
+++ b/go/main.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package main
 
 import (

--- a/go/tools.go
+++ b/go/tools.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 //go:build tools
 
 package tools

--- a/lib/sq-api-go/auth.go
+++ b/lib/sq-api-go/auth.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi
 
 import (

--- a/lib/sq-api-go/client.go
+++ b/lib/sq-api-go/client.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package sqapi provides a typed Go client for the SonarQube Server and
 // SonarQube Cloud APIs. It is scoped to the endpoints used by the
 // sonar-migration-tool.

--- a/lib/sq-api-go/client_test.go
+++ b/lib/sq-api-go/client_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi_test
 
 import (

--- a/lib/sq-api-go/cloud/branches.go
+++ b/lib/sq-api-go/cloud/branches.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/client.go
+++ b/lib/sq-api-go/cloud/client.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package cloud provides typed SonarQube Cloud API clients for the endpoints
 // used by the sonar-migration-tool. It covers write-path (migration) operations:
 // creating, updating, and deleting projects, groups, quality profiles, quality

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud_test
 
 import (

--- a/lib/sq-api-go/cloud/dop.go
+++ b/lib/sq-api-go/cloud/dop.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/enterprises.go
+++ b/lib/sq-api-go/cloud/enterprises.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package cloud — enterprises.go covers the /enterprises REST API available on
 // SonarQube Cloud Enterprise plans. This API uses a different base URL
 // (api.sonarcloud.io rather than sonarcloud.io) and JSON request/response bodies.

--- a/lib/sq-api-go/cloud/fix_suggestions.go
+++ b/lib/sq-api-go/cloud/fix_suggestions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package cloud — fix_suggestions.go covers the SonarQube Cloud AI
 // Code Fix organization-config endpoint, used by the migration tool to
 // translate SQS-side AI Code Fix configuration into the equivalent SQC

--- a/lib/sq-api-go/cloud/groups.go
+++ b/lib/sq-api-go/cloud/groups.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/hotspots.go
+++ b/lib/sq-api-go/cloud/hotspots.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/integration_test.go
+++ b/lib/sq-api-go/cloud/integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 //go:build integration
 
 package cloud_test

--- a/lib/sq-api-go/cloud/issues.go
+++ b/lib/sq-api-go/cloud/issues.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/newcode.go
+++ b/lib/sq-api-go/cloud/newcode.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package cloud — newcode.go covers the /api/new_code_periods endpoints used
 // by the sonar-migration-tool to migrate per-branch new-code policy.
 package cloud

--- a/lib/sq-api-go/cloud/organizations.go
+++ b/lib/sq-api-go/cloud/organizations.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package cloud — organizations.go covers the lookup endpoints we need to
 // resolve a human-readable organization key (e.g. "my-org") to the UUID that
 // other SonarQube Cloud enterprise endpoints expect — in particular

--- a/lib/sq-api-go/cloud/permissions.go
+++ b/lib/sq-api-go/cloud/permissions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/projects.go
+++ b/lib/sq-api-go/cloud/projects.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/qualitygates.go
+++ b/lib/sq-api-go/cloud/qualitygates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/qualityprofiles.go
+++ b/lib/sq-api-go/cloud/qualityprofiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/rules.go
+++ b/lib/sq-api-go/cloud/rules.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/settings.go
+++ b/lib/sq-api-go/cloud/settings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/cloud/webhooks.go
+++ b/lib/sq-api-go/cloud/webhooks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package cloud
 
 import (

--- a/lib/sq-api-go/debug.go
+++ b/lib/sq-api-go/debug.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi
 
 import (

--- a/lib/sq-api-go/errors.go
+++ b/lib/sq-api-go/errors.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi
 
 import (

--- a/lib/sq-api-go/export_test.go
+++ b/lib/sq-api-go/export_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // This file is in package sqapi (not sqapi_test) so it can access unexported
 // identifiers. It is compiled only during 'go test' because the filename ends
 // in _test.go. These exports are not part of the public API.

--- a/lib/sq-api-go/options.go
+++ b/lib/sq-api-go/options.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi
 
 import (

--- a/lib/sq-api-go/pagination.go
+++ b/lib/sq-api-go/pagination.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi
 
 import (

--- a/lib/sq-api-go/phase1_test.go
+++ b/lib/sq-api-go/phase1_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi_test
 
 import (

--- a/lib/sq-api-go/retry.go
+++ b/lib/sq-api-go/retry.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package sqapi
 
 import (

--- a/lib/sq-api-go/server/alm.go
+++ b/lib/sq-api-go/server/alm.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/analyses.go
+++ b/lib/sq-api-go/server/analyses.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/branches.go
+++ b/lib/sq-api-go/server/branches.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/client.go
+++ b/lib/sq-api-go/server/client.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package server provides typed SonarQube Server API clients for the endpoints
 // used by the sonar-migration-tool.
 //

--- a/lib/sq-api-go/server/groups.go
+++ b/lib/sq-api-go/server/groups.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/hotspots.go
+++ b/lib/sq-api-go/server/hotspots.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/integration_test.go
+++ b/lib/sq-api-go/server/integration_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 //go:build integration
 
 package server_test

--- a/lib/sq-api-go/server/issues.go
+++ b/lib/sq-api-go/server/issues.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/measures.go
+++ b/lib/sq-api-go/server/measures.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/newcode.go
+++ b/lib/sq-api-go/server/newcode.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/permissions.go
+++ b/lib/sq-api-go/server/permissions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/phase2_test.go
+++ b/lib/sq-api-go/server/phase2_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server_test
 
 import (

--- a/lib/sq-api-go/server/phase3_test.go
+++ b/lib/sq-api-go/server/phase3_test.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server_test
 
 import (

--- a/lib/sq-api-go/server/plugins.go
+++ b/lib/sq-api-go/server/plugins.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/projects.go
+++ b/lib/sq-api-go/server/projects.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/pullrequests.go
+++ b/lib/sq-api-go/server/pullrequests.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/qualitygates.go
+++ b/lib/sq-api-go/server/qualitygates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/qualityprofiles.go
+++ b/lib/sq-api-go/server/qualityprofiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/rules.go
+++ b/lib/sq-api-go/server/rules.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/settings.go
+++ b/lib/sq-api-go/server/settings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/system.go
+++ b/lib/sq-api-go/server/system.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/tokens.go
+++ b/lib/sq-api-go/server/tokens.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/users.go
+++ b/lib/sq-api-go/server/users.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/views.go
+++ b/lib/sq-api-go/server/views.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/server/webhooks.go
+++ b/lib/sq-api-go/server/webhooks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package server
 
 import (

--- a/lib/sq-api-go/types/alm.go
+++ b/lib/sq-api-go/types/alm.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // AlmSetting represents a single ALM (Application Lifecycle Management)

--- a/lib/sq-api-go/types/analyses.go
+++ b/lib/sq-api-go/types/analyses.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Analysis represents a single project analysis returned by

--- a/lib/sq-api-go/types/branches.go
+++ b/lib/sq-api-go/types/branches.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // BranchStatus holds the quality gate result for a branch.

--- a/lib/sq-api-go/types/common.go
+++ b/lib/sq-api-go/types/common.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 // Package types contains shared response types for the sq-api-go library.
 package types
 

--- a/lib/sq-api-go/types/enterprises.go
+++ b/lib/sq-api-go/types/enterprises.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Enterprise represents a SonarQube Cloud enterprise returned by

--- a/lib/sq-api-go/types/fix_suggestions.go
+++ b/lib/sq-api-go/types/fix_suggestions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // FixSuggestionsOrgConfig is the request body for SonarQube Cloud's

--- a/lib/sq-api-go/types/groups.go
+++ b/lib/sq-api-go/types/groups.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Group represents a single group returned by /api/permissions/groups.

--- a/lib/sq-api-go/types/hotspots.go
+++ b/lib/sq-api-go/types/hotspots.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Hotspot represents a single security hotspot returned by /api/hotspots/search.

--- a/lib/sq-api-go/types/issues.go
+++ b/lib/sq-api-go/types/issues.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Issue represents a single code issue returned by /api/issues/search.

--- a/lib/sq-api-go/types/measures.go
+++ b/lib/sq-api-go/types/measures.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Measure represents a single component metric measurement returned by

--- a/lib/sq-api-go/types/newcode.go
+++ b/lib/sq-api-go/types/newcode.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // NewCodePeriod represents a single new code period definition returned by

--- a/lib/sq-api-go/types/organizations.go
+++ b/lib/sq-api-go/types/organizations.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Organization represents a SonarQube Cloud organization as returned by

--- a/lib/sq-api-go/types/permissions.go
+++ b/lib/sq-api-go/types/permissions.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // TemplatePermission describes the users/groups count for one permission key

--- a/lib/sq-api-go/types/plugins.go
+++ b/lib/sq-api-go/types/plugins.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Plugin represents a single installed plugin returned by

--- a/lib/sq-api-go/types/projects.go
+++ b/lib/sq-api-go/types/projects.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Project represents a single project returned by /api/projects/search.

--- a/lib/sq-api-go/types/pullrequests.go
+++ b/lib/sq-api-go/types/pullrequests.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // PullRequestStatus holds the quality gate result for a pull request.

--- a/lib/sq-api-go/types/qualitygates.go
+++ b/lib/sq-api-go/types/qualitygates.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 import "encoding/json"

--- a/lib/sq-api-go/types/qualityprofiles.go
+++ b/lib/sq-api-go/types/qualityprofiles.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // QualityProfile represents a single quality profile returned by

--- a/lib/sq-api-go/types/rules.go
+++ b/lib/sq-api-go/types/rules.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // RuleParam is a parameter definition on a rule template.

--- a/lib/sq-api-go/types/settings.go
+++ b/lib/sq-api-go/types/settings.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Setting represents a single configuration setting returned by

--- a/lib/sq-api-go/types/system.go
+++ b/lib/sq-api-go/types/system.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 import "encoding/json"

--- a/lib/sq-api-go/types/tokens.go
+++ b/lib/sq-api-go/types/tokens.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // UserToken represents a single API token returned by /api/user_tokens/search.

--- a/lib/sq-api-go/types/users.go
+++ b/lib/sq-api-go/types/users.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // User represents a single user returned by /api/users/search.

--- a/lib/sq-api-go/types/views.go
+++ b/lib/sq-api-go/types/views.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // View represents a portfolio or application returned by /api/views/search.

--- a/lib/sq-api-go/types/webhooks.go
+++ b/lib/sq-api-go/types/webhooks.go
@@ -1,3 +1,7 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
 package types
 
 // Webhook represents a single webhook returned by /api/webhooks/list.


### PR DESCRIPTION
Per legal guidance (Luis Villa), adds the standard 3-line SonarSource copyright header to all .go, .html, and .css source files. Uses Go template comments ({{/* */}}) for HTML templates to avoid breaking Go's html/template engine which strips HTML comments.

Excluded: *.pb.go (protobuf generated), vendored JS (htmx), coverage.html.