### PR TITLE
Issue #317: align config option format to use underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ The tool ships with several commands. Pick the workflow that matches your situat
 
 Use `transfer`. It runs the whole migration in a single command — extracting from SonarQube Server, mapping the configuration, importing source code and issues, and pushing everything to SonarQube Cloud — then writes a PDF summary you can hand to your team.
 
-`transfer` shares the same `--config` file and the same direction-neutral CLI flags as `extract` / `migrate` / `reset` — `--source-*` for the SonarQube Server side, `--target-*` for the SonarQube Cloud side. Anything you don't pass on the CLI is read from the config file; CLI flags always win.
+`transfer` shares the same `--config` file and the same direction-neutral CLI flags as `extract` / `migrate` / `reset` — `--source_*` for the SonarQube Server side, `--target_*` for the SonarQube Cloud side. Anything you don't pass on the CLI is read from the config file; CLI flags always win.
 
 ```bash
 ./sonar-migration-tool transfer \
-  --source-url https://sonarqube.example.com \
-  --source-token sqp_xxx \
-  --project-key my-project \
-  --target-token squ_xxx \
+  --source_url https://sonarqube.example.com \
+  --source_token sqp_xxx \
+  --project_key my-project \
+  --target_token squ_xxx \
   --default_organization my-org
 ```
 
@@ -99,12 +99,12 @@ Or use a **config file** to keep tokens out of your shell history:
 ```bash
 cp examples/config-transfer.example.json my-config.json
 # Edit my-config.json with your SonarQube Server and SonarQube Cloud credentials
-./sonar-migration-tool transfer -c my-config.json --project-key my-project
+./sonar-migration-tool transfer -c my-config.json --project_key my-project
 ```
 
 The config file uses the same unified shape as every other command — one top-level block of shared defaults plus `source` and `target` sub-objects. `concurrency`, `timeout`, `export_directory`, mTLS (`pem_file_path` / `key_file_path` / `cert_password`), and `--default_organization` / `--enterprise_key` are all honored either via the JSON file or as CLI overrides.
 
-Add `--target-url` to target a different SonarQube Cloud instance (e.g. `--target-url https://sc-staging.io` for staging).
+Add `--target_url` to target a different SonarQube Cloud instance (e.g. `--target_url https://sc-staging.io` for staging).
 
 Full reference, more examples, and the config-file format:
 👉 **[Using `transfer` — Transfer One Project](docs/TRANSFER.md)**
@@ -157,8 +157,8 @@ Once the command finishes:
 1. Log in to [sonarcloud.io](https://sonarcloud.io).
 2. Open the target organization.
 3. Spot-check that your project(s) are listed and the quality gate and quality profile are correct.
-4. Unless you passed `--skip-project-data-migration`, verify that issues, hotspots, and their creation dates match the source. You can also run `./sonar-migration-tool regtest` for automated verification.
-5. **Re-scan your projects in CI** to seed ongoing analysis. If you used `--skip-project-data-migration`, this first scan will be the baseline for all issue tracking.
+4. Unless you passed `--skip_project_data_migration`, verify that issues, hotspots, and their creation dates match the source. You can also run `./sonar-migration-tool regtest` for automated verification.
+5. **Re-scan your projects in CI** to seed ongoing analysis. If you used `--skip_project_data_migration`, this first scan will be the baseline for all issue tracking.
 6. Update your CI/CD pipeline to point at SonarQube Cloud (`SONAR_TOKEN` and `SONAR_HOST_URL`).
 
 For the full post-migration checklist, see [After you migrate](docs/MIGRATE.md#after-you-migrate) in the MIGRATE guide.

--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -38,12 +38,12 @@ All optional.
 | `concurrency` | `10` | Default max parallel HTTP calls. |
 | `timeout` | `60` | Default HTTP request timeout in seconds. |
 | `export_directory` | `./migration-files` | Root directory for extract / migrate output. |
-| `skip-issue-sync` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the final per-issue and per-hotspot metadata sync that runs after scan history is replayed. Defaults to `false` so the sync happens. Accepted aliases are case-insensitive. Issue #299. |
-| `skip-project-data-migration` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the entire project-data migration: the scan-history import AND the trailing issue + hotspot sync. Useful when customers cut over to SonarQube Cloud by re-scanning rather than importing historical state. Implies `skip-issue-sync` — there's nothing to sync against. Same FlexibleBool aliases. Issue #303. |
+| `skip_issue_sync` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the final per-issue and per-hotspot metadata sync that runs after scan history is replayed. Defaults to `false` so the sync happens. Accepted aliases are case-insensitive. Issue #299. |
+| `skip_project_data_migration` | `false` | When `true` (or `"on"` / `"yes"` / `1`), skip the entire project-data migration: the scan-history import AND the trailing issue + hotspot sync. Useful when customers cut over to SonarQube Cloud by re-scanning rather than importing historical state. Implies `skip_issue_sync` — there's nothing to sync against. Same FlexibleBool aliases. Issue #303. |
 
 `concurrency` and `timeout` can also be set inside `source` / `target` — those values override the top-level default for that command only.
 
-The CLI flags `--skip-issue-sync` and `--skip-project-data-migration` on `migrate` / `transfer` are the one-way equivalents of the config fields — passing a flag forces the matching opt-out on regardless of the config-file value.
+The CLI flags `--skip_issue_sync` and `--skip_project_data_migration` on `migrate` / `transfer` are the one-way equivalents of the config fields — passing a flag forces the matching opt-out on regardless of the config-file value.
 
 ---
 
@@ -103,7 +103,7 @@ sonar-migration-tool extract [url] [token] [flags]
 | `--target_task <task>` | Run a specific task (with its dependencies). |
 | `--concurrency <n>` | Max concurrent requests. |
 | `--timeout <s>` | Request timeout in seconds. |
-| `--skip-project-data-migration` | Skip the issue / source / SCM-blame extract (extracted by default). |
+| `--skip_project_data_migration` | Skip the issue / source / SCM-blame extract (extracted by default). |
 | `--exclude_branches <pattern>` | Glob pattern for non-main branches to skip during scan history import. Repeatable (pass multiple times for multiple patterns). Main branch is never excluded. |
 | `--pem_file_path <path>` | mTLS PEM file. |
 | `--key_file_path <path>` | mTLS key file. |
@@ -137,8 +137,8 @@ sonar-migration-tool migrate [token] [enterprise_key] [flags]
 | `--run_id <id>` | Resume a failed migration. |
 | `--target_task <task>` | Run a specific migration task (with its dependencies). |
 | `--skip_profiles` | Skip quality profile migration / provisioning. |
-| `--skip-issue-sync` | Skip the final per-issue / per-hotspot metadata sync (#299). One-way: setting this on the CLI forces the sync off, overriding the `skip-issue-sync` config field. |
-| `--skip-project-data-migration` | Skip the entire project-data migration: `importScanHistory` plus the trailing sync pair. Implies `--skip-issue-sync`. One-way override of the `skip-project-data-migration` config field. Issue #303. |
+| `--skip_issue_sync` | Skip the final per-issue / per-hotspot metadata sync (#299). One-way: setting this on the CLI forces the sync off, overriding the `skip_issue_sync` config field. |
+| `--skip_project_data_migration` | Skip the entire project-data migration: `importScanHistory` plus the trailing sync pair. Implies `--skip_issue_sync`. One-way override of the `skip_project_data_migration` config field. Issue #303. |
 | `--exclude_branches <pattern>` | Glob pattern for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
 | `--default_organization <key>` | SonarCloud org applied to every project when `organizations.csv` has no mapping defined. |
 | `--concurrency <n>` | Max concurrent requests. |
@@ -175,22 +175,22 @@ file.
 | Flag | Config key | Description |
 |---|---|---|
 | `-c, --config <path>` | — | Path to JSON configuration file. |
-| `--source-url <url>` | `source.url` | SonarQube Server URL. |
-| `--source-token <token>` | `source.token` | SonarQube Server token. |
-| `--project-key <key>` | — | Project key to transfer (omit to transfer all projects). |
-| `--target-url <url>` | `target.url` | SonarQube Cloud URL. |
-| `--target-token <token>` | `target.token` | SonarQube Cloud token. |
+| `--source_url <url>` | `source.url` | SonarQube Server URL. |
+| `--source_token <token>` | `source.token` | SonarQube Server token. |
+| `--project_key <key>` | — | Project key to transfer (omit to transfer all projects). |
+| `--target_url <url>` | `target.url` | SonarQube Cloud URL. |
+| `--target_token <token>` | `target.token` | SonarQube Cloud token. |
 | `--default_organization <key>` | `target.default_organization` | SonarQube Cloud organization key. |
 | `--enterprise_key <key>` | `target.enterprise_key` | SonarQube Cloud enterprise key (defaults to `--default_organization`). |
-| `--export-dir <dir>` | `export_directory` | Working directory (default `./migration-files/`). |
+| `--export_dir <dir>` | `export_directory` | Working directory (default `./migration-files/`). |
 | `--concurrency <n>` | `concurrency` | Max concurrent HTTP requests. |
 | `--timeout <s>` | `timeout` | HTTP request timeout in seconds. |
 | `--pem_file_path <path>` | `source.pem_file_path` | Client mTLS PEM file. |
 | `--key_file_path <path>` | `source.key_file_path` | Client mTLS key file. |
 | `--cert_password <pw>` | `source.cert_password` | Client mTLS password. |
-| `--skip-issue-sync` | top-level `skip-issue-sync` | Skip the final per-issue / per-hotspot metadata sync (#299). |
-| `--skip-project-data-migration` | top-level `skip-project-data-migration` | Skip the entire project-data migration (importScanHistory + trailing syncs). #303. |
-| `--exclude-branches <pattern>` | `target.exclude_branches` | Glob pattern for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
+| `--skip_issue_sync` | top-level `skip_issue_sync` | Skip the final per-issue / per-hotspot metadata sync (#299). |
+| `--skip_project_data_migration` | top-level `skip_project_data_migration` | Skip the entire project-data migration (importScanHistory + trailing syncs). #303. |
+| `--exclude_branches <pattern>` | `target.exclude_branches` | Glob pattern for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
 
 CLI flags always override the corresponding config-file value.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,7 +124,7 @@ Organized by category in `go/internal/extract/tasks_*.go`:
 - **Templates** — Permission templates, associated groups/users
 - **Views** — Portfolios, applications (Enterprise+ only)
 - **Issues** — Accepted issues, safe hotspots
-- **Scan History** — `getProjectIssuesFull` (issues with comments/tags/flows), `getProjectHotspotsFull` (hotspots with review details), `getProjectVersions` (current project version per branch via `/api/navigation/component`), component trees (using `FIL,UTS` qualifiers for files and unit test source files), source code, SCM data. External issues (ruff, pylint, flake8, etc.) are extracted alongside native issues. Runs by default; skipped when `--skip-project-data-migration` is set.
+- **Scan History** — `getProjectIssuesFull` (issues with comments/tags/flows), `getProjectHotspotsFull` (hotspots with review details), `getProjectVersions` (current project version per branch via `/api/navigation/component`), component trees (using `FIL,UTS` qualifiers for files and unit test source files), source code, SCM data. External issues (ruff, pylint, flake8, etc.) are extracted alongside native issues. Runs by default; skipped when `--skip_project_data_migration` is set.
 - **Webhooks** — Global and project-level webhooks
 
 ### Migrate Tasks (44+ tasks)
@@ -138,8 +138,8 @@ Organized by category in `go/internal/migrate/tasks_*.go`:
 - **Rules** — Custom rule activation
 - **ALM** — DevOps platform binding detection
 - **Scan History** — Import scan reports via reconstructed protobuf format (native issues, external issues via ExternalIssue protobuf, hotspots mapped to issues). BackdateChangesets mechanism preserves original issue creation dates; external issues are included in changeset backdating alongside native issues. Project version (`sonar.projectVersion`) is migrated from SonarQube Server to SonarQube Cloud: the extracted version is set in both the protobuf metadata and the CE submit form, falling back to `"1.0.0"` if unavailable (matching CloudVoyager behavior). Harvested from CloudVoyager's `resolve-source-project-version.js`. **Multi-branch handling:** Branches are sorted main-first via `sortBranchesMainFirst()`, then imported in two phases — (1) main branch import + CE wait for SUCCESS, (2) parallel non-main branch imports. If the main branch CE task fails, all non-main branches are skipped. Supports `ExcludeBranches` glob patterns to skip non-main branches, and per-branch checkpoint/resume via `loadCompletedBranches()`/`shouldSkipBranch()`. Project-level concurrency uses `errgroup.WithContext` + `SetLimit`.
-- **Issue Metadata Sync** — `syncIssueMetadata`: two-phase task that waits for Cloud indexing, matches source→cloud issues by composite key (rule|filePath|line), then syncs status transitions (with fallback transition paths), comments, and tags per matched pair. Idempotent via `metadata-synchronized` tag. Runs by default; skipped when `--skip-project-data-migration` is set.
-- **Hotspot Metadata Sync** — `syncHotspotMetadata`: same two-phase pattern, matches source→cloud hotspots by composite key, syncs REVIEWED status/resolution and comments. Idempotent. Runs by default; skipped when `--skip-project-data-migration` is set.
+- **Issue Metadata Sync** — `syncIssueMetadata`: two-phase task that waits for Cloud indexing, matches source→cloud issues by composite key (rule|filePath|line), then syncs status transitions (with fallback transition paths), comments, and tags per matched pair. Idempotent via `metadata-synchronized` tag. Runs by default; skipped when `--skip_project_data_migration` is set.
+- **Hotspot Metadata Sync** — `syncHotspotMetadata`: same two-phase pattern, matches source→cloud hotspots by composite key, syncs REVIEWED status/resolution and comments. Idempotent. Runs by default; skipped when `--skip_project_data_migration` is set.
 - **Global Settings** — Migrates only SQS-supported settings; `sonar.dbcleaner.branchesToKeepWhenInactive` is migrated as a regex on SonarQube Cloud
 - **Delete/Reset** — Cleanup tasks for the `reset` command
 
@@ -221,7 +221,7 @@ All four pipelines implement the `Pipeline` interface; compile-time checks (`var
 
 `go/cmd/transfer.go` provides a single-command migration path that chains the four
 manual phases automatically so users never touch a CSV file. Flag names are defined
-as package-level constants (e.g. `flagSourceURL = "source-url"`) to avoid duplicated
+as package-level constants (e.g. `flagSourceURL = "source_url"`) to avoid duplicated
 string literals. Config resolution is handled by `resolveTransferConfig()` — it calls
 `loadTransferFileDefaults()` (which reuses `extract.LoadExtractConfigFile` and
 `migrate.LoadMigrateConfigFile` so transfer accepts the same unified config shape as
@@ -232,12 +232,12 @@ the other actions, issue #295) and then applies CLI overrides via
 ```bash
 # Flags
 sonar-migration-tool transfer \
-  --source-url https://sonarqube.example.com --source-token sqp_xxx \
-  --project-key my-project \
-  --target-token squ_xxx --default_organization my-org
+  --source_url https://sonarqube.example.com --source_token sqp_xxx \
+  --project_key my-project \
+  --target_token squ_xxx --default_organization my-org
 
 # Config file
-sonar-migration-tool transfer -c config.json --project-key my-project
+sonar-migration-tool transfer -c config.json --project_key my-project
 ```
 
 **config.json** (same unified shape as `extract` / `migrate`):
@@ -249,13 +249,13 @@ sonar-migration-tool transfer -c config.json --project-key my-project
 }
 ```
 
-`--project-key` is optional and lives on the CLI only. When provided, the
+`--project_key` is optional and lives on the CLI only. When provided, the
 `/api/projects/search` call is filtered server-side via the `projects=` param, so only
 the target project and its data are extracted. When omitted, all projects on the server
 are migrated.
 
 **Execution sequence:**
-1. `extract.RunExtract` — sets `ExtractConfig.ProjectKeys` when `--project-key` is given
+1. `extract.RunExtract` — sets `ExtractConfig.ProjectKeys` when `--project_key` is given
 2. `structure.RunStructure(dir, defaultOrg)` — pre-populates `sonarcloud_org_key` in organizations.csv
 3. `structure.RunMappings(dir)` — generates gates/profiles/groups/templates CSVs
 4. `migrate.RunMigrate` — pushes everything to SonarQube Cloud
@@ -355,7 +355,7 @@ See [roadmap/README.md](../roadmap/README.md) for the full spec index, dependenc
 ### Issue #102: Project Version Migration
 <!-- updated: 2026-06-04_15:30:00 -->
 
-The migration tool now migrates `sonar.projectVersion` from SonarQube Server to SonarQube Cloud during scan history import. The `getProjectVersions` extract task fetches the current project version per branch via `/api/navigation/component`. During scan history import, the extracted version is passed to both the protobuf metadata and the CE submit form. Falls back to `"1.0.0"` if the version is not available (matching CloudVoyager behavior). This feature was harvested from CloudVoyager's `resolve-source-project-version.js`. Runs by default; skipped when `--skip-project-data-migration` is set.
+The migration tool now migrates `sonar.projectVersion` from SonarQube Server to SonarQube Cloud during scan history import. The `getProjectVersions` extract task fetches the current project version per branch via `/api/navigation/component`. During scan history import, the extracted version is passed to both the protobuf metadata and the CE submit form. Falls back to `"1.0.0"` if the version is not available (matching CloudVoyager behavior). This feature was harvested from CloudVoyager's `resolve-source-project-version.js`. Runs by default; skipped when `--skip_project_data_migration` is set.
 
 ### Issue #104: Migrate All Issues (Implementation Status)
 <!-- updated: 2026-06-04_15:30:00 -->

--- a/docs/CLOUDVOYAGER-DELTA.md
+++ b/docs/CLOUDVOYAGER-DELTA.md
@@ -287,7 +287,7 @@ or absent after migration — only live scans will populate them.
 
 2. **BUG-16b+c (Critical/High): No CE gate between main and non-main branches** — `importProjectBranches` was restructured into two phases: (1) import the main branch first and wait for CE SUCCESS, (2) only then import non-main branches. If the main branch CE task fails, all non-main branches are marked "skipped" and the project is aborted. This matches CloudVoyager's sequencing behavior.
 
-3. **BUG-16d (Medium): No branch filtering** — Added `ExcludeBranches` config option (glob patterns via `filepath.Match`) to skip non-main branches during scan history import. Available as `--exclude-branches` CLI flag and `exclude_branches` JSON config key. The main branch is never excluded regardless of patterns.
+3. **BUG-16d (Medium): No branch filtering** — Added `ExcludeBranches` config option (glob patterns via `filepath.Match`) to skip non-main branches during scan history import. Available as `--exclude_branches` CLI flag and `exclude_branches` JSON config key. The main branch is never excluded regardless of patterns.
 
 4. **BUG-16e (Medium): No per-branch checkpoint/resume** — Added `loadCompletedBranches()` and `shouldSkipBranch()` to read existing `importScanHistory` results and skip branches that already succeeded on resume. Previously, resuming a failed run would re-import branches that had already completed successfully.
 
@@ -484,7 +484,7 @@ pattern.
 ### ~~FEAT-10: `--url` default silently targets production~~ **[FIXED]**
 <!-- updated: 2026-06-04_01:14:00.000 by Claude -->
 
-**Status**: FIXED — `--target-url` flag was added to the transfer command (renamed from `--sc-url` in #295). The default no longer silently targets production. Users can pass `--target-url https://sc-staging.io` for staging.
+**Status**: FIXED — `--target_url` flag was added to the transfer command (renamed from `--sc-url` in #295). The default no longer silently targets production. Users can pass `--target_url https://sc-staging.io` for staging.
 
 ~~**File**: [go/internal/migrate/migrate.go:190](../go/internal/migrate/migrate.go#L190)~~
 
@@ -600,14 +600,14 @@ systematic wrong dates for projects with multiple issues of the same rule.~~
 | FEAT-08a | ~~P2~~ **FIXED** | Scan History | ~~No project version migration~~ Fixed: Issue #102, harvested from CloudVoyager's `resolve-source-project-version.js` |
 | FEAT-08 | P3 | CLI | No incremental transfer mode |
 | FEAT-09 | P2 | Issue Sync | `syncIssueMetadata` writes no per-project output file |
-| FEAT-10 | ~~P2~~ **FIXED** | CLI | ~~`--url` default silently targets production~~ Fixed: `--target-url` flag added to transfer command (renamed from `--sc-url` in #295) |
+| FEAT-10 | ~~P2~~ **FIXED** | CLI | ~~`--url` default silently targets production~~ Fixed: `--target_url` flag added to transfer command (renamed from `--sc-url` in #295) |
 | BUG-12 | P1 | Extract | `getActiveProfileRules` missing from scan-history-only extract |
 | BUG-13 | P2 | Scan History | Analysis date is migration time, not extraction timestamp |
 | BUG-14 | P3 | Hotspot Sync | No inter-comment delay for rate-limit protection |
 | BUG-15 | ~~P1~~ **FIXED** | Scan History | ~~`toExtractedIssues` date map uses wrong key~~ Fixed in commits `e769b95`/`21d74e8` (PR #291) |
 | BUG-16a | ~~P0~~ **FIXED** | Scan History | ~~Main branch not guaranteed first in multi-branch import~~ Fixed: `sortBranchesMainFirst()` |
 | BUG-16b+c | ~~P0~~ **FIXED** | Scan History | ~~No CE gate between main and non-main branch imports~~ Fixed: two-phase import with CE wait |
-| BUG-16d | ~~P1~~ **FIXED** | Scan History | ~~No branch filtering support~~ Fixed: `--exclude-branches` glob patterns |
+| BUG-16d | ~~P1~~ **FIXED** | Scan History | ~~No branch filtering support~~ Fixed: `--exclude_branches` glob patterns |
 | BUG-16e | ~~P1~~ **FIXED** | Scan History | ~~No per-branch checkpoint/resume~~ Fixed: `loadCompletedBranches()` + `shouldSkipBranch()` |
 | BUG-16f | ~~P1~~ **FIXED** | Scan History | ~~Project-level concurrency not properly managed~~ Fixed: `errgroup.WithContext` + `SetLimit` |
 
@@ -625,7 +625,7 @@ systematic wrong dates for projects with multiple issues of the same rule.~~
 7. **BUG-06** — Add source-link comments to both issue and hotspot sync
 8. **FEAT-09** — Add per-project output file to `syncIssueMetadata`
 9. **BUG-12** — Add `getActiveProfileRules` to scan-history extract task list
-10. ~~**FEAT-10**~~ — ~~Add URL default warning~~ **DONE** (`--target-url` flag added to transfer command (renamed from `--sc-url` in #295))
+10. ~~**FEAT-10**~~ — ~~Add URL default warning~~ **DONE** (`--target_url` flag added to transfer command (renamed from `--sc-url` in #295))
 11. **FEAT-05** — Add CE submission retry
 12. **BUG-13** — Use extraction timestamp for analysis date
 13. **FEAT-02** — Extract issue changelog data

--- a/docs/MIGRATE.md
+++ b/docs/MIGRATE.md
@@ -120,7 +120,7 @@ sonar-migration-tool extract <URL> <TOKEN> --export_directory ./files/ [--concur
 | `--timeout` | Request timeout in seconds |
 | `--extract_type` | Type of extract to run |
 | `--export_directory` | Output directory (default: `./migration-files`) |
-| `--skip-project-data-migration` | Skip the issue / source / SCM-blame extract (project data is extracted by default) |
+| `--skip_project_data_migration` | Skip the issue / source / SCM-blame extract (project data is extracted by default) |
 | `--pem_file_path` | Client certificate PEM file (mTLS) |
 | `--key_file_path` | Client certificate key file (mTLS) |
 | `--cert_password` | Client certificate password (mTLS) |

--- a/docs/PLAN-FIX-106.md
+++ b/docs/PLAN-FIX-106.md
@@ -289,7 +289,7 @@ Step 3 (migrate loader) ───┘
 
 ## Backward Compatibility
 
-- **No config changes** — measures are automatically included as part of the project-data extract (default; opt-out via `--skip-project-data-migration`)
+- **No config changes** — measures are automatically included as part of the project-data extract (default; opt-out via `--skip_project_data_migration`)
 - **No new CLI flags** — the metric key set is determined by the source SQ version
 - **Graceful with old extracts** — if component tree data lacks measures (extracted before this change), the measures map stays empty (identical to current behavior)
 - **No new extract tasks** — reuses existing `getProjectComponentTree` task, just requests more data

--- a/docs/REGRESSION-TESTING-PLAN.md
+++ b/docs/REGRESSION-TESTING-PLAN.md
@@ -4,7 +4,7 @@
 After any fix or feature, run **both** migration paths against real SonarQube Server and SonarCloud instances, then verify **everything** migrated correctly. "Everything" means: projects, issues (all statuses/severities/types/resolutions), hotspots, quality profiles, quality gates, groups, permission templates, settings, new code periods, custom rules, project permissions, ALM bindings, portfolios, measures, and extract file integrity.
 
 Both paths must be tested because they exercise different code paths:
-- **Transfer** (`transfer`) — single-command, auto-populates CSVs, targets one project via `--project-key`
+- **Transfer** (`transfer`) — single-command, auto-populates CSVs, targets one project via `--project_key`
 - **Full migration** (`extract` → `structure` → `mappings` → `migrate`) — multi-step, manual CSV review, migrates all projects
 
 ---
@@ -42,7 +42,7 @@ Tests the `transfer` command, which chains extract → structure → mappings �
 ### A2. Run transfer
 ```bash
 rm -rf ./migration-files/
-./sonar-migration-tool transfer --config transfer-config.json --project-key <PROJECT_KEY> 2>&1 | tee /tmp/smt-transfer.log
+./sonar-migration-tool transfer --config transfer-config.json --project_key <PROJECT_KEY> 2>&1 | tee /tmp/smt-transfer.log
 ```
 Must exit 0. If not, inspect the log and fix.
 

--- a/docs/TRANSFER.md
+++ b/docs/TRANSFER.md
@@ -128,22 +128,22 @@ Full form:
 ```bash
 # From source
 cd go && go run . transfer \
-  --source-url https://sonarqube.example.com \
-  --source-token sqp_xxx \
-  --project-key my-project \
-  --target-token squ_xxx \
+  --source_url https://sonarqube.example.com \
+  --source_token sqp_xxx \
+  --project_key my-project \
+  --target_token squ_xxx \
   --default_organization my-org
 
 # Built binary
 sonar-migration-tool transfer \
-  --source-url https://sonarqube.example.com \
-  --source-token sqp_xxx \
-  --project-key my-project \
-  --target-token squ_xxx \
+  --source_url https://sonarqube.example.com \
+  --source_token sqp_xxx \
+  --project_key my-project \
+  --target_token squ_xxx \
   --default_organization my-org
 ```
 
-Omit `--project-key` to transfer **every** project visible to the token (in which case the rest of the manual workflow applies — see [MIGRATE.md](MIGRATE.md) for the per-project `organizations.csv` mapping step).
+Omit `--project_key` to transfer **every** project visible to the token (in which case the rest of the manual workflow applies — see [MIGRATE.md](MIGRATE.md) for the per-project `organizations.csv` mapping step).
 
 ---
 
@@ -152,21 +152,21 @@ Omit `--project-key` to transfer **every** project visible to the token (in whic
 | Flag | Config key | Description |
 |------|------------|-------------|
 | `-c, --config` | — | Path to a JSON configuration file (see [ADVANCED-CONFIG.md](ADVANCED-CONFIG.md)) |
-| `--source-url` | `source.url` | SonarQube Server URL |
-| `--source-token` | `source.token` | SonarQube Server token |
-| `--project-key` | `project_key` | Project key to transfer. Omit to transfer every project visible to the token. |
-| `--target-url` | `target.url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
-| `--target-token` | `target.token` | SonarQube Cloud token |
+| `--source_url` | `source.url` | SonarQube Server URL |
+| `--source_token` | `source.token` | SonarQube Server token |
+| `--project_key` | `project_key` | Project key to transfer. Omit to transfer every project visible to the token. |
+| `--target_url` | `target.url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
+| `--target_token` | `target.token` | SonarQube Cloud token |
 | `--default_organization` | `target.default_organization` | SonarQube Cloud organization key |
 | `--enterprise_key` | `target.enterprise_key` | SonarQube Cloud enterprise key (defaults to `--default_organization`) |
-| `--export-dir` | `export_directory` | Working directory for intermediate files (default: `./migration-files/`) |
+| `--export_dir` | `export_directory` | Working directory for intermediate files (default: `./migration-files/`) |
 | `--concurrency` | `concurrency` | Max concurrent HTTP requests (default: `25`) |
 | `--timeout` | `timeout` | HTTP request timeout in seconds |
 | `--pem_file_path` | `source.pem_file_path` | Client mTLS PEM file for the source server |
 | `--key_file_path` | `source.key_file_path` | Client mTLS key file for the source server |
 | `--cert_password` | `source.cert_password` | Password for the source server mTLS client certificate |
-| `--skip-project-data-migration` | top-level `skip-project-data-migration` | Skip the project-data migration (importScanHistory + per-issue / per-hotspot sync). Defaults to off — scan history is migrated by default. Issue #303. |
-| `--exclude-branches` | `target.exclude_branches` | Glob patterns for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
+| `--skip_project_data_migration` | top-level `skip_project_data_migration` | Skip the project-data migration (importScanHistory + per-issue / per-hotspot sync). Defaults to off — scan history is migrated by default. Issue #303. |
+| `--exclude_branches` | `target.exclude_branches` | Glob patterns for non-main branches to skip during scan history import. Repeatable. Main branch is never excluded. |
 
 CLI flags override values from the config file when both are provided.
 
@@ -174,7 +174,7 @@ CLI flags override values from the config file when both are provided.
 
 ## Output
 
-- **Intermediate files** — written to `--export-dir` (default `./migration-files/`). Same files as the manual workflow: `organizations.csv`, `gates.csv`, `profiles.csv`, `groups.csv`, `templates.csv`, `portfolios.csv`.
+- **Intermediate files** — written to `--export_dir` (default `./migration-files/`). Same files as the manual workflow: `organizations.csv`, `gates.csv`, `profiles.csv`, `groups.csv`, `templates.csv`, `portfolios.csv`.
 - **PDF summary** — written to the export directory on successful completion.
 - **Stdout** — every command prints `See sonar-migration-tool output results in <directory>` when it finishes so you always know where to look.
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -281,11 +281,11 @@ The tool automatically handles this: it sorts branches so the main branch is alw
 
 ### Excluding branches from migration
 
-Use the `--exclude-branches` flag (or `exclude_branches` in the JSON config) to skip specific non-main branches during scan history import. This accepts glob patterns compatible with Go's `filepath.Match`:
+Use the `--exclude_branches` flag (or `exclude_branches` in the JSON config) to skip specific non-main branches during scan history import. This accepts glob patterns compatible with Go's `filepath.Match`:
 
 ```bash
 # Exclude all feature branches and release branches
-sonar-migration-tool migrate ... --exclude-branches "feature/*" --exclude-branches "release/*"
+sonar-migration-tool migrate ... --exclude_branches "feature/*" --exclude_branches "release/*"
 
 # Or in config.json
 {

--- a/examples/config-migrate.example.json
+++ b/examples/config-migrate.example.json
@@ -4,6 +4,6 @@
   "url": "https://sonarcloud.io/",
   "export_directory": "./files",
   "concurrency": 10,
-  "skip-issue-sync": false,
-  "skip-project-data-migration": false
+  "skip_issue_sync": false,
+  "skip_project_data_migration": false
 }

--- a/examples/config-transfer.example.json
+++ b/examples/config-transfer.example.json
@@ -2,8 +2,8 @@
   "concurrency": 10,
   "timeout": 60,
   "export_directory": "./migration-files",
-  "skip-issue-sync": false,
-  "skip-project-data-migration": false,
+  "skip_issue_sync": false,
+  "skip_project_data_migration": false,
   "project_key": "my-project-key",
   "source": {
     "url": "https://sonarqube.example.com",

--- a/examples/config.example.json
+++ b/examples/config.example.json
@@ -25,7 +25,7 @@
     "concurrency": 10,
     "run_id": null,
     "target_task": null,
-    "skip-issue-sync": false,
-    "skip-project-data-migration": false
+    "skip_issue_sync": false,
+    "skip_project_data_migration": false
   }
 }

--- a/examples/config.unified.example.json
+++ b/examples/config.unified.example.json
@@ -2,8 +2,8 @@
   "concurrency": 10,
   "timeout": 60,
   "export_directory": "./migration-files",
-  "skip-issue-sync": false,
-  "skip-project-data-migration": false,
+  "skip_issue_sync": false,
+  "skip_project_data_migration": false,
   "source": {
     "url": "https://sonarqube.example.com",
     "token": "squ_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",

--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -88,8 +88,8 @@ func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfi
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	overrideInt(cmd, "timeout", &cfg.Timeout)
 	// Project data is extracted by default. The only opt-out is
-	// SkipProjectDataMigration (CLI --skip-project-data-migration or
-	// config "skip-project-data-migration": true). CLI flag wins over
+	// SkipProjectDataMigration (CLI --skip_project_data_migration or
+	// config "skip_project_data_migration": true). CLI flag wins over
 	// config; one-way (passing the flag forces opt-out).
 	if cmd.Flags().Changed(flagSkipProjectDataMigration) {
 		v, _ := cmd.Flags().GetBool(flagSkipProjectDataMigration)

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -51,7 +51,7 @@ func init() {
 	f.String("export_directory", "", "Root directory containing all SonarQube exports")
 	f.String("target_task", "", "Name of a specific migration task to complete")
 	f.Bool("skip_profiles", false, "Skip quality profile migration/provisioning in SonarQube Cloud")
-	f.Bool("skip-issue-sync", false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip-issue-sync config-file field — defaults to false (sync happens); pass the flag to skip.")
+	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importScanHistory and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.String("default_organization", "", "SonarQube Cloud organization to migrate every project into when organizations.csv has no mapping defined. Ignored if any mapping is present.")
 	f.StringSlice("exclude_branches", nil, "Glob patterns for non-main branches to skip during scan history import (e.g. feature/*,bugfix/*)")
@@ -90,17 +90,17 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	if cmd.Flags().Changed("skip_profiles") {
 		cfg.SkipProfiles, _ = cmd.Flags().GetBool("skip_profiles")
 	}
-	// --skip-issue-sync explicitly turns off the trailing sync. The
-	// flag always wins over the config-file skip-issue-sync field.
-	// One-way: --skip-issue-sync=false on the CLI does NOT undo a
-	// config-file skip-issue-sync: true.
-	if cmd.Flags().Changed("skip-issue-sync") {
-		v, _ := cmd.Flags().GetBool("skip-issue-sync")
+	// --skip_issue_sync explicitly turns off the trailing sync. The
+	// flag always wins over the config-file skip_issue_sync field.
+	// One-way: --skip_issue_sync=false on the CLI does NOT undo a
+	// config-file skip_issue_sync: true.
+	if cmd.Flags().Changed(flagSkipIssueSync) {
+		v, _ := cmd.Flags().GetBool(flagSkipIssueSync)
 		if v {
 			cfg.SkipIssueSync = true
 		}
 	}
-	// --skip-project-data-migration is the wider opt-out: it covers
+	// --skip_project_data_migration is the wider opt-out: it covers
 	// importScanHistory AND the trailing sync pair. Same one-way
 	// override semantics. #303.
 	if cmd.Flags().Changed(flagSkipProjectDataMigration) {

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -25,23 +25,23 @@ const (
 	scCloudName  = "SonarQube Cloud"
 
 	flagConfig             = "config"
-	flagSourceURL          = "source-url"
-	flagSourceToken        = "source-token"
-	flagProjectKey         = "project-key"
-	flagTargetURL          = "target-url"
-	flagTargetToken        = "target-token"
+	flagSourceURL          = "source_url"
+	flagSourceToken        = "source_token"
+	flagProjectKey         = "project_key"
+	flagTargetURL          = "target_url"
+	flagTargetToken        = "target_token"
 	flagEnterpriseKey      = "enterprise_key"
 	flagDefaultOrg         = "default_organization"
-	flagExportDir                = "export-dir"
-	flagSkipIssueSync            = "skip-issue-sync"
-	flagSkipProjectDataMigration = "skip-project-data-migration"
+	flagExportDir                = "export_dir"
+	flagSkipIssueSync            = "skip_issue_sync"
+	flagSkipProjectDataMigration = "skip_project_data_migration"
 	flagConcurrency              = "concurrency"
 	flagTimeout            = "timeout"
 	flagPEMFilePath        = "pem_file_path"
 	flagKeyFilePath        = "key_file_path"
 	flagCertPassword       = "cert_password"
 	flagDebug              = "debug"
-	flagExcludeBranches    = "exclude-branches"
+	flagExcludeBranches    = "exclude_branches"
 )
 
 // transferTargetTasks is the explicit set of project-scoped "leaf" migrate
@@ -96,14 +96,14 @@ default gate/profile selection are not modified; use the migrate command for
 a full instance migration.
 
 Issue and hotspot scan history is always extracted and imported for transfer
-unless --skip-project-data-migration is passed.
+unless --skip_project_data_migration is passed.
 
 Example (flags):
   sonar-migration-tool transfer \
-    --source-url https://sonarqube.example.com \
-    --source-token sqp_xxx \
-    --project-key my-project \
-    --target-token squ_xxx \
+    --source_url https://sonarqube.example.com \
+    --source_token sqp_xxx \
+    --project_key my-project \
+    --target_token squ_xxx \
     --default_organization my-org
 
 Example (config file):
@@ -152,7 +152,7 @@ func init() {
 	f.String(flagDefaultOrg, "", scCloudName+" organization key (maps to target.default_organization)")
 	f.String(flagEnterpriseKey, "", scCloudName+" enterprise key (maps to target.enterprise_key, defaults to --"+flagDefaultOrg+")")
 	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
-	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip-issue-sync config-file field — defaults to false (sync happens); pass the flag to skip.")
+	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importScanHistory and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
 	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout)")
@@ -296,17 +296,17 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 	applyFlagString(cmd, flagPEMFilePath, &cfg.pemFilePath)
 	applyFlagString(cmd, flagKeyFilePath, &cfg.keyFilePath)
 	applyFlagString(cmd, flagCertPassword, &cfg.certPassword)
-	// --skip-issue-sync is one-way: explicit true on the CLI sets
+	// --skip_issue_sync is one-way: explicit true on the CLI sets
 	// skipIssueSync, but the absence of the flag does NOT undo a
-	// config-file skip-issue-sync: true.
+	// config-file skip_issue_sync: true.
 	if cmd.Flags().Changed(flagSkipIssueSync) {
 		v, _ := cmd.Flags().GetBool(flagSkipIssueSync)
 		if v {
 			cfg.skipIssueSync = true
 		}
 	}
-	// --skip-project-data-migration is the wider opt-out. Same
-	// one-way semantics as --skip-issue-sync. #303.
+	// --skip_project_data_migration is the wider opt-out. Same
+	// one-way semantics as --skip_issue_sync. #303.
 	if cmd.Flags().Changed(flagSkipProjectDataMigration) {
 		v, _ := cmd.Flags().GetBool(flagSkipProjectDataMigration)
 		if v {
@@ -410,7 +410,7 @@ func runTransferExtract(ctx context.Context, cfg transferConfig) ([]string, erro
 		// Transfer extracts the project's issues and hotspots so the
 		// downstream migrate phase can replay them. Only skipped when
 		// the operator opts out of project-data migration entirely
-		// via --skip-project-data-migration.
+		// via --skip_project_data_migration.
 		IncludeScanHistory: !cfg.skipProjectDataMigration,
 		Debug:              cfg.debug,
 	})

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -125,13 +125,13 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 	cmd := newTransferTestCmd()
 	args := []string{
 		"-c", path,
-		"--source-url", "https://cli-source",
-		"--source-token", "cli-source-tok",
-		"--target-url", "https://cli-target",
-		"--target-token", "cli-target-tok",
+		"--source_url", "https://cli-source",
+		"--source_token", "cli-source-tok",
+		"--target_url", "https://cli-target",
+		"--target_token", "cli-target-tok",
 		"--default_organization", "cli-org",
 		"--enterprise_key", "cli-ent",
-		"--export-dir", "/tmp/cli",
+		"--export_dir", "/tmp/cli",
 		"--concurrency", "11",
 		"--timeout", "99",
 		"--pem_file_path", "/cli/pem",
@@ -177,9 +177,9 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 func TestResolveTransferConfig_EnterpriseKeyDefaultsToOrg(t *testing.T) {
 	cmd := newTransferTestCmd()
 	if err := cmd.ParseFlags([]string{
-		"--source-url", "https://sq",
-		"--source-token", "tok",
-		"--target-token", "ct",
+		"--source_url", "https://sq",
+		"--source_token", "tok",
+		"--target_token", "ct",
 		"--default_organization", "my-org",
 	}); err != nil {
 		t.Fatal(err)
@@ -194,7 +194,7 @@ func TestResolveTransferConfig_EnterpriseKeyDefaultsToOrg(t *testing.T) {
 }
 
 // Validation must error if either side is missing credentials, with a
-// message that names the new --source-* / --target-* flags so users
+// message that names the new --source_* / --target_* flags so users
 // aren't pointed at the retired --sq-* / --sc-* names.
 func TestValidateTransferConfig_MissingCredentials(t *testing.T) {
 	cases := []struct {

--- a/go/internal/extract/config_file.go
+++ b/go/internal/extract/config_file.go
@@ -39,7 +39,7 @@ type configFileShape struct {
 	Timeout            int    `json:"timeout"`
 	ExtractID                string `json:"extract_id"`
 	TargetTask               string `json:"target_task"`
-	SkipProjectDataMigration bool   `json:"skip-project-data-migration"`
+	SkipProjectDataMigration bool   `json:"skip_project_data_migration"`
 
 	// Shape 2 (command-sectioned).
 	Extract *configFileShape `json:"extract"`
@@ -148,7 +148,7 @@ func (s configFileShape) toExtractConfig() ExtractConfig {
 			cfg.Timeout = s.Timeout
 		}
 		cfg.ExportDirectory = s.ExportDirectory
-		// #303: top-level skip-project-data-migration drives whether
+		// #303: top-level skip_project_data_migration drives whether
 		// the extract pulls issue / source / SCM-blame data.
 		cfg.SkipProjectDataMigration = s.SkipProjectDataMigration
 	case s.SonarQube != nil:

--- a/go/internal/extract/config_file_test.go
+++ b/go/internal/extract/config_file_test.go
@@ -91,7 +91,7 @@ func TestLoadExtractConfigFileSnakeCaseFields(t *testing.T) {
 		"timeout": 90,
 		"extract_id": "resume-me",
 		"target_task": "getRules",
-		"skip-project-data-migration": true
+		"skip_project_data_migration": true
 	}`)
 	f.Close()
 

--- a/go/internal/extract/planner.go
+++ b/go/internal/extract/planner.go
@@ -95,7 +95,7 @@ func RegisterAll() []TaskDef {
 
 // scanHistoryTaskNames lists task names that pull issue, source-code,
 // SCM-blame, and version data — extracted by default and dropped only
-// when --skip-project-data-migration is set.
+// when --skip_project_data_migration is set.
 var scanHistoryTaskNames = map[string]bool{
 	"getProjectIssuesFull":    true,
 	"getProjectComponentTree": true,

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -38,13 +38,13 @@ type configFileShape struct {
 	// Defaults to false (sync happens); set to true (or on / yes) to
 	// skip the sync. Pointer + custom unmarshaller so we can
 	// distinguish "absent" from "explicit false".
-	SkipIssueSync *FlexibleBool `json:"skip-issue-sync"`
+	SkipIssueSync *FlexibleBool `json:"skip_issue_sync"`
 	// SkipProjectDataMigration disables the entire project-data import:
 	// importScanHistory plus the trailing issue + hotspot syncs (#303).
 	// Defaults to false (data is migrated). Setting true (or on/yes)
 	// implies SkipIssueSync — there's nothing to sync against. Same
-	// FlexibleBool semantics as skip-issue-sync.
-	SkipProjectDataMigration *FlexibleBool `json:"skip-project-data-migration"`
+	// FlexibleBool semantics as skip_issue_sync.
+	SkipProjectDataMigration *FlexibleBool `json:"skip_project_data_migration"`
 	Debug                    bool          `json:"debug"`
 	ExcludeBranches          []string      `json:"exclude_branches"`
 
@@ -166,7 +166,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			cfg.Concurrency = s.Concurrency
 		}
 		cfg.ExportDirectory = s.ExportDirectory
-		// Top-level skip-issue-sync applies to every shape (#299).
+		// Top-level skip_issue_sync applies to every shape (#299).
 		// The field name matches the MigrateConfig field one-for-one
 		// so there's no inversion.
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
@@ -187,7 +187,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		return cfg
 	case s.Migrate != nil:
 		cfg := s.Migrate.toMigrateConfig()
-		// Outer-level skip-issue-sync wins when both outer and inner
+		// Outer-level skip_issue_sync wins when both outer and inner
 		// set it (#299). If only outer is set, propagate it down.
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -202,7 +202,7 @@ func TestLoadMigrateConfigFileUnifiedShape(t *testing.T) {
 	}
 }
 
-// Issue #299: top-level `skip-issue-sync` parses into
+// Issue #299: top-level `skip_issue_sync` parses into
 // MigrateConfig.SkipIssueSync one-for-one (no inversion). Defaults to
 // false (sync happens). Verifies every accepted alias from the
 // FlexibleBool type plus case variations.
@@ -213,14 +213,14 @@ func TestLoadMigrateConfigFile_SkipIssueSync(t *testing.T) {
 		wantSkip  bool
 	}{
 		{"absent (default)", "", false},
-		{"true", `"skip-issue-sync": true,`, true},
-		{"false", `"skip-issue-sync": false,`, false},
-		{"string on", `"skip-issue-sync": "on",`, true},
-		{"string off", `"skip-issue-sync": "OFF",`, false},
-		{"string yes", `"skip-issue-sync": "Yes",`, true},
-		{"string no", `"skip-issue-sync": "no",`, false},
-		{"numeric 1", `"skip-issue-sync": 1,`, true},
-		{"numeric 0", `"skip-issue-sync": 0,`, false},
+		{"true", `"skip_issue_sync": true,`, true},
+		{"false", `"skip_issue_sync": false,`, false},
+		{"string on", `"skip_issue_sync": "on",`, true},
+		{"string off", `"skip_issue_sync": "OFF",`, false},
+		{"string yes", `"skip_issue_sync": "Yes",`, true},
+		{"string no", `"skip_issue_sync": "no",`, false},
+		{"numeric 1", `"skip_issue_sync": 1,`, true},
+		{"numeric 0", `"skip_issue_sync": 0,`, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -232,7 +232,7 @@ func TestLoadMigrateConfigFile_SkipIssueSync(t *testing.T) {
   }
 }`
 			dir := t.TempDir()
-			path := dir + "/skip-issue-sync.json"
+			path := dir + "/skip_issue_sync.json"
 			if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 				t.Fatal(err)
 			}
@@ -313,7 +313,7 @@ func TestLoadResetConfigFileUnifiedShape(t *testing.T) {
 	}
 }
 
-// Issue #303: top-level `skip-project-data-migration` parses into
+// Issue #303: top-level `skip_project_data_migration` parses into
 // MigrateConfig.SkipProjectDataMigration one-for-one (no inversion).
 // Defaults to false (data is migrated). Every FlexibleBool alias is
 // accepted, case-insensitive.
@@ -324,13 +324,13 @@ func TestLoadMigrateConfigFile_SkipProjectDataMigration(t *testing.T) {
 		wantSkip  bool
 	}{
 		{"absent (default)", "", false},
-		{"true", `"skip-project-data-migration": true,`, true},
-		{"false", `"skip-project-data-migration": false,`, false},
-		{"string on", `"skip-project-data-migration": "on",`, true},
-		{"string OFF", `"skip-project-data-migration": "OFF",`, false},
-		{"string Yes", `"skip-project-data-migration": "Yes",`, true},
-		{"numeric 1", `"skip-project-data-migration": 1,`, true},
-		{"numeric 0", `"skip-project-data-migration": 0,`, false},
+		{"true", `"skip_project_data_migration": true,`, true},
+		{"false", `"skip_project_data_migration": false,`, false},
+		{"string on", `"skip_project_data_migration": "on",`, true},
+		{"string OFF", `"skip_project_data_migration": "OFF",`, false},
+		{"string Yes", `"skip_project_data_migration": "Yes",`, true},
+		{"numeric 1", `"skip_project_data_migration": 1,`, true},
+		{"numeric 0", `"skip_project_data_migration": 0,`, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -159,7 +159,7 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (string, error) {
 	}
 
 	// Announce the skipped sync tasks explicitly so an operator who
-	// passed --skip-issue-sync (or set skip-issue-sync: true in the
+	// passed --skip_issue_sync (or set skip_issue_sync: true in the
 	// config) sees them named in the log alongside the rest of the
 	// plan. The gating itself happens inside MigrateTargetTasks. #299.
 	if cfg.SkipIssueSync {

--- a/go/internal/migrate/migrate_test.go
+++ b/go/internal/migrate/migrate_test.go
@@ -221,7 +221,7 @@ func TestExtractAnyStr(t *testing.T) {
 	}
 }
 
-// --skip-project-data-migration must drop importScanHistory along
+// --skip_project_data_migration must drop importScanHistory along
 // with the two trailing sync tasks. #303.
 func TestMigrateTargetTasksSkipProjectDataMigration(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
@@ -234,7 +234,7 @@ func TestMigrateTargetTasksSkipProjectDataMigration(t *testing.T) {
 	}
 }
 
-// Without --skip-project-data-migration, all three project-data
+// Without --skip_project_data_migration, all three project-data
 // tasks should run. Regression guard so the skip gate doesn't
 // accidentally always exclude.
 func TestMigrateTargetTasksProjectDataMigrationEnabledByDefault(t *testing.T) {
@@ -252,7 +252,7 @@ func TestMigrateTargetTasksProjectDataMigrationEnabledByDefault(t *testing.T) {
 }
 
 // Explicit TargetTasks lists (used by transfer for project-scoped
-// migration) must still respect --skip-project-data-migration —
+// migration) must still respect --skip_project_data_migration —
 // otherwise the operator's opt-out is silently bypassed.
 func TestMigrateTargetTasksExplicitListHonorsSkipProjectDataMigration(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())
@@ -269,7 +269,7 @@ func TestMigrateTargetTasksExplicitListHonorsSkipProjectDataMigration(t *testing
 	}
 }
 
-// Same explicit list with --skip-issue-sync (and project data on)
+// Same explicit list with --skip_issue_sync (and project data on)
 // must drop only the trailing pair; importScanHistory stays.
 func TestMigrateTargetTasksExplicitListHonorsSkipIssueSync(t *testing.T) {
 	reg := BuildMigrateRegistry(RegisterAll())

--- a/go/internal/migrate/planner.go
+++ b/go/internal/migrate/planner.go
@@ -76,7 +76,7 @@ func RegisterAll() []TaskDef {
 // per-project data after the configuration migration finishes — the
 // scan-history import plus the trailing issue + hotspot metadata
 // syncs. All three run by default; the operator opts out via
-// --skip-project-data-migration (#303).
+// --skip_project_data_migration (#303).
 var migrateProjectDataTasks = map[string]bool{
 	"importScanHistory":   true,
 	"syncHotspotMetadata": true,
@@ -84,8 +84,8 @@ var migrateProjectDataTasks = map[string]bool{
 }
 
 // migrateIssueSyncTasks lists the final per-issue / per-hotspot
-// metadata sync tasks that --skip-issue-sync (or config skip-issue-
-// sync: true) excludes. importScanHistory itself stays included;
+// metadata sync tasks that --skip_issue_sync (or config skip_issue_sync:
+// true) excludes. importScanHistory itself stays included;
 // only the trailing sync pair is skipped. #299.
 var migrateIssueSyncTasks = map[string]bool{
 	"syncHotspotMetadata": true,
@@ -106,8 +106,8 @@ var migrateIssueSyncTasks = map[string]bool{
 func MigrateTargetTasks(reg map[string]*TaskDef, targetTask string, skipProfiles, includeScanHistory, skipIssueSync, skipProjectDataMigration bool, targetTasks []string) []string {
 	if len(targetTasks) > 0 {
 		// Filter the explicit list against the skip gates so transfer's
-		// project-scoped target list still honors --skip-project-data-
-		// migration / --skip-issue-sync. Without this the transfer
+		// project-scoped target list still honors --skip_project_data_migration
+		// / --skip_issue_sync. Without this the transfer
 		// command would always run importScanHistory + the syncs even
 		// when the operator opted out, because the explicit list
 		// bypassed isExcludedTask. The other gates (--skip_profiles,

--- a/roadmap/specs/SPEC-021-migration-verification.md
+++ b/roadmap/specs/SPEC-021-migration-verification.md
@@ -331,7 +331,7 @@ func ClassifyDifference(checkName string, sqValue, scValue any) string {
 #### Verification Pipeline
 
 ```
-1. Parse CLI flags (--token, --export_directory, --output-dir, --only)
+1. Parse CLI flags (--token, --export_directory, --output_dir, --only)
 2. Load org mapping from export directory (organizations.csv, projects.csv)
 3. Create SQ Server and SC API clients
 4. For each organization:
@@ -444,28 +444,28 @@ Multiple `--only` values can be combined: `--only issues --only measures`
 ```bash
 # Full verification
 sonar-migration-tool verify \
-  --source-url https://sq.example.com \
-  --source-token squ_xxx \
-  --cloud-token sqc_xxx \
-  --export-directory ./files/ \
-  --output-dir ./verify-output/
+  --source_url https://sq.example.com \
+  --source_token squ_xxx \
+  --cloud_token sqc_xxx \
+  --export_directory ./files/ \
+  --output_dir ./verify-output/
 
 # Verify only issues and measures
 sonar-migration-tool verify \
-  --source-url https://sq.example.com \
-  --source-token squ_xxx \
-  --cloud-token sqc_xxx \
-  --export-directory ./files/ \
+  --source_url https://sq.example.com \
+  --source_token squ_xxx \
+  --cloud_token sqc_xxx \
+  --export_directory ./files/ \
   --only issues --only measures
 
 # Verify with custom tolerance
 sonar-migration-tool verify \
-  --source-url https://sq.example.com \
-  --source-token squ_xxx \
-  --cloud-token sqc_xxx \
-  --export-directory ./files/ \
-  --issue-count-tolerance 0.02 \
-  --measure-tolerance 0.01
+  --source_url https://sq.example.com \
+  --source_token squ_xxx \
+  --cloud_token sqc_xxx \
+  --export_directory ./files/ \
+  --issue_count_tolerance 0.02 \
+  --measure_tolerance 0.01
 ```
 
 ## Acceptance Criteria

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -23,7 +23,7 @@
       "default": "./migration-files",
       "description": "Root directory for extract / migrate output."
     },
-    "skip-issue-sync": {
+    "skip_issue_sync": {
       "oneOf": [
         { "type": "boolean" },
         { "type": "integer", "enum": [0, 1] },
@@ -32,14 +32,14 @@
       "default": false,
       "description": "When true (or on / yes / 1), skip the final per-issue and per-hotspot metadata sync after scan history is replayed. Defaults to false so the sync happens. Issue #299."
     },
-    "skip-project-data-migration": {
+    "skip_project_data_migration": {
       "oneOf": [
         { "type": "boolean" },
         { "type": "integer", "enum": [0, 1] },
         { "type": "string", "pattern": "^(?i)(true|false|on|off|yes|no|0|1)$" }
       ],
       "default": false,
-      "description": "When true (or on / yes / 1), skip the entire project-data migration: the scan-history import AND the trailing issue + hotspot sync. Implies skip-issue-sync. Defaults to false so the data is migrated. Issue #303."
+      "description": "When true (or on / yes / 1), skip the entire project-data migration: the scan-history import AND the trailing issue + hotspot sync. Implies skip_issue_sync. Defaults to false so the data is migrated. Issue #303."
     },
     "source": {
       "$ref": "#/$defs/sourceBlock",


### PR DESCRIPTION
## Summary
- Fixes #317 by converting every hyphenated CLI flag and config-file key to use `_` as the word separator, applied uniformly to CLI parameters, JSON config files, the JSON schema, examples, docs, and tests.
- Renamed flags: `--source_url`, `--source_token`, `--target_url`, `--target_token`, `--project_key`, `--export_dir`, `--exclude_branches`, `--skip_issue_sync`, `--skip_project_data_migration`.
- Same renames applied to the matching JSON config keys (`skip_issue_sync`, `skip_project_data_migration`) in the schema, all example configs, and struct tags.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` — all packages pass (cmd, extract, migrate, structure, …)
- [x] Repo-wide grep confirms zero remaining hyphenated forms of the affected flags/keys
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)