### PR TITLE
Issue #326: order projects, portfolios and permission templates alphabetically

### DIFF
--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -10,6 +10,8 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
+	"strings"
 	"sync/atomic"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
@@ -17,6 +19,84 @@ import (
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 	"golang.org/x/sync/errgroup"
 )
+
+// sortSpec describes how a task's items should be ordered before iteration
+// (#326). orgField names the JSON field used to bucket items by SonarCloud
+// org so each org's objects are processed contiguously — empty means
+// enterprise-wide, no bucketing. sortField names the JSON field used to
+// alphabetize items within each bucket.
+type sortSpec struct {
+	orgField  string
+	sortField string
+}
+
+// taskSortSpecs registers per-task ordering for the centralized iteration
+// helpers. Tasks not listed here keep their input order (no-op sort).
+//
+// Within each entry the chosen sortField is the operator-visible identifier:
+// project key for projects, name for groups / profiles / gates / portfolios
+// / permission templates. Org-scoped objects are bucketed by
+// sonarcloud_org_key first; portfolios are enterprise-wide so they sort
+// purely by name. Extract-driven tasks read records that don't carry the
+// org key, so they sort by projectKey alone — the within-org alphabetical
+// order is preserved as a sub-sequence.
+var taskSortSpecs = map[string]sortSpec{
+	// Migrate-driven (records carry sonarcloud_org_key).
+	"createProjects":            {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	"setProjectGates":           {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	"setProjectBinding":         {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	"createProfiles":            {orgField: "sonarcloud_org_key", sortField: "name"},
+	"createGates":               {orgField: "sonarcloud_org_key", sortField: "name"},
+	"createGroups":              {orgField: "sonarcloud_org_key", sortField: "name"},
+	"createPermissionTemplates": {orgField: "sonarcloud_org_key", sortField: "name"},
+	"setDefaultProfiles":        {orgField: "sonarcloud_org_key", sortField: "name"},
+	"setDefaultGates":           {orgField: "sonarcloud_org_key", sortField: "name"},
+	"setDefaultTemplates":       {orgField: "sonarcloud_org_key", sortField: "name"},
+	"syncIssueMetadata":         {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	"syncHotspotMetadata":       {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	"importScanHistory":         {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	// Enterprise-wide (no org bucketing).
+	"createPortfolios":    {sortField: "name"},
+	"configurePortfolios": {sortField: "name"},
+	// Extract-driven tasks: records carry projectKey but no org key.
+	"setProjectProfiles":         {sortField: "projectKey"},
+	"setProjectGroupPermissions": {sortField: "projectKey"},
+	"setProjectSettings":         {sortField: "projectKey"},
+	"setProjectTags":             {sortField: "projectKey"},
+	"setProjectLinks":            {sortField: "projectKey"},
+	"setProjectWebhooks":         {sortField: "projectKey"},
+	"setNewCodePeriods":          {sortField: "projectKey"},
+}
+
+// sortMigrateItems orders items per the task's sortSpec. Stable, in-place;
+// a no-op for tasks without a spec.
+func sortMigrateItems(taskName string, items []json.RawMessage) {
+	spec, ok := taskSortSpecs[taskName]
+	if !ok {
+		return
+	}
+	slices.SortStableFunc(items, func(a, b json.RawMessage) int {
+		if spec.orgField != "" {
+			if c := strings.Compare(extractField(a, spec.orgField), extractField(b, spec.orgField)); c != 0 {
+				return c
+			}
+		}
+		return strings.Compare(extractField(a, spec.sortField), extractField(b, spec.sortField))
+	})
+}
+
+// sortExtractItems orders extract items per the task's sortSpec. Stable,
+// in-place; a no-op for tasks without a spec. Extract records don't carry
+// the org key, so spec.orgField (when set) is ignored here.
+func sortExtractItems(taskName string, items []structure.ExtractItem) {
+	spec, ok := taskSortSpecs[taskName]
+	if !ok {
+		return
+	}
+	slices.SortStableFunc(items, func(a, b structure.ExtractItem) int {
+		return strings.Compare(extractField(a.Data, spec.sortField), extractField(b.Data, spec.sortField))
+	})
+}
 
 // readExtractItems reads JSONL items from an extract task across all extract runs.
 func readExtractItems(e *Executor, taskKey string) ([]structure.ExtractItem, error) {
@@ -48,6 +128,10 @@ func forEachMigrateItemFiltered(ctx context.Context, e *Executor, taskName, depT
 			filtered = append(filtered, item)
 		}
 	}
+
+	// Order items so the log stream reflects alphabetical progress within
+	// each org (#326). No-op for tasks not in the sort registry.
+	sortMigrateItems(taskName, filtered)
 
 	e.Logger.Info("starting task", "task", taskName, "items", len(filtered))
 	prog := newProgressLogger(e.Logger, taskName, len(filtered))
@@ -82,6 +166,10 @@ func forEachExtractItem(ctx context.Context, e *Executor, taskName, extractKey s
 	if err != nil {
 		return fmt.Errorf("%s: reading %s: %w", taskName, extractKey, err)
 	}
+
+	// Order items so the log stream reflects alphabetical progress (#326).
+	// No-op for tasks not in the sort registry.
+	sortExtractItems(taskName, items)
 
 	e.Logger.Info("starting task", "task", taskName, "items", len(items))
 	prog := newProgressLogger(e.Logger, taskName, len(items))
@@ -256,35 +344,36 @@ type progressLogger struct {
 // should emit an INFO line for a given task. Per-task entries take
 // precedence over the size-based fallback in newProgressLogger.
 //
-// Tuned for operator-visible cadence (issue #202):
-//   - createProjects is one API call per project and the slowest
-//     per-item task on large platforms; surface progress every 10.
-//   - configurePortfolios issues multiple Enterprise-API calls per
-//     portfolio (create + update + project membership); every 10
-//     keeps progress visible at the user's expected cadence.
-//   - setProjectSettings does multiple HTTP calls per record on
-//     average (definition-driven dispatch, fan-out fallback);
-//     every 50 strikes a balance between visibility and noise.
-//   - setProjectGroupPermissions can run into the tens of thousands
-//     of items (projects × groups × permissions); every 100 keeps
-//     the log readable while still ticking visibly.
+// Cadence policy (#326): the default is 20 items (set in
+// newProgressLogger), with a per-task override below for the two cases
+// that need a tighter cadence:
+//   - syncIssueMetadata / syncHotspotMetadata: slowest per-project work
+//     in a migrate run; every 10 projects so an operator tailing the
+//     log can see steady forward motion.
+//
+// Historical overrides retained from #202 where they remain operator-
+// friendly: createProjects and configurePortfolios already tick every
+// 10. setProjectSettings (was 50) and setProjectGroupPermissions (was
+// 100) are now capped at the new 20-item ceiling.
 var progressLogInterval = map[string]int64{
 	"createProjects":             10,
 	"configurePortfolios":        10,
-	"setProjectSettings":         50,
-	"setProjectGroupPermissions": 100,
+	"setProjectSettings":         20,
+	"setProjectGroupPermissions": 20,
+	"importScanHistory":          20,
+	"syncIssueMetadata":          10,
+	"syncHotspotMetadata":        10,
 }
 
 func newProgressLogger(logger *slog.Logger, task string, total int) *progressLogger {
-	interval := int64(1000)
-	if total < 1000 {
-		interval = 100
-	}
-	if total < 100 {
+	// Default cadence is 20 items (#326). Capped at total so a small
+	// batch still emits its single end-of-task line via the
+	// "n == total" branch in Increment.
+	interval := int64(20)
+	if int64(total) < interval {
 		interval = int64(total)
 	}
-	// Per-task override beats the size-based default — operator
-	// cadence trumps "log volume." Capped at total so the very last
+	// Per-task override beats the default. Same cap so the very last
 	// item still emits a line when override > total.
 	if explicit, ok := progressLogInterval[task]; ok && explicit > 0 {
 		interval = explicit

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -308,19 +308,27 @@ func TestProgressLoggerLogsAtInterval(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	// total=50 → interval=50 (< 100 branch)
-	prog := newProgressLogger(logger, "test", 50)
-	for i := range 49 {
+	// total=40 with default interval=20 (#326). First log expected at
+	// the 20th item; second log at the 40th (which is also the total).
+	prog := newProgressLogger(logger, "test", 40)
+	for i := range 19 {
 		prog.Increment()
 		if buf.Len() > 0 {
 			t.Fatalf("unexpected log at iteration %d", i)
 		}
 	}
-	prog.Increment() // 50th item
-	// Issue #202: message now reads "task N/M - X%" — a single
-	// readable line operators can scan when tailing the log.
-	if !strings.Contains(buf.String(), "test 50/50 - 100%") {
-		t.Errorf("expected progress message \"test 50/50 - 100%%\", got: %s", buf.String())
+	prog.Increment() // 20th item: first interval hit
+	if !strings.Contains(buf.String(), "test 20/40 - 50%") {
+		t.Errorf("expected progress message \"test 20/40 - 50%%\", got: %s", buf.String())
+	}
+	for i := 20; i < 39; i++ {
+		prog.Increment()
+	}
+	prog.Increment() // 40th item: final
+	// Issue #202: message reads "task N/M - X%" — a single readable
+	// line operators can scan when tailing the log.
+	if !strings.Contains(buf.String(), "test 40/40 - 100%") {
+		t.Errorf("expected progress message \"test 40/40 - 100%%\", got: %s", buf.String())
 	}
 }
 
@@ -350,8 +358,10 @@ func TestProgressLoggerFiresFinalHundredPercent(t *testing.T) {
 }
 
 // Per-task interval overrides take precedence over the size-based
-// default. createProjects ships at every-10, setProjectGroupPermissions
-// at every-100 (issue #202).
+// default (issue #202, retuned in #326). createProjects ships at
+// every-10; setProjectSettings / setProjectGroupPermissions /
+// importScanHistory at every-20; syncIssueMetadata /
+// syncHotspotMetadata at every-10.
 func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 	cases := []struct {
 		task          string
@@ -377,16 +387,37 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 		{
 			task:          "setProjectSettings",
 			total:         1234,
-			wantInterval:  50,
-			wantFirstAt:   50,
-			wantFirstLine: "setProjectSettings 50/1234 - 4%",
+			wantInterval:  20,
+			wantFirstAt:   20,
+			wantFirstLine: "setProjectSettings 20/1234 - 1%",
 		},
 		{
 			task:          "setProjectGroupPermissions",
 			total:         19778,
-			wantInterval:  100,
-			wantFirstAt:   100,
-			wantFirstLine: "setProjectGroupPermissions 100/19778 - 0%",
+			wantInterval:  20,
+			wantFirstAt:   20,
+			wantFirstLine: "setProjectGroupPermissions 20/19778 - 0%",
+		},
+		{
+			task:          "importScanHistory",
+			total:         500,
+			wantInterval:  20,
+			wantFirstAt:   20,
+			wantFirstLine: "importScanHistory 20/500 - 4%",
+		},
+		{
+			task:          "syncIssueMetadata",
+			total:         123,
+			wantInterval:  10,
+			wantFirstAt:   10,
+			wantFirstLine: "syncIssueMetadata 10/123 - 8%",
+		},
+		{
+			task:          "syncHotspotMetadata",
+			total:         42,
+			wantInterval:  10,
+			wantFirstAt:   10,
+			wantFirstLine: "syncHotspotMetadata 10/42 - 23%",
 		},
 	}
 	for _, c := range cases {
@@ -409,4 +440,128 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 			}
 		})
 	}
+}
+
+// #326: tasks without a per-task override get the new 20-item default.
+// Small batches collapse to total so a short task still emits a final
+// "100%" line.
+func TestProgressLoggerDefaultCadenceIs20(t *testing.T) {
+	cases := []struct {
+		name         string
+		total        int
+		wantInterval int64
+	}{
+		{"large batch", 5000, 20},
+		{"medium batch", 200, 20},
+		{"just-above-default", 21, 20},
+		{"exact default", 20, 20},
+		{"small batch caps to total", 7, 7},
+		{"single item", 1, 1},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+			prog := newProgressLogger(logger, "unregisteredTask", c.total)
+			if prog.interval != c.wantInterval {
+				t.Errorf("interval: want %d, got %d", c.wantInterval, prog.interval)
+			}
+		})
+	}
+}
+
+// #326: sortMigrateItems orders items by (orgField, sortField) for tasks
+// in the registry, and is a no-op for tasks not in the registry.
+func TestSortMigrateItems(t *testing.T) {
+	t.Run("org-bucketed alphabetical", func(t *testing.T) {
+		items := []json.RawMessage{
+			json.RawMessage(`{"sonarcloud_org_key":"org-b","cloud_project_key":"banana"}`),
+			json.RawMessage(`{"sonarcloud_org_key":"org-a","cloud_project_key":"zebra"}`),
+			json.RawMessage(`{"sonarcloud_org_key":"org-b","cloud_project_key":"apple"}`),
+			json.RawMessage(`{"sonarcloud_org_key":"org-a","cloud_project_key":"alpha"}`),
+		}
+		sortMigrateItems("createProjects", items)
+
+		gotOrgs := make([]string, len(items))
+		gotKeys := make([]string, len(items))
+		for i, it := range items {
+			gotOrgs[i] = extractField(it, "sonarcloud_org_key")
+			gotKeys[i] = extractField(it, "cloud_project_key")
+		}
+		wantOrgs := []string{"org-a", "org-a", "org-b", "org-b"}
+		wantKeys := []string{"alpha", "zebra", "apple", "banana"}
+		for i := range items {
+			if gotOrgs[i] != wantOrgs[i] || gotKeys[i] != wantKeys[i] {
+				t.Errorf("position %d: got (%s, %s), want (%s, %s)",
+					i, gotOrgs[i], gotKeys[i], wantOrgs[i], wantKeys[i])
+			}
+		}
+	})
+
+	t.Run("enterprise-wide alphabetical (no org bucketing)", func(t *testing.T) {
+		items := []json.RawMessage{
+			json.RawMessage(`{"name":"Charlie"}`),
+			json.RawMessage(`{"name":"Alice"}`),
+			json.RawMessage(`{"name":"Bob"}`),
+		}
+		sortMigrateItems("configurePortfolios", items)
+		want := []string{"Alice", "Bob", "Charlie"}
+		for i, it := range items {
+			if got := extractField(it, "name"); got != want[i] {
+				t.Errorf("position %d: got %s, want %s", i, got, want[i])
+			}
+		}
+	})
+
+	t.Run("unregistered task is a no-op", func(t *testing.T) {
+		items := []json.RawMessage{
+			json.RawMessage(`{"name":"Charlie"}`),
+			json.RawMessage(`{"name":"Alice"}`),
+			json.RawMessage(`{"name":"Bob"}`),
+		}
+		sortMigrateItems("notInRegistry", items)
+		// Order preserved exactly.
+		want := []string{"Charlie", "Alice", "Bob"}
+		for i, it := range items {
+			if got := extractField(it, "name"); got != want[i] {
+				t.Errorf("position %d: got %s, want %s (sort should be no-op)", i, got, want[i])
+			}
+		}
+	})
+
+	t.Run("empty input does not panic", func(t *testing.T) {
+		sortMigrateItems("createProjects", nil)
+		sortMigrateItems("createProjects", []json.RawMessage{})
+	})
+}
+
+// #326: sortExtractItems orders extract items by the spec's sortField.
+// Extract records don't carry orgField, so any spec.orgField is ignored
+// at this layer.
+func TestSortExtractItems(t *testing.T) {
+	t.Run("alphabetical by sort field", func(t *testing.T) {
+		items := []structure.ExtractItem{
+			{Data: json.RawMessage(`{"projectKey":"omega"}`)},
+			{Data: json.RawMessage(`{"projectKey":"alpha"}`)},
+			{Data: json.RawMessage(`{"projectKey":"mu"}`)},
+		}
+		sortExtractItems("setProjectSettings", items)
+		want := []string{"alpha", "mu", "omega"}
+		for i, it := range items {
+			if got := extractField(it.Data, "projectKey"); got != want[i] {
+				t.Errorf("position %d: got %s, want %s", i, got, want[i])
+			}
+		}
+	})
+
+	t.Run("unregistered task is a no-op", func(t *testing.T) {
+		items := []structure.ExtractItem{
+			{Data: json.RawMessage(`{"projectKey":"omega"}`)},
+			{Data: json.RawMessage(`{"projectKey":"alpha"}`)},
+		}
+		sortExtractItems("notInRegistry", items)
+		if extractField(items[0].Data, "projectKey") != "omega" {
+			t.Errorf("expected input order preserved for unregistered task")
+		}
+	})
 }

--- a/go/internal/migrate/tasks_scanhistory.go
+++ b/go/internal/migrate/tasks_scanhistory.go
@@ -37,6 +37,10 @@ func runImportScanHistory(ctx context.Context, e *Executor) error {
 		return fmt.Errorf("importScanHistory: reading createProjects: %w", err)
 	}
 
+	// Process projects org-by-org, alphabetical within each org (#326),
+	// so the per-project log stream reflects predictable progress.
+	sortMigrateItems("importScanHistory", projects)
+
 	w, err := e.Store.Writer("importScanHistory")
 	if err != nil {
 		return err
@@ -44,10 +48,13 @@ func runImportScanHistory(ctx context.Context, e *Executor) error {
 
 	completed := loadCompletedBranches(e.Store)
 
+	e.Logger.Info("starting task", "task", "importScanHistory", "items", len(projects))
+	prog := newProgressLogger(e.Logger, "importScanHistory", len(projects))
+
 	g, gCtx := errgroup.WithContext(ctx)
 	g.SetLimit(cap(e.Sem))
 
-	for i, proj := range projects {
+	for _, proj := range projects {
 		cloudKey := extractField(proj, "cloud_project_key")
 		orgKey := extractField(proj, "sonarcloud_org_key")
 		serverURL := extractField(proj, "server_url")
@@ -57,7 +64,7 @@ func runImportScanHistory(ctx context.Context, e *Executor) error {
 			continue
 		}
 
-		e.Logger.Info("importing scan history", "project", cloudKey, "progress", fmt.Sprintf("%d/%d", i+1, len(projects)))
+		e.Logger.Debug("importing scan history", "project", cloudKey)
 
 		g.Go(func() error {
 			if gCtx.Err() != nil {
@@ -76,6 +83,7 @@ func runImportScanHistory(ctx context.Context, e *Executor) error {
 			if err := importProjectBranches(gCtx, e, proj, sqBranches, scMainBranch, completed, w); err != nil {
 				e.Logger.Warn("project scan history failed", "project", cloudKey, "err", err)
 			}
+			prog.Increment()
 			return nil
 		})
 	}


### PR DESCRIPTION
## Summary
- Fixes #326. Objects are now iterated alphabetically during extract / migrate: org-by-org for org-scoped objects (projects, groups, profiles, gates, permission templates), enterprise-wide for portfolios.
- A small per-task sort registry drives the two centralized iteration helpers (`forEachMigrateItem`/`Filtered`, `forEachExtractItem`) plus the manual `runImportScanHistory` loop. Tasks not listed in the registry keep their input order.
- Progress logger retuned: default cadence is 20 items, with 10 for `syncIssueMetadata` / `syncHotspotMetadata`. `createProjects` and `configurePortfolios` keep their 10-item tuning from #202; `setProjectSettings` (was 50) and `setProjectGroupPermissions` (was 100) are capped at 20. `importScanHistory` now routes through `progressLogger`, with its per-project Info log demoted to Debug.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] New unit tests for `sortMigrateItems`, `sortExtractItems`, default cadence, retuned per-task intervals
- [ ] CI green
- [ ] Smoke: `transfer --debug` against an SQ -> SC pair with two orgs and >40 projects; log stream shows org-by-org alphabetical projects and every-20 INFO ticks (every-10 for issue/hotspot sync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)