### PR TITLE
Fix #312: drop 10 MB JSONL line limit silently dropping source data

### DIFF
--- a/go/internal/common/store.go
+++ b/go/internal/common/store.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,7 +64,15 @@ func (ds *DataStore) ReadAll(taskName string) ([]json.RawMessage, error) {
 	return all, nil
 }
 
-// ReadJSONLFile reads a single JSONL file into a slice of raw JSON messages.
+// ReadJSONLFile reads a single JSONL file into a slice of raw JSON
+// messages. Lines are unbounded in length: scan-history extract
+// records embed full source files as a JSON string, and large
+// generated / minified sources routinely exceed the bufio.Scanner
+// default ceiling (and even the bumped 10 MB ceiling we used to
+// carry). We use bufio.Reader.ReadBytes('\n') so the only effective
+// limit is available memory. A single oversize line previously
+// caused readTaskDir to abort the entire task — which silently
+// dropped every source record across the migration.
 func ReadJSONLFile(path string) ([]json.RawMessage, error) {
 	f, err := os.Open(path)
 	if err != nil {
@@ -71,16 +80,22 @@ func ReadJSONLFile(path string) ([]json.RawMessage, error) {
 	}
 	defer f.Close()
 	var items []json.RawMessage
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // 10 MB max line
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" {
-			continue
+	r := bufio.NewReader(f)
+	for {
+		line, err := r.ReadBytes('\n')
+		if len(line) > 0 {
+			trimmed := strings.TrimSpace(string(line))
+			if trimmed != "" {
+				items = append(items, json.RawMessage(trimmed))
+			}
 		}
-		items = append(items, json.RawMessage(line))
+		if err != nil {
+			if err == io.EOF {
+				return items, nil
+			}
+			return items, err
+		}
 	}
-	return items, scanner.Err()
 }
 
 // MarkComplete marks a task as finished.


### PR DESCRIPTION
## Summary

Fixes #312. After running `extract` + `migrate`, no project data was actually being migrated — the log filled with "skipping branch: source code not retrievable" warnings on every branch of every project, even when `getProjectSourceCode/` had thousands of well-formed JSONL records.

### Root cause

`ReadJSONLFile` used `bufio.Scanner` with a 10 MB max-line buffer:

```go
scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024) // 10 MB max line
```

Scan-history extract records embed full source files as a JSON string in the `source` field, so a single record's serialised length scales with the underlying source file. Large generated / minified / vendored sources routinely exceed 10 MB once JSON-encoded.

When the scanner hit such a line it returned `bufio.ErrTooLong`. `readTaskDir` surfaced the error to `ReadExtractData`, which silently `continue`d past **the entire task**:

```go
for serverURL, extractID := range mapping {
    taskDir := filepath.Join(directory, extractID, key)
    raw, err := readTaskDir(taskDir)
    if err != nil {
        continue // task may not exist for this extract
    }
    ...
}
```

So one oversize record nuked loading for every source record in the migration — and the user saw a generic "source not retrievable" warning that pointed in the wrong direction (housekeeping / purged branches).

In my local repro, 5 of 6758 `getProjectSourceCode/` JSONL files were >10 MB; the 6753 well-formed records were dropped along with them.

### Fix

Switch `ReadJSONLFile` to `bufio.Reader.ReadBytes('\n')`. No fixed line limit, only available memory. One oversize record no longer poisons the rest of the task.

I also kept the same "skip empty lines, return all records up to first error" semantics so downstream callers see no behaviour change for well-formed files.

## Test plan

- [x] `go test ./internal/common/...` — green.
- [x] Probed against the failing live extract: `ReadExtractData("getProjectSourceCode")` previously returned 0 items; now returns all 6758.
- [ ] Re-run `migrate` against the live SQS → SQC pair and confirm:
  - The "source code not retrievable" warnings disappear for projects whose source was extracted.
  - The migration report shows non-zero issue / hotspot syncs.

### Follow-up worth considering (not in this PR)

`readTaskDir` returns `nil, err` on the first file error, dropping every file already read. Even with the buffer fix, an actual corrupt JSONL file (or future regression) could again take down the entire migration silently. Making it skip-with-warn on a single file failure would be more resilient.

Generated with [Claude Code](https://claude.com/claude-code)
