### PR TITLE
Issue #203 The migrate step should handle API rate limiting

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -12,7 +12,16 @@ require (
 	google.golang.org/protobuf v1.36.11
 )
 
-require github.com/yuin/goldmark v1.8.2
+require (
+	github.com/stretchr/testify v1.9.0
+	github.com/yuin/goldmark v1.8.2
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -76,6 +76,7 @@ golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -107,7 +107,20 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 			"method", method, "endpoint", url,
 			"status", status, "attempt", attempt, "maxAttempts", total)
 	}
-	clientOpts := []sqapi.Option{sqapi.WithRetryLogger(retryLog)}
+	rateLimitTracker := NewRateLimitTracker()
+	rateLimitObs := func(event sqapi.RateLimitEvent) {
+		if rateLimitTracker.Observe(event) {
+			logger.Warn("rate limiting detected",
+				"kind", event.Kind.String(),
+				"retryAfter", event.RetryAfter,
+				"waitChosen", event.WaitChosen,
+				"bodySnippet", event.BodySnippet)
+		}
+	}
+	clientOpts := []sqapi.Option{
+		sqapi.WithRetryLogger(retryLog),
+		sqapi.WithRateLimitObserver(rateLimitObs),
+	}
 	if cfg.Debug {
 		clientOpts = append(clientOpts, sqapi.WithDebugLogger(common.NewHTTPDebugLogger(logger)))
 	}
@@ -164,6 +177,12 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 		}
 		if err := writeRunEvents(runDir, collector); err != nil {
 			logger.Warn("writing run events", "err", err)
+		}
+	}()
+
+	defer func() {
+		if writeErr := rateLimitTracker.WriteJSON(filepath.Join(runDir, RateLimitEventsFile)); writeErr != nil {
+			logger.Warn("failed to write rate-limit events artefact", "err", writeErr)
 		}
 	}()
 

--- a/go/internal/migrate/ratelimit.go
+++ b/go/internal/migrate/ratelimit.go
@@ -1,0 +1,128 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+// RateLimitEventsFile is the filename written under the run directory
+// when one or more 429 responses were observed during the run. The PDF
+// report collector reads this artefact to decide whether to render the
+// amber rate-limit warning.
+const RateLimitEventsFile = "rate_limit_events.json"
+
+// FirstEventSnapshot is the JSON shape of the first observed event of
+// a given RateLimitKind. The report uses BodySnippet and Headers to
+// surface non-standard 429s (Cloudflare/unknown) for operator review.
+type FirstEventSnapshot struct {
+	ObservedAt        time.Time         `json:"observedAt"`
+	RetryAfterSeconds float64           `json:"retryAfterSeconds"`
+	WaitChosenSeconds float64           `json:"waitChosenSeconds"`
+	BodySnippet       string            `json:"bodySnippet"`
+	Headers           map[string]string `json:"headers"`
+}
+
+// RateLimitState is the JSON shape persisted to RateLimitEventsFile.
+// Counts and FirstByKind are keyed by sqapi.RateLimitKind.String() so
+// the report can group hits by classification without an enum mapping.
+type RateLimitState struct {
+	Total                  int                           `json:"total"`
+	Counts                 map[string]int                `json:"counts"`
+	FirstHitAt             time.Time                     `json:"firstHitAt"`
+	LastHitAt              time.Time                     `json:"lastHitAt"`
+	CumulativePauseSeconds float64                       `json:"cumulativePauseSeconds"`
+	LongestPauseSeconds    float64                       `json:"longestPauseSeconds"`
+	FirstByKind            map[string]FirstEventSnapshot `json:"firstByKind"`
+}
+
+// RateLimitTracker accumulates RateLimitEvent observations from the
+// HTTP retry transport and renders them as a single JSON artefact at
+// the end of the run. It is safe for concurrent use — Observe is
+// called directly from arbitrary task goroutines.
+type RateLimitTracker struct {
+	mu    sync.Mutex
+	state RateLimitState
+}
+
+// NewRateLimitTracker returns an empty tracker ready to receive events.
+func NewRateLimitTracker() *RateLimitTracker {
+	return &RateLimitTracker{
+		state: RateLimitState{
+			Counts:      make(map[string]int),
+			FirstByKind: make(map[string]FirstEventSnapshot),
+		},
+	}
+}
+
+// Observe records a single 429 event. Returns true when this is the
+// first event of its RateLimitKind seen in this run — callers use that
+// to emit a one-time "rate limiting detected" warn log per kind rather
+// than spamming the log on every retry.
+func (t *RateLimitTracker) Observe(event sqapi.RateLimitEvent) (firstOfKind bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	kind := event.Kind.String()
+	_, seen := t.state.FirstByKind[kind]
+	firstOfKind = !seen
+
+	t.state.Total++
+	t.state.Counts[kind]++
+
+	if t.state.FirstHitAt.IsZero() || event.ObservedAt.Before(t.state.FirstHitAt) {
+		t.state.FirstHitAt = event.ObservedAt
+	}
+	if event.ObservedAt.After(t.state.LastHitAt) {
+		t.state.LastHitAt = event.ObservedAt
+	}
+
+	waitSec := event.WaitChosen.Seconds()
+	t.state.CumulativePauseSeconds += waitSec
+	if waitSec > t.state.LongestPauseSeconds {
+		t.state.LongestPauseSeconds = waitSec
+	}
+
+	if firstOfKind {
+		t.state.FirstByKind[kind] = FirstEventSnapshot{
+			ObservedAt:        event.ObservedAt,
+			RetryAfterSeconds: event.RetryAfter.Seconds(),
+			WaitChosenSeconds: waitSec,
+			BodySnippet:       event.BodySnippet,
+			Headers:           event.Headers,
+		}
+	}
+
+	return firstOfKind
+}
+
+// HasHits reports whether any 429 has been observed.
+func (t *RateLimitTracker) HasHits() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.state.Total > 0
+}
+
+// WriteJSON serialises the tracker's accumulated state to path. Returns
+// nil without writing when no hits have been recorded — clean runs do
+// not produce the artefact, keeping run dirs free of zero-information
+// noise.
+func (t *RateLimitTracker) WriteJSON(path string) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.state.Total == 0 {
+		return nil
+	}
+	data, err := json.MarshalIndent(t.state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o600)
+}

--- a/go/internal/migrate/ratelimit.go
+++ b/go/internal/migrate/ratelimit.go
@@ -85,7 +85,11 @@ func (t *RateLimitTracker) Observe(event sqapi.RateLimitEvent) (firstOfKind bool
 	}
 
 	waitSec := event.WaitChosen.Seconds()
-	t.state.CumulativePauseSeconds += waitSec
+	// CumulativePauseSeconds is gate-deduplicated wall-clock pause —
+	// summing per-request WaitChosen would inflate by N when N concurrent
+	// workers park on the same gate window. WallClockAdded carries the
+	// already-deduplicated contribution from the transport.
+	t.state.CumulativePauseSeconds += event.WallClockAdded.Seconds()
 	if waitSec > t.state.LongestPauseSeconds {
 		t.state.LongestPauseSeconds = waitSec
 	}

--- a/go/internal/migrate/ratelimit_test.go
+++ b/go/internal/migrate/ratelimit_test.go
@@ -1,0 +1,126 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+func TestTrackerObserveFirstOfKind(t *testing.T) {
+	tracker := migrate.NewRateLimitTracker()
+
+	first := tracker.Observe(sqapi.RateLimitEvent{
+		Kind:       sqapi.KindSQCRateLimit,
+		WaitChosen: 5 * time.Second,
+		ObservedAt: time.Now(),
+	})
+	assert.True(t, first, "first event of a kind must be flagged")
+
+	second := tracker.Observe(sqapi.RateLimitEvent{
+		Kind:       sqapi.KindSQCRateLimit,
+		WaitChosen: 5 * time.Second,
+		ObservedAt: time.Now(),
+	})
+	assert.False(t, second, "second event of the same kind must not be flagged")
+
+	otherKind := tracker.Observe(sqapi.RateLimitEvent{
+		Kind:       sqapi.KindCloudflareRateLimit,
+		WaitChosen: 0,
+		ObservedAt: time.Now(),
+	})
+	assert.True(t, otherKind, "first event of a new kind must be flagged")
+}
+
+func TestTrackerAccumulatesPause(t *testing.T) {
+	tracker := migrate.NewRateLimitTracker()
+	now := time.Now()
+	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 5 * time.Second, ObservedAt: now})
+	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 15 * time.Second, ObservedAt: now.Add(10 * time.Second)})
+	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 7 * time.Second, ObservedAt: now.Add(20 * time.Second)})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, migrate.RateLimitEventsFile)
+	require.NoError(t, tracker.WriteJSON(path))
+
+	var state migrate.RateLimitState
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &state))
+
+	assert.Equal(t, 3, state.Total)
+	assert.Equal(t, 3, state.Counts[sqapi.KindSQCRateLimit.String()])
+	assert.InDelta(t, 27.0, state.CumulativePauseSeconds, 0.001)
+	assert.InDelta(t, 15.0, state.LongestPauseSeconds, 0.001)
+}
+
+func TestTrackerWriteJSONSkipsCleanRun(t *testing.T) {
+	tracker := migrate.NewRateLimitTracker()
+	dir := t.TempDir()
+	path := filepath.Join(dir, migrate.RateLimitEventsFile)
+	require.NoError(t, tracker.WriteJSON(path))
+
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err), "no JSON file should be written for a clean run")
+}
+
+func TestTrackerConcurrentObserve(t *testing.T) {
+	tracker := migrate.NewRateLimitTracker()
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracker.Observe(sqapi.RateLimitEvent{
+				Kind:       sqapi.KindSQCRateLimit,
+				WaitChosen: time.Second,
+				ObservedAt: time.Now(),
+			})
+		}()
+	}
+	wg.Wait()
+	assert.True(t, tracker.HasHits())
+}
+
+func TestTrackerSnapshotsFirstBody(t *testing.T) {
+	tracker := migrate.NewRateLimitTracker()
+	tracker.Observe(sqapi.RateLimitEvent{
+		Kind:        sqapi.KindCloudflareRateLimit,
+		WaitChosen:  2 * time.Second,
+		BodySnippet: "<html>1015</html>",
+		Headers:     map[string]string{"CF-Ray": "abc"},
+		ObservedAt:  time.Now(),
+	})
+	tracker.Observe(sqapi.RateLimitEvent{
+		Kind:        sqapi.KindCloudflareRateLimit,
+		WaitChosen:  2 * time.Second,
+		BodySnippet: "<html>different body, ignored</html>",
+		Headers:     map[string]string{"CF-Ray": "def"},
+		ObservedAt:  time.Now(),
+	})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, migrate.RateLimitEventsFile)
+	require.NoError(t, tracker.WriteJSON(path))
+
+	var state migrate.RateLimitState
+	data, _ := os.ReadFile(path)
+	require.NoError(t, json.Unmarshal(data, &state))
+
+	snap, ok := state.FirstByKind[sqapi.KindCloudflareRateLimit.String()]
+	require.True(t, ok)
+	assert.Equal(t, "<html>1015</html>", snap.BodySnippet,
+		"FirstByKind must hold the FIRST snapshot, not be overwritten")
+}

--- a/go/internal/migrate/ratelimit_test.go
+++ b/go/internal/migrate/ratelimit_test.go
@@ -47,9 +47,12 @@ func TestTrackerObserveFirstOfKind(t *testing.T) {
 func TestTrackerAccumulatesPause(t *testing.T) {
 	tracker := migrate.NewRateLimitTracker()
 	now := time.Now()
-	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 5 * time.Second, ObservedAt: now})
-	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 15 * time.Second, ObservedAt: now.Add(10 * time.Second)})
-	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 7 * time.Second, ObservedAt: now.Add(20 * time.Second)})
+	// CumulativePauseSeconds sums WallClockAdded (gate-deduplicated),
+	// not WaitChosen — three sequential SQC events each extending the
+	// gate contribute the full delta each time.
+	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 5 * time.Second, WallClockAdded: 5 * time.Second, ObservedAt: now})
+	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 15 * time.Second, WallClockAdded: 15 * time.Second, ObservedAt: now.Add(10 * time.Second)})
+	tracker.Observe(sqapi.RateLimitEvent{Kind: sqapi.KindSQCRateLimit, WaitChosen: 7 * time.Second, WallClockAdded: 7 * time.Second, ObservedAt: now.Add(20 * time.Second)})
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, migrate.RateLimitEventsFile)
@@ -64,6 +67,45 @@ func TestTrackerAccumulatesPause(t *testing.T) {
 	assert.Equal(t, 3, state.Counts[sqapi.KindSQCRateLimit.String()])
 	assert.InDelta(t, 27.0, state.CumulativePauseSeconds, 0.001)
 	assert.InDelta(t, 15.0, state.LongestPauseSeconds, 0.001)
+}
+
+// TestTrackerCumulativePauseDeduped verifies that concurrent SQC events
+// parking on a shared gate window do not inflate CumulativePauseSeconds.
+// Each request still reports its full WaitChosen (used for
+// LongestPauseSeconds), but only one event per window contributes the
+// full wall-clock pause via WallClockAdded.
+func TestTrackerCumulativePauseDeduped(t *testing.T) {
+	tracker := migrate.NewRateLimitTracker()
+	now := time.Now()
+	// 20 concurrent workers each chose to wait 60s; only the leading
+	// 429 actually added 60s of wall-clock pause to the migration.
+	for i := 0; i < 20; i++ {
+		wallClock := time.Duration(0)
+		if i == 0 {
+			wallClock = 60 * time.Second
+		}
+		tracker.Observe(sqapi.RateLimitEvent{
+			Kind:           sqapi.KindSQCRateLimit,
+			WaitChosen:     60 * time.Second,
+			WallClockAdded: wallClock,
+			ObservedAt:     now,
+		})
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, migrate.RateLimitEventsFile)
+	require.NoError(t, tracker.WriteJSON(path))
+
+	var state migrate.RateLimitState
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(data, &state))
+
+	assert.Equal(t, 20, state.Total, "all events counted")
+	assert.InDelta(t, 60.0, state.CumulativePauseSeconds, 0.001,
+		"CumulativePauseSeconds must reflect wall-clock pause (60s), not 20x60s")
+	assert.InDelta(t, 60.0, state.LongestPauseSeconds, 0.001,
+		"LongestPauseSeconds reflects the largest single WaitChosen")
 }
 
 func TestTrackerWriteJSONSkipsCleanRun(t *testing.T) {

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -71,6 +71,7 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 		GeneratedAt: time.Now(),
 		Sections:    sections,
 		Limitations: collectLimitations(runDir, exportDir, extractMapping),
+		RateLimit:   collectRateLimitReport(runDir, failuresByType),
 	}
 
 	// Fold in migrate-engine runtime telemetry (run_meta.json /
@@ -235,17 +236,17 @@ func collectGlobalSettingMappingLimitations(exportDir string, mapping structure.
 // list is deliberately small and explicit so a setting that merely
 // happens to start with "sonar.security" doesn't trip the heuristic.
 var sastCustomizationKeys = map[string]bool{
-	"sonar.security.config.javasecurity":       true,
-	"sonar.security.config.phpsecurity":        true,
-	"sonar.security.config.pythonsecurity":     true,
+	"sonar.security.config.javasecurity":                     true,
+	"sonar.security.config.phpsecurity":                      true,
+	"sonar.security.config.pythonsecurity":                   true,
 	"sonar.security.config.roslyn.sonaranalyzer.security.cs": true,
-	"sonar.security.config.jssecurity":         true,
-	"sonar.security.config.tssecurity":         true,
-	"sonar.security.sources.javasecurity":      true,
-	"sonar.security.sources.phpsecurity":       true,
-	"sonar.security.sources.pythonsecurity":    true,
-	"sonar.security.sources.jssecurity":        true,
-	"sonar.security.sources.tssecurity":        true,
+	"sonar.security.config.jssecurity":                       true,
+	"sonar.security.config.tssecurity":                       true,
+	"sonar.security.sources.javasecurity":                    true,
+	"sonar.security.sources.phpsecurity":                     true,
+	"sonar.security.sources.pythonsecurity":                  true,
+	"sonar.security.sources.jssecurity":                      true,
+	"sonar.security.sources.tssecurity":                      true,
 }
 
 // collectSASTCustomizationLimitation scans server-level and project-

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -115,6 +115,10 @@ func RenderPDF(summary *MigrationSummary) ([]byte, error) {
 	pdf.AddPage()
 	renderTitlePage(pdf, summary)
 
+	if summary.RateLimit != nil {
+		renderRateLimitWarning(pdf, summary.RateLimit)
+	}
+
 	for _, section := range summary.Sections {
 		if summary.OmitSections[section.Name] {
 			continue
@@ -499,7 +503,9 @@ var sectionsWithoutOrganization = map[string]bool{
 }
 
 // renderUnifiedTable renders the per-section table:
-//   Name | Organization | Outcome (colored) | Details
+//
+//	Name | Organization | Outcome (colored) | Details
+//
 // For sections in sectionsWithoutOrganization (and for the predictive
 // report, #240, where org mapping isn't meaningful), the Organization
 // column is dropped — producing a 3-column table: Name | Outcome |
@@ -563,14 +569,14 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section, predictive bool) {
 	// not balloon vertically. Multi-line details (typically metric mapping
 	// notes) also drop to a smaller 6pt font so the per-line cost stays low.
 	const (
-		singleLineH       = 6.0
+		singleLineH = 6.0
 		// wrappedLineH at 3.0mm was too tight for the 8pt body font
 		// used in the Name column: descenders on g/p/y/j were clipped
 		// for long wrapping setting keys (issue #207, example
 		// sonar.java.ignoreUnnamedModuleForSplitPackage). 4.0mm gives
 		// 8pt enough leading while staying readable for the 6pt
 		// multi-line details column.
-		wrappedLineH = 4.0
+		wrappedLineH      = 4.0
 		bodyFontSize      = 8.0
 		multiLineFontSize = 6.0
 	)

--- a/go/internal/report/summary/ratelimit.go
+++ b/go/internal/report/summary/ratelimit.go
@@ -243,20 +243,32 @@ const (
 // function does not gate on its argument; nil is a programmer error.
 //
 // Layout: full-width box, light amber border, amber bold heading on
-// the first line, black body text wrapping below.
+// the first line, black body text wrapping below. The body is
+// pre-measured under the body font so the page-break check reserves
+// exactly the space the wrapped text needs — otherwise long bodies
+// (notably the non-SQC variant with a 160-char snippet) auto-break
+// mid-MultiCell and the border rectangle is drawn across the page
+// boundary.
 func renderRateLimitWarning(pdf *fpdf.Fpdf, r *RateLimitReport) {
 	pdf.Ln(4)
 	pageW, _ := pdf.GetPageSize()
 	left, _, right, _ := pdf.GetMargins()
 	boxW := pageW - left - right
+	innerW := boxW - 2*rateLimitBoxPadding
 
 	body := sanitizeForPDF(rateLimitMessage(r))
 
-	checkPageBreak(pdf, rateLimitHeadingLineH+rateLimitBodyLineH*4+rateLimitBoxPadding*2)
+	pdf.SetFont(pdfFontFamilyBody, "", rateLimitBodyFontPt)
+	bodyLines := pdf.SplitLines([]byte(body), innerW)
+	bodyLineCount := len(bodyLines)
+	if bodyLineCount < 1 {
+		bodyLineCount = 1
+	}
+	boxHeight := rateLimitHeadingLineH + rateLimitBodyLineH*float64(bodyLineCount) + rateLimitBoxPadding*2
+	checkPageBreak(pdf, boxHeight)
 
 	startY := pdf.GetY()
 	innerX := left + rateLimitBoxPadding
-	innerW := boxW - 2*rateLimitBoxPadding
 
 	pdf.SetXY(innerX, startY+rateLimitBoxPadding)
 	setColor(pdf, colorAmber)

--- a/go/internal/report/summary/ratelimit.go
+++ b/go/internal/report/summary/ratelimit.go
@@ -1,0 +1,294 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/go-pdf/fpdf"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/analysis"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+// rateLimitImpactPauseThreshold is the cumulative pause time (in
+// seconds) above which the orange warning is rendered even when the
+// migration completed cleanly. A short blip that recovered in under
+// half a minute is not worth a callout — operators see the JSON in the
+// run dir if they want details.
+const rateLimitImpactPauseThreshold = 30.0
+
+// collectRateLimitReport reads rate_limit_events.json from runDir and
+// returns a *RateLimitReport only when rate limiting materially
+// impacted the run. Returns nil for clean runs, missing files, or
+// recoverable single-blip runs.
+//
+// The "materially impacted" predicate is satisfied when ANY of the
+// following hold:
+//   - one or more tasks failed with HTTP 429 as the terminal status,
+//   - cumulative pause time exceeded rateLimitImpactPauseThreshold,
+//   - any non-SQC-classified 429 was observed (Cloudflare or unknown).
+func collectRateLimitReport(runDir string, failuresByType map[string][]analysis.ReportRow) *RateLimitReport {
+	state, ok := readRateLimitState(runDir)
+	if !ok {
+		return nil
+	}
+	report := buildRateLimitReport(state)
+	report.CausedTaskFailure = anyFailureWas429(failuresByType)
+	if !rateLimitImpacted(report) {
+		return nil
+	}
+	return report
+}
+
+// readRateLimitState loads the JSON artefact written by the migrate
+// command. Missing files are not an error — they mean the run had no
+// 429s.
+func readRateLimitState(runDir string) (migrate.RateLimitState, bool) {
+	path := filepath.Join(runDir, migrate.RateLimitEventsFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return migrate.RateLimitState{}, false
+	}
+	var state migrate.RateLimitState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return migrate.RateLimitState{}, false
+	}
+	return state, state.Total > 0
+}
+
+// buildRateLimitReport flattens the JSON state into the report shape
+// rendered by the PDF. The first body snippet and headers summary are
+// taken from the first non-SQC event of any kind — SQC application
+// limits produce uninteresting JSON error bodies, so surfacing them
+// in the PDF would add no signal.
+func buildRateLimitReport(state migrate.RateLimitState) *RateLimitReport {
+	report := &RateLimitReport{
+		TotalHits:              state.Total,
+		SQCHits:                state.Counts[sqapi.KindSQCRateLimit.String()],
+		CloudflareHits:         state.Counts[sqapi.KindCloudflareRateLimit.String()],
+		UnknownHits:            state.Counts[sqapi.KindUnknown429.String()],
+		CumulativePauseSeconds: state.CumulativePauseSeconds,
+	}
+	for _, kind := range nonSQCKindsInPDFOrder {
+		snap, ok := state.FirstByKind[kind.String()]
+		if !ok {
+			continue
+		}
+		report.FirstBodySnippet = snap.BodySnippet
+		report.FirstHeadersSummary = formatHeaders(snap.Headers)
+		break
+	}
+	return report
+}
+
+// nonSQCKindsInPDFOrder lists the non-SQC RateLimitKinds in the order
+// the PDF should prefer when picking a body snippet to display. A
+// Cloudflare-classified event is more diagnostic than an unknown one,
+// so it wins when both kinds appear in the same run.
+var nonSQCKindsInPDFOrder = []sqapi.RateLimitKind{
+	sqapi.KindCloudflareRateLimit,
+	sqapi.KindUnknown429,
+}
+
+// rateLimitImpacted is the "Only on impact" predicate gating the PDF
+// warning. See the package-level constant for the cumulative-pause
+// cutoff; the other branches are unconditional.
+func rateLimitImpacted(r *RateLimitReport) bool {
+	if r.CloudflareHits > 0 || r.UnknownHits > 0 {
+		return true
+	}
+	if r.CausedTaskFailure {
+		return true
+	}
+	return r.CumulativePauseSeconds > rateLimitImpactPauseThreshold
+}
+
+// anyFailureWas429 reports whether any failed request recorded in the
+// analysis report ended with HTTP 429 as its terminal status. Used by
+// the impact predicate to surface the warning even for short pause
+// totals when retries actually exhausted on a 429.
+func anyFailureWas429(failuresByType map[string][]analysis.ReportRow) bool {
+	for _, rows := range failuresByType {
+		for _, row := range rows {
+			if row.HTTPStatus == "429" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// formatHeaders renders a headers map as "Name: value; Name: value"
+// for inclusion in the PDF callout. Sorted by header name so the
+// output is deterministic across runs.
+func formatHeaders(headers map[string]string) string {
+	if len(headers) == 0 {
+		return ""
+	}
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	parts := make([]string, 0, len(headers))
+	for _, name := range names {
+		parts = append(parts, name+": "+headers[name])
+	}
+	return strings.Join(parts, "; ")
+}
+
+// rateLimitMessage assembles the body text shown inside the orange
+// callout box. The three variants correspond to the impact branches in
+// rateLimitImpacted: clean-but-slow SQC throttling, SQC throttling that
+// killed at least one task, and any non-SQC 429 observation.
+//
+// The function is pure so it can be unit-tested without touching fpdf
+// or the disk.
+func rateLimitMessage(r *RateLimitReport) string {
+	hasNonSQC := r.CloudflareHits > 0 || r.UnknownHits > 0
+	switch {
+	case hasNonSQC:
+		return nonSQCMessage(r)
+	case r.CausedTaskFailure:
+		return sqcFailureMessage(r)
+	default:
+		return sqcRecoveredMessage(r)
+	}
+}
+
+func sqcRecoveredMessage(r *RateLimitReport) string {
+	return fmt.Sprintf(
+		"SonarQube Cloud's API rate limit was reached %s during this run. "+
+			"The tool paused and resumed automatically; total pause time was %s. "+
+			"The migration completed successfully but ran slower than usual.",
+		pluralHits(r.SQCHits), formatSeconds(r.CumulativePauseSeconds))
+}
+
+func sqcFailureMessage(r *RateLimitReport) string {
+	return fmt.Sprintf(
+		"SonarQube Cloud's API rate limit was reached %s during this run. "+
+			"After retries with adaptive backoff the limit did not clear, and one or "+
+			"more tasks failed (see Failed rows below). Re-run with `--run-id` to "+
+			"resume from the last successful task.",
+		pluralHits(r.SQCHits))
+}
+
+func nonSQCMessage(r *RateLimitReport) string {
+	hits := r.CloudflareHits + r.UnknownHits
+	return fmt.Sprintf(
+		"A non-standard 429 response was received %s during this run. "+
+			"The body and headers suggest an upstream proxy or WAF — not SonarQube "+
+			"Cloud's documented application rate limit. The tool did not pause and "+
+			"resume for these because the cause may require operator action (IP "+
+			"block, bot rule, etc.). First response body snippet: %s",
+		pluralHits(hits), snippetForMessage(r.FirstBodySnippet))
+}
+
+func pluralHits(n int) string {
+	if n == 1 {
+		return "1 time"
+	}
+	return fmt.Sprintf("%d times", n)
+}
+
+// formatSeconds prints a duration count as a human-friendly string.
+// Sub-minute durations stay in seconds with one decimal; minute+ values
+// round to whole minutes so the callout doesn't read like a stopwatch.
+func formatSeconds(secs float64) string {
+	if secs < 60 {
+		return fmt.Sprintf("%.1f seconds", secs)
+	}
+	mins := int(math.Round(secs / 60))
+	if mins == 1 {
+		return "about 1 minute"
+	}
+	return fmt.Sprintf("about %d minutes", mins)
+}
+
+func snippetForMessage(snippet string) string {
+	snippet = strings.TrimSpace(snippet)
+	if snippet == "" {
+		return "(empty response body)"
+	}
+	const maxInMessage = 160
+	if len(snippet) > maxInMessage {
+		snippet = snippet[:maxInMessage] + "…"
+	}
+	return strings.Join(strings.Fields(snippet), " ")
+}
+
+const (
+	rateLimitHeading        = "Rate limiting detected during migration"
+	rateLimitBoxPadding     = 3.0
+	rateLimitBoxBorderWidth = 0.4
+	rateLimitHeadingFontPt  = 11
+	rateLimitBodyFontPt     = 9
+	rateLimitHeadingLineH   = 6.0
+	rateLimitBodyLineH      = 4.5
+)
+
+// renderRateLimitWarning draws the amber callout box between the
+// executive summary and the per-section tables. The box renders only
+// when CollectSummary determined that rate limiting materially
+// impacted the run (impact predicate in rateLimitImpacted) — so this
+// function does not gate on its argument; nil is a programmer error.
+//
+// Layout: full-width box, light amber border, amber bold heading on
+// the first line, black body text wrapping below.
+func renderRateLimitWarning(pdf *fpdf.Fpdf, r *RateLimitReport) {
+	pdf.Ln(4)
+	pageW, _ := pdf.GetPageSize()
+	left, _, right, _ := pdf.GetMargins()
+	boxW := pageW - left - right
+
+	body := sanitizeForPDF(rateLimitMessage(r))
+
+	checkPageBreak(pdf, rateLimitHeadingLineH+rateLimitBodyLineH*4+rateLimitBoxPadding*2)
+
+	startY := pdf.GetY()
+	innerX := left + rateLimitBoxPadding
+	innerW := boxW - 2*rateLimitBoxPadding
+
+	pdf.SetXY(innerX, startY+rateLimitBoxPadding)
+	setColor(pdf, colorAmber)
+	pdf.SetFont(pdfFontFamilyHeading, "B", rateLimitHeadingFontPt)
+	pdf.CellFormat(innerW, rateLimitHeadingLineH, rateLimitHeading, "", 1, "L", false, 0, "")
+
+	pdf.SetX(innerX)
+	setColor(pdf, colorBlack)
+	pdf.SetFont(pdfFontFamilyBody, "", rateLimitBodyFontPt)
+	pdf.MultiCell(innerW, rateLimitBodyLineH, body, "", "L", false)
+
+	endY := pdf.GetY() + rateLimitBoxPadding
+
+	prevLineWidth := pdf.GetLineWidth()
+	pdf.SetLineWidth(rateLimitBoxBorderWidth)
+	prevDraw := setDrawColorAmber(pdf)
+	pdf.Rect(left, startY, boxW, endY-startY, "D")
+	restoreDrawColor(pdf, prevDraw)
+	pdf.SetLineWidth(prevLineWidth)
+
+	pdf.SetY(endY + 2)
+}
+
+// setDrawColorAmber installs the amber draw colour and returns the
+// previous (Sonar-grey) colour as a triple for restoration. The fpdf
+// API has no "current draw color" accessor so we cache the constant
+// rather than reading state back.
+func setDrawColorAmber(pdf *fpdf.Fpdf) [3]int {
+	pdf.SetDrawColor(colorAmber[0], colorAmber[1], colorAmber[2])
+	return colorSonarGrey
+}
+
+func restoreDrawColor(pdf *fpdf.Fpdf, c [3]int) {
+	pdf.SetDrawColor(c[0], c[1], c[2])
+}

--- a/go/internal/report/summary/ratelimit_test.go
+++ b/go/internal/report/summary/ratelimit_test.go
@@ -206,3 +206,36 @@ func TestRenderRateLimitWarningProducesContent(t *testing.T) {
 	require.NoError(t, pdf.Output(&buf))
 	assert.Greater(t, buf.Len(), 1000, "PDF must be non-trivial after rendering the warning")
 }
+
+// TestRenderRateLimitWarningNearPageBottomBreaksCleanly verifies that
+// when the warning is rendered near the bottom of a page, the entire
+// box (including a long non-SQC body that wraps to many lines) moves to
+// a fresh page rather than being drawn with its border spanning the
+// page break.
+func TestRenderRateLimitWarningNearPageBottomBreaksCleanly(t *testing.T) {
+	pdf := fpdf.New("P", "mm", "Letter", "")
+	pdf.SetAutoPageBreak(true, 20)
+	registerUnicodeFont(pdf)
+	pdf.AddPage()
+
+	_, pageH := pdf.GetPageSize()
+	// Park the cursor near the bottom so the old "reserve 4 lines"
+	// constant would fit-and-overflow, while a long-body box correctly
+	// computed should push to a new page.
+	pdf.SetY(pageH - 40)
+	startPage := pdf.PageNo()
+
+	report := &RateLimitReport{
+		TotalHits:           1,
+		CloudflareHits:      1,
+		FirstBodySnippet:    strings.Repeat("Cloudflare 1015 Error Encountered ", 8),
+		FirstHeadersSummary: "CF-Ray: abc; Retry-After: 60",
+	}
+	renderRateLimitWarning(pdf, report)
+
+	assert.Greater(t, pdf.PageNo(), startPage,
+		"long body near page bottom must trigger a page break before drawing the box")
+
+	var buf bytes.Buffer
+	require.NoError(t, pdf.Output(&buf), "rendering must produce a valid PDF")
+}

--- a/go/internal/report/summary/ratelimit_test.go
+++ b/go/internal/report/summary/ratelimit_test.go
@@ -1,0 +1,208 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-pdf/fpdf"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/analysis"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+func writeRateLimitArtefact(t *testing.T, dir string, state migrate.RateLimitState) {
+	t.Helper()
+	data, err := json.Marshal(state)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, migrate.RateLimitEventsFile), data, 0o600))
+}
+
+func TestCollectRateLimitReport_NoFileReturnsNil(t *testing.T) {
+	dir := t.TempDir()
+	got := collectRateLimitReport(dir, nil)
+	assert.Nil(t, got)
+}
+
+func TestCollectRateLimitReport_SingleBlipBelowThreshold(t *testing.T) {
+	dir := t.TempDir()
+	writeRateLimitArtefact(t, dir, migrate.RateLimitState{
+		Total:                  1,
+		Counts:                 map[string]int{sqapi.KindSQCRateLimit.String(): 1},
+		CumulativePauseSeconds: 5,
+		FirstByKind: map[string]migrate.FirstEventSnapshot{
+			sqapi.KindSQCRateLimit.String(): {ObservedAt: time.Now()},
+		},
+	})
+	got := collectRateLimitReport(dir, nil)
+	assert.Nil(t, got, "single 5s SQC blip below 30s threshold should not surface")
+}
+
+func TestCollectRateLimitReport_CumulativeAboveThreshold(t *testing.T) {
+	dir := t.TempDir()
+	writeRateLimitArtefact(t, dir, migrate.RateLimitState{
+		Total:                  3,
+		Counts:                 map[string]int{sqapi.KindSQCRateLimit.String(): 3},
+		CumulativePauseSeconds: 65,
+		FirstByKind: map[string]migrate.FirstEventSnapshot{
+			sqapi.KindSQCRateLimit.String(): {ObservedAt: time.Now()},
+		},
+	})
+	got := collectRateLimitReport(dir, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, 3, got.SQCHits)
+	assert.InDelta(t, 65.0, got.CumulativePauseSeconds, 0.001)
+	assert.False(t, got.CausedTaskFailure)
+}
+
+func TestCollectRateLimitReport_TaskFailureWith429(t *testing.T) {
+	dir := t.TempDir()
+	writeRateLimitArtefact(t, dir, migrate.RateLimitState{
+		Total:                  2,
+		Counts:                 map[string]int{sqapi.KindSQCRateLimit.String(): 2},
+		CumulativePauseSeconds: 2,
+		FirstByKind: map[string]migrate.FirstEventSnapshot{
+			sqapi.KindSQCRateLimit.String(): {ObservedAt: time.Now()},
+		},
+	})
+	failures := map[string][]analysis.ReportRow{
+		"Project": {{HTTPStatus: "429"}},
+	}
+	got := collectRateLimitReport(dir, failures)
+	require.NotNil(t, got)
+	assert.True(t, got.CausedTaskFailure)
+}
+
+func TestCollectRateLimitReport_CloudflareHitAlwaysSurfaces(t *testing.T) {
+	dir := t.TempDir()
+	writeRateLimitArtefact(t, dir, migrate.RateLimitState{
+		Total: 1,
+		Counts: map[string]int{
+			sqapi.KindCloudflareRateLimit.String(): 1,
+		},
+		CumulativePauseSeconds: 0,
+		FirstByKind: map[string]migrate.FirstEventSnapshot{
+			sqapi.KindCloudflareRateLimit.String(): {
+				ObservedAt:  time.Now(),
+				BodySnippet: "<html>1015</html>",
+				Headers:     map[string]string{"CF-Ray": "abc", "Server": "cloudflare"},
+			},
+		},
+	})
+	got := collectRateLimitReport(dir, nil)
+	require.NotNil(t, got, "any non-SQC 429 must always surface, regardless of pause time")
+	assert.Equal(t, 1, got.CloudflareHits)
+	assert.Equal(t, "<html>1015</html>", got.FirstBodySnippet)
+	assert.Contains(t, got.FirstHeadersSummary, "CF-Ray: abc")
+	assert.Contains(t, got.FirstHeadersSummary, "Server: cloudflare")
+}
+
+func TestRateLimitMessageVariants(t *testing.T) {
+	cases := []struct {
+		name     string
+		report   *RateLimitReport
+		contains []string
+	}{
+		{
+			name: "sqc recovered slow",
+			report: &RateLimitReport{
+				TotalHits: 4, SQCHits: 4,
+				CumulativePauseSeconds: 95,
+			},
+			contains: []string{"SonarQube Cloud", "4 times", "paused and resumed", "minute"},
+		},
+		{
+			name: "sqc task failure",
+			report: &RateLimitReport{
+				TotalHits: 2, SQCHits: 2,
+				CausedTaskFailure: true,
+			},
+			contains: []string{"limit did not clear", "tasks failed", "--run-id"},
+		},
+		{
+			name: "cloudflare hit",
+			report: &RateLimitReport{
+				TotalHits: 1, CloudflareHits: 1,
+				FirstBodySnippet: "<html>1015</html>",
+			},
+			contains: []string{"non-standard 429", "upstream proxy or WAF", "operator action", "1015"},
+		},
+		{
+			name: "unknown 429",
+			report: &RateLimitReport{
+				TotalHits: 1, UnknownHits: 1,
+				FirstBodySnippet: "  body  with  spaces  ",
+			},
+			contains: []string{"non-standard 429", "body with spaces"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			msg := rateLimitMessage(tc.report)
+			for _, want := range tc.contains {
+				assert.Contains(t, msg, want, "expected %q in message", want)
+			}
+		})
+	}
+}
+
+func TestFormatHeaders(t *testing.T) {
+	got := formatHeaders(map[string]string{
+		"Server": "cloudflare",
+		"CF-Ray": "abc",
+	})
+	assert.Equal(t, "CF-Ray: abc; Server: cloudflare", got)
+	assert.Empty(t, formatHeaders(nil))
+	assert.Empty(t, formatHeaders(map[string]string{}))
+}
+
+func TestFormatSeconds(t *testing.T) {
+	assert.Equal(t, "5.0 seconds", formatSeconds(5))
+	assert.Equal(t, "29.5 seconds", formatSeconds(29.5))
+	assert.Equal(t, "55.0 seconds", formatSeconds(55))   // still under the 60s threshold
+	assert.Equal(t, "about 1 minute", formatSeconds(70)) // rounds to 1 min
+	assert.Equal(t, "about 5 minutes", formatSeconds(300))
+}
+
+func TestSnippetForMessage(t *testing.T) {
+	assert.Equal(t, "(empty response body)", snippetForMessage(""))
+	assert.Equal(t, "(empty response body)", snippetForMessage("   "))
+	assert.Equal(t, "compact body", snippetForMessage("  compact   body  "))
+
+	long := strings.Repeat("a", 250)
+	got := snippetForMessage(long)
+	assert.LessOrEqual(t, len(got), 165, "long snippets should be truncated with an ellipsis")
+}
+
+func TestRenderRateLimitWarningProducesContent(t *testing.T) {
+	pdf := fpdf.New("P", "mm", "Letter", "")
+	pdf.SetAutoPageBreak(true, 20)
+	registerUnicodeFont(pdf)
+	pdf.AddPage()
+	pdf.SetY(40)
+
+	report := &RateLimitReport{
+		TotalHits: 5, SQCHits: 5,
+		CumulativePauseSeconds: 120, CausedTaskFailure: true,
+	}
+	startY := pdf.GetY()
+	renderRateLimitWarning(pdf, report)
+	endY := pdf.GetY()
+
+	assert.Greater(t, endY, startY, "rendering must advance the Y cursor")
+
+	var buf bytes.Buffer
+	require.NoError(t, pdf.Output(&buf))
+	assert.Greater(t, buf.Len(), 1000, "PDF must be non-trivial after rendering the warning")
+}

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -48,6 +48,36 @@ type MigrationSummary struct {
 	Warnings      WarningLedger
 	Branches      []BranchStat
 	Throughput    ThroughputStats
+
+	// RateLimit is populated only when API rate limiting materially
+	// impacted the run (one or more tasks failed on 429, total pause
+	// exceeded the impact threshold, or any non-SQC 429 was observed).
+	// Nil for clean runs, which renders the report unchanged.
+	RateLimit *RateLimitReport
+}
+
+// RateLimitReport summarises 429 hits seen during the run for inclusion
+// in the orange callout box rendered between the executive summary and
+// the per-section tables.
+//
+// Counts are broken out by classification so the warning text can
+// distinguish between SonarQube Cloud's documented application rate
+// limit (recoverable via pause-and-resume) and non-standard 429s
+// (Cloudflare-managed limits, WAF blocks, or unknown upstreams) that
+// may require operator action.
+type RateLimitReport struct {
+	TotalHits              int
+	SQCHits                int
+	CloudflareHits         int
+	UnknownHits            int
+	CumulativePauseSeconds float64
+	CausedTaskFailure      bool
+	// FirstBodySnippet and FirstHeadersSummary capture the first
+	// non-SQC event observed (Cloudflare or unknown). Empty when the
+	// only observed events were SQC application limits — for those
+	// the body and headers add no operator-actionable signal.
+	FirstBodySnippet    string
+	FirstHeadersSummary string
 }
 
 // PhaseTiming captures the wall-clock duration of one migration phase.
@@ -149,9 +179,9 @@ type ThroughputStats struct {
 // from issues #224 and #227:
 //   - Succeeded   → green  (perfect-fidelity migration)
 //   - NearPerfect → yellow (migrated with a known close-equivalent substitution,
-//                   e.g. a metric mapping from #143)
+//     e.g. a metric mapping from #143)
 //   - Partial     → orange (created on SQC but a follow-up configuration step
-//                   was incomplete, or a feature was dropped)
+//     was incomplete, or a feature was dropped)
 //   - Failed      → red    (create call itself failed)
 //   - Skipped     → grey   (deliberately skipped by configuration)
 type Section struct {
@@ -166,7 +196,7 @@ type Section struct {
 // EntityItem represents a single entity in the report.
 type EntityItem struct {
 	Name         string
-	Language     string   // populated for Quality Profiles only; empty otherwise
+	Language     string // populated for Quality Profiles only; empty otherwise
 	Organization string
 	Detail       string   // cloud key for successes, scan history status, skip reason
 	ErrorMessage string   // failures only

--- a/lib/sq-api-go/client.go
+++ b/lib/sq-api-go/client.go
@@ -128,9 +128,13 @@ func buildTransport(cfg *clientConfig, token string, version float64) http.Round
 	}
 
 	retry := &retryTransport{
-		inner:   base,
-		backoff: defaultBackoff,
-		logFn:   cfg.retryLogFn,
+		inner:         base,
+		backoff:       defaultBackoff,
+		sqcBackoff:    sqc429Backoff,
+		nonSQCBackoff: nonSQC429Backoff,
+		logFn:         cfg.retryLogFn,
+		observer:      cfg.rateLimitObsFn,
+		gate:          &rateLimitGate{},
 	}
 
 	var rt http.RoundTripper = &authTransport{

--- a/lib/sq-api-go/export_test.go
+++ b/lib/sq-api-go/export_test.go
@@ -8,6 +8,7 @@
 package sqapi
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"time"
@@ -101,5 +102,5 @@ type RateLimitGate struct {
 	inner *rateLimitGate
 }
 
-func (g *RateLimitGate) WaitIfBlocked()         { g.inner.waitIfBlocked() }
-func (g *RateLimitGate) Extend(until time.Time) { g.inner.extend(until) }
+func (g *RateLimitGate) WaitIfBlocked(ctx context.Context)    { g.inner.waitIfBlocked(ctx) }
+func (g *RateLimitGate) Extend(until time.Time) time.Duration { return g.inner.extend(until) }

--- a/lib/sq-api-go/export_test.go
+++ b/lib/sq-api-go/export_test.go
@@ -51,3 +51,55 @@ func ApplyWithRetryLogger(fn RetryLogFunc) *clientConfig {
 	WithRetryLogger(fn)(cfg)
 	return cfg
 }
+
+// Classify429 exposes classify429 for tests.
+func Classify429(headers http.Header, body []byte) RateLimitKind {
+	return classify429(headers, body)
+}
+
+// ParseRetryAfterHeader exposes parseRetryAfter for tests.
+func ParseRetryAfterHeader(headers http.Header) time.Duration {
+	return parseRetryAfter(headers)
+}
+
+// RetryTransportConfig lets tests build a retry transport with every
+// behavior toggle exposed — separate 5xx / SQC-429 / non-SQC-429
+// schedules plus an optional observer and a freshly-allocated shared
+// gate.
+type RetryTransportConfig struct {
+	Inner         http.RoundTripper
+	Backoff       []time.Duration
+	SQCBackoff    []time.Duration
+	NonSQCBackoff []time.Duration
+	Logger        RetryLogFunc
+	Observer      RateLimitObserver
+}
+
+// NewRetryTransportFull constructs a retryTransport using cfg.
+func NewRetryTransportFull(cfg RetryTransportConfig) http.RoundTripper {
+	return &retryTransport{
+		inner:         cfg.Inner,
+		backoff:       cfg.Backoff,
+		sqcBackoff:    cfg.SQCBackoff,
+		nonSQCBackoff: cfg.NonSQCBackoff,
+		logFn:         cfg.Logger,
+		observer:      cfg.Observer,
+		gate:          &rateLimitGate{},
+	}
+}
+
+// NewRateLimitGate returns a freshly-allocated rate-limit gate for
+// testing the gate primitive in isolation.
+func NewRateLimitGate() *RateLimitGate {
+	return &RateLimitGate{inner: &rateLimitGate{}}
+}
+
+// RateLimitGate is a test wrapper around the unexported gate so tests
+// can drive WaitIfBlocked / Extend without depending on the retry
+// transport.
+type RateLimitGate struct {
+	inner *rateLimitGate
+}
+
+func (g *RateLimitGate) WaitIfBlocked()         { g.inner.waitIfBlocked() }
+func (g *RateLimitGate) Extend(until time.Time) { g.inner.extend(until) }

--- a/lib/sq-api-go/options.go
+++ b/lib/sq-api-go/options.go
@@ -15,12 +15,13 @@ type Option func(*clientConfig)
 
 // clientConfig holds optional Client configuration assembled from Option values.
 type clientConfig struct {
-	tlsConfig   *tls.Config
-	certErr     error // deferred cert loading error, reported on first request
-	maxConns    int
-	timeoutSecs int
-	retryLogFn  RetryLogFunc
-	debugLogFn  DebugLogFunc
+	tlsConfig      *tls.Config
+	certErr        error // deferred cert loading error, reported on first request
+	maxConns       int
+	timeoutSecs    int
+	retryLogFn     RetryLogFunc
+	debugLogFn     DebugLogFunc
+	rateLimitObsFn RateLimitObserver
 }
 
 // DebugLogFunc is invoked once per request/response pair with the verbatim
@@ -99,5 +100,16 @@ func WithRetryLogger(fn RetryLogFunc) Option {
 func WithDebugLogger(fn DebugLogFunc) Option {
 	return func(cfg *clientConfig) {
 		cfg.debugLogFn = fn
+	}
+}
+
+// WithRateLimitObserver installs a callback that fires once per observed
+// HTTP 429 response. The migration tool uses this to count rate-limit
+// hits per classification, sum cumulative pause time, and capture the
+// first event of each kind for the PDF report. The callback is invoked
+// from arbitrary goroutines and must be safe for concurrent use.
+func WithRateLimitObserver(fn RateLimitObserver) Option {
+	return func(cfg *clientConfig) {
+		cfg.rateLimitObsFn = fn
 	}
 }

--- a/lib/sq-api-go/ratelimit.go
+++ b/lib/sq-api-go/ratelimit.go
@@ -57,9 +57,18 @@ type RateLimitEvent struct {
 	Kind        RateLimitKind
 	RetryAfter  time.Duration // 0 if no Retry-After header was present
 	WaitChosen  time.Duration // duration the transport will sleep before retrying; 0 if no retry
-	BodySnippet string        // truncated to bodySnippetMax bytes
-	Headers     map[string]string
-	ObservedAt  time.Time
+	// WallClockAdded is the gate-deduplicated wall-clock pause this
+	// event actually contributes to the migration. For SQC 429s that
+	// share the rate-limit gate, only the first (or extending) event of
+	// a window reports the full pause; piggy-back events report 0. For
+	// non-gated 429s (Cloudflare/unknown) this equals WaitChosen. Use
+	// this — not WaitChosen — when summing total pause time, otherwise
+	// concurrent workers parking on the same gate window will inflate
+	// the total by N×.
+	WallClockAdded time.Duration
+	BodySnippet    string // truncated to bodySnippetMax bytes
+	Headers        map[string]string
+	ObservedAt     time.Time
 }
 
 // RateLimitObserver is invoked once per observed 429. Implementations

--- a/lib/sq-api-go/ratelimit.go
+++ b/lib/sq-api-go/ratelimit.go
@@ -1,0 +1,193 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package sqapi
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// RateLimitKind classifies an HTTP 429 response by its likely source.
+//
+// SonarQube Cloud's documented application rate limit returns a JSON body
+// matching the SonarQube error shape, with or without a Retry-After hint.
+// Upstream proxies (notably Cloudflare) can also return 429 — those
+// responses typically carry HTML bodies and Cloudflare-specific headers,
+// and may indicate an IP-level WAF rule rather than a steady-state quota.
+// Treating both identically risks pausing pointlessly when a WAF block is
+// active; the classification lets the transport pick an appropriate
+// retry strategy and lets the report surface non-standard 429s for
+// operator review.
+type RateLimitKind int
+
+const (
+	// KindUnknown429 is the zero value; used when a 429 cannot be
+	// classified, e.g. an empty body with no recognisable headers.
+	KindUnknown429 RateLimitKind = iota
+	// KindSQCRateLimit is SonarQube Cloud's application-layer rate limit.
+	KindSQCRateLimit
+	// KindCloudflareRateLimit is a 429 served by Cloudflare in front
+	// of SQC — either a Cloudflare-managed rate-limit rule or a
+	// WAF challenge that uses 429 as the action.
+	KindCloudflareRateLimit
+)
+
+// String returns the kind as a short stable identifier suitable for
+// logging and JSON serialisation.
+func (k RateLimitKind) String() string {
+	switch k {
+	case KindSQCRateLimit:
+		return "sqc-rate-limit"
+	case KindCloudflareRateLimit:
+		return "cloudflare-rate-limit"
+	default:
+		return "unknown-429"
+	}
+}
+
+// RateLimitEvent describes a single 429 observed by the retry transport.
+// It is delivered to RateLimitObserver callbacks so the caller can record
+// per-run statistics (counts, longest pause, first-event-of-each-kind
+// snapshots) without parsing logs.
+type RateLimitEvent struct {
+	Kind        RateLimitKind
+	RetryAfter  time.Duration // 0 if no Retry-After header was present
+	WaitChosen  time.Duration // duration the transport will sleep before retrying; 0 if no retry
+	BodySnippet string        // truncated to bodySnippetMax bytes
+	Headers     map[string]string
+	ObservedAt  time.Time
+}
+
+// RateLimitObserver is invoked once per observed 429. Implementations
+// must be safe for concurrent calls — the retry transport invokes it
+// directly from RoundTrip, which can run on many goroutines.
+type RateLimitObserver func(event RateLimitEvent)
+
+// bodySnippetMax is the maximum number of body bytes preserved in a
+// RateLimitEvent. Matches the truncation used by APIError.Body so the
+// report and the error message see comparable amounts of context.
+const bodySnippetMax = 500
+
+// rateLimitHeaders are the response headers worth capturing on a 429.
+// Order is preserved for readable summary strings in the PDF report.
+var rateLimitHeaders = []string{
+	"Retry-After",
+	"X-RateLimit-Limit",
+	"X-RateLimit-Remaining",
+	"X-RateLimit-Reset",
+	"CF-Ray",
+	"CF-Mitigated",
+	"Server",
+}
+
+// classify429 inspects a 429 response's body and headers and returns
+// the most likely source of the throttling decision.
+//
+// The detection is deliberately conservative: only responses that look
+// like SonarQube's JSON error envelope are classified as SQC; only
+// responses that carry Cloudflare-specific headers or HTML markers are
+// classified as Cloudflare; anything else falls through to
+// KindUnknown429 so the operator is shown the body in the PDF report.
+func classify429(headers http.Header, body []byte) RateLimitKind {
+	if isCloudflare429(headers, body) {
+		return KindCloudflareRateLimit
+	}
+	if isSonarJSONError(body) {
+		return KindSQCRateLimit
+	}
+	return KindUnknown429
+}
+
+// isCloudflare429 reports whether the response carries signals that
+// strongly suggest Cloudflare authored the 429 (managed rate limit,
+// WAF rule, or bot mitigation).
+func isCloudflare429(headers http.Header, body []byte) bool {
+	if headers.Get("CF-Ray") != "" {
+		return true
+	}
+	if headers.Get("CF-Mitigated") != "" {
+		return true
+	}
+	if strings.EqualFold(headers.Get("Server"), "cloudflare") {
+		return true
+	}
+	// Cloudflare's branded Error 1015 page is HTML and mentions
+	// "rate limited" or "Cloudflare" prominently. Catch the
+	// case where the headers were stripped but the body survives.
+	lower := strings.ToLower(string(trimForCheck(body)))
+	if strings.HasPrefix(lower, "<") && strings.Contains(lower, "cloudflare") {
+		return true
+	}
+	return false
+}
+
+// isSonarJSONError reports whether the body looks like SonarQube's
+// canonical error response shape: {"errors":[{"msg":"..."}]}. The check
+// is intentionally loose — it tolerates whitespace and additional fields
+// — so a future format tweak by Sonar that leaves the envelope intact
+// keeps working without code changes.
+func isSonarJSONError(body []byte) bool {
+	trimmed := trimForCheck(body)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+	lower := strings.ToLower(string(trimmed))
+	return strings.Contains(lower, `"errors"`)
+}
+
+// trimForCheck returns the body with leading whitespace stripped, capped
+// at bodySnippetMax bytes so prefix checks remain bounded.
+func trimForCheck(body []byte) []byte {
+	if len(body) > bodySnippetMax {
+		body = body[:bodySnippetMax]
+	}
+	return []byte(strings.TrimLeft(string(body), " \t\r\n"))
+}
+
+// parseRetryAfter parses the Retry-After response header in either of
+// the two RFC 7231 forms: a non-negative integer count of seconds, or
+// an HTTP-date. Returns 0 when the header is absent or unparseable, so
+// callers can use a "max(parsed, defaultBackoff)" pattern without nil
+// checks.
+func parseRetryAfter(headers http.Header) time.Duration {
+	raw := strings.TrimSpace(headers.Get("Retry-After"))
+	if raw == "" {
+		return 0
+	}
+	if secs, err := strconv.Atoi(raw); err == nil && secs >= 0 {
+		return time.Duration(secs) * time.Second
+	}
+	if t, err := http.ParseTime(raw); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+// snapshotHeaders extracts the rate-limit-relevant headers into a flat
+// map suitable for embedding in a RateLimitEvent or JSON-serialising
+// into the run's rate_limit_events.json artefact.
+func snapshotHeaders(headers http.Header) map[string]string {
+	out := make(map[string]string, len(rateLimitHeaders))
+	for _, name := range rateLimitHeaders {
+		if v := headers.Get(name); v != "" {
+			out[name] = v
+		}
+	}
+	return out
+}
+
+// snapshotBody returns the first bodySnippetMax bytes of body as a string.
+func snapshotBody(body []byte) string {
+	if len(body) > bodySnippetMax {
+		body = body[:bodySnippetMax]
+	}
+	return string(body)
+}

--- a/lib/sq-api-go/ratelimit_test.go
+++ b/lib/sq-api-go/ratelimit_test.go
@@ -1,0 +1,262 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package sqapi_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+func TestClassify429(t *testing.T) {
+	cases := []struct {
+		name    string
+		headers http.Header
+		body    []byte
+		want    sqapi.RateLimitKind
+	}{
+		{
+			name:    "sonar json body",
+			headers: http.Header{},
+			body:    []byte(`{"errors":[{"msg":"Rate limit exceeded"}]}`),
+			want:    sqapi.KindSQCRateLimit,
+		},
+		{
+			name:    "html body with cf-ray header",
+			headers: http.Header{"Cf-Ray": []string{"abc123-IAD"}},
+			body:    []byte("<html><body>Error 1015</body></html>"),
+			want:    sqapi.KindCloudflareRateLimit,
+		},
+		{
+			name:    "html body mentioning cloudflare, no header",
+			headers: http.Header{},
+			body:    []byte("<html><head><title>Cloudflare</title></head></html>"),
+			want:    sqapi.KindCloudflareRateLimit,
+		},
+		{
+			name:    "server cloudflare header",
+			headers: http.Header{"Server": []string{"cloudflare"}},
+			body:    nil,
+			want:    sqapi.KindCloudflareRateLimit,
+		},
+		{
+			name:    "empty body, no signals",
+			headers: http.Header{},
+			body:    nil,
+			want:    sqapi.KindUnknown429,
+		},
+		{
+			name:    "plain text body, no signals",
+			headers: http.Header{},
+			body:    []byte("Too Many Requests"),
+			want:    sqapi.KindUnknown429,
+		},
+		{
+			name:    "cf-mitigated header takes precedence",
+			headers: http.Header{"Cf-Mitigated": []string{"challenge"}},
+			body:    []byte(`{"errors":[{"msg":"x"}]}`),
+			want:    sqapi.KindCloudflareRateLimit,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sqapi.Classify429(tc.headers, tc.body)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestRateLimitKindString(t *testing.T) {
+	assert.Equal(t, "sqc-rate-limit", sqapi.KindSQCRateLimit.String())
+	assert.Equal(t, "cloudflare-rate-limit", sqapi.KindCloudflareRateLimit.String())
+	assert.Equal(t, "unknown-429", sqapi.KindUnknown429.String())
+}
+
+func TestClassify429LongBody(t *testing.T) {
+	long := append([]byte(`{"errors":[{"msg":"`), make([]byte, 1000)...)
+	for i := range long[len(`{"errors":[{"msg":"`):] {
+		long[len(`{"errors":[{"msg":"`)+i] = 'x'
+	}
+	got := sqapi.Classify429(http.Header{}, long)
+	assert.Equal(t, sqapi.KindSQCRateLimit, got,
+		"long bodies must still classify correctly via the bounded prefix")
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		name    string
+		header  string
+		wantMin time.Duration
+		wantMax time.Duration
+	}{
+		{"absent", "", 0, 0},
+		{"seconds", "42", 42 * time.Second, 42 * time.Second},
+		{"zero seconds", "0", 0, 0},
+		{"negative ignored", "-5", 0, 0},
+		{"garbage ignored", "soon", 0, 0},
+		{"http date in future", time.Now().Add(30 * time.Second).UTC().Format(http.TimeFormat), 25 * time.Second, 31 * time.Second},
+		{"http date in past", time.Now().Add(-time.Hour).UTC().Format(http.TimeFormat), 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := http.Header{}
+			if tc.header != "" {
+				h.Set("Retry-After", tc.header)
+			}
+			got := sqapi.ParseRetryAfterHeader(h)
+			assert.GreaterOrEqual(t, got, tc.wantMin)
+			assert.LessOrEqual(t, got, tc.wantMax)
+		})
+	}
+}
+
+func TestRetryTransportSQCBackoff(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"errors":[{"msg":"rate limit exceeded"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var observed sqapi.RateLimitEvent
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:      http.DefaultTransport,
+		Backoff:    []time.Duration{0},
+		SQCBackoff: []time.Duration{0, 0, 0},
+		Observer: func(e sqapi.RateLimitEvent) {
+			observed = e
+		},
+	})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(2), attempts.Load(), "should retry once after the 429")
+	assert.Equal(t, sqapi.KindSQCRateLimit, observed.Kind)
+	assert.Contains(t, observed.BodySnippet, "rate limit exceeded")
+}
+
+func TestRetryTransportFailFastForCloudflare(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.Header().Set("CF-Ray", "abc-DFW")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte("<html>Cloudflare error 1015</html>"))
+	}))
+	defer ts.Close()
+
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:         http.DefaultTransport,
+		Backoff:       []time.Duration{0, 0, 0, 0, 0},
+		SQCBackoff:    []time.Duration{0, 0, 0, 0, 0, 0},
+		NonSQCBackoff: []time.Duration{0},
+	})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(2), attempts.Load(),
+		"Cloudflare-classified 429 should fall under the short fail-fast schedule (1 retry)")
+}
+
+func TestRetryTransportRetryAfterHonored(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"errors":[{"msg":"slow down"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:      http.DefaultTransport,
+		Backoff:    []time.Duration{0},
+		SQCBackoff: []time.Duration{0, 0},
+	})
+
+	start := time.Now()
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	elapsed := time.Since(start)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.GreaterOrEqual(t, elapsed, 1*time.Second,
+		"Retry-After: 1 should produce at least one second of wall-clock pause")
+}
+
+func TestRateLimitGateExtend(t *testing.T) {
+	gate := sqapi.NewRateLimitGate()
+	gate.Extend(time.Now().Add(50 * time.Millisecond))
+
+	start := time.Now()
+	gate.WaitIfBlocked()
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond,
+		"WaitIfBlocked must sleep at least until the deadline")
+	assert.Less(t, elapsed, 200*time.Millisecond,
+		"WaitIfBlocked must not sleep substantially past the deadline")
+}
+
+func TestRateLimitGateExtendDoesNotShorten(t *testing.T) {
+	gate := sqapi.NewRateLimitGate()
+	gate.Extend(time.Now().Add(100 * time.Millisecond))
+	gate.Extend(time.Now().Add(10 * time.Millisecond)) // earlier — ignored
+
+	start := time.Now()
+	gate.WaitIfBlocked()
+	elapsed := time.Since(start)
+
+	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond,
+		"a later Extend with an earlier deadline must not shorten the wait")
+}
+
+func TestRateLimitGateConcurrent(t *testing.T) {
+	gate := sqapi.NewRateLimitGate()
+	gate.Extend(time.Now().Add(80 * time.Millisecond))
+
+	var wg sync.WaitGroup
+	elapsed := make([]time.Duration, 5)
+	for i := range elapsed {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			start := time.Now()
+			gate.WaitIfBlocked()
+			elapsed[idx] = time.Since(start)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, d := range elapsed {
+		assert.GreaterOrEqual(t, d, 60*time.Millisecond,
+			"goroutine %d should have waited on the gate", i)
+	}
+}

--- a/lib/sq-api-go/ratelimit_test.go
+++ b/lib/sq-api-go/ratelimit_test.go
@@ -5,6 +5,7 @@
 package sqapi_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -216,7 +217,7 @@ func TestRateLimitGateExtend(t *testing.T) {
 	gate.Extend(time.Now().Add(50 * time.Millisecond))
 
 	start := time.Now()
-	gate.WaitIfBlocked()
+	gate.WaitIfBlocked(context.Background())
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 40*time.Millisecond,
@@ -231,7 +232,7 @@ func TestRateLimitGateExtendDoesNotShorten(t *testing.T) {
 	gate.Extend(time.Now().Add(10 * time.Millisecond)) // earlier — ignored
 
 	start := time.Now()
-	gate.WaitIfBlocked()
+	gate.WaitIfBlocked(context.Background())
 	elapsed := time.Since(start)
 
 	assert.GreaterOrEqual(t, elapsed, 80*time.Millisecond,
@@ -249,7 +250,7 @@ func TestRateLimitGateConcurrent(t *testing.T) {
 		go func(idx int) {
 			defer wg.Done()
 			start := time.Now()
-			gate.WaitIfBlocked()
+			gate.WaitIfBlocked(context.Background())
 			elapsed[idx] = time.Since(start)
 		}(i)
 	}
@@ -259,4 +260,65 @@ func TestRateLimitGateConcurrent(t *testing.T) {
 		assert.GreaterOrEqual(t, d, 60*time.Millisecond,
 			"goroutine %d should have waited on the gate", i)
 	}
+}
+
+// TestRateLimitGateExtendReturnsAddedDelta verifies that extend reports
+// the wall-clock pause it actually contributed. The first extend returns
+// the full wait; subsequent piggy-back extends to the same or earlier
+// deadline return zero; later-extending calls return only the delta
+// beyond the prior deadline.
+func TestRateLimitGateExtendReturnsAddedDelta(t *testing.T) {
+	gate := sqapi.NewRateLimitGate()
+
+	first := gate.Extend(time.Now().Add(60 * time.Second))
+	assert.InDelta(t, 60*time.Second, first, float64(time.Second),
+		"first extend should return the full pause")
+
+	piggy := gate.Extend(time.Now().Add(60 * time.Second))
+	assert.LessOrEqual(t, piggy, 100*time.Millisecond,
+		"piggy-back extend to same deadline should add near-zero")
+
+	earlier := gate.Extend(time.Now().Add(30 * time.Second))
+	assert.Equal(t, time.Duration(0), earlier,
+		"extend to an earlier deadline should add zero")
+
+	longer := gate.Extend(time.Now().Add(90 * time.Second))
+	assert.InDelta(t, 30*time.Second, longer, float64(time.Second),
+		"extending past the current deadline should add only the delta")
+}
+
+// TestRateLimitGateExtendAfterWindowExpired verifies that a new extend
+// arriving after the previous window has ended counts only the new
+// pause, not the gap of unpaused time in between.
+func TestRateLimitGateExtendAfterWindowExpired(t *testing.T) {
+	gate := sqapi.NewRateLimitGate()
+	gate.Extend(time.Now().Add(20 * time.Millisecond))
+	time.Sleep(40 * time.Millisecond) // let the window expire
+
+	added := gate.Extend(time.Now().Add(50 * time.Millisecond))
+	assert.GreaterOrEqual(t, added, 40*time.Millisecond,
+		"new window after expiry should report its own pause")
+	assert.LessOrEqual(t, added, 60*time.Millisecond,
+		"new window after expiry should exclude the unpaused gap")
+}
+
+// TestRateLimitGateContextCancellation verifies that WaitIfBlocked aborts
+// promptly when the caller's context is cancelled, instead of blocking
+// for the full remaining duration of the gate.
+func TestRateLimitGateContextCancellation(t *testing.T) {
+	gate := sqapi.NewRateLimitGate()
+	gate.Extend(time.Now().Add(5 * time.Second))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	gate.WaitIfBlocked(ctx)
+	elapsed := time.Since(start)
+
+	assert.Less(t, elapsed, 500*time.Millisecond,
+		"WaitIfBlocked must return promptly when context is cancelled")
 }

--- a/lib/sq-api-go/retry.go
+++ b/lib/sq-api-go/retry.go
@@ -5,6 +5,7 @@
 package sqapi
 
 import (
+	"context"
 	"io"
 	"math/rand/v2"
 	"net/http"
@@ -76,12 +77,15 @@ type rateLimitGate struct {
 	blocked time.Time
 }
 
-func (g *rateLimitGate) waitIfBlocked() {
+func (g *rateLimitGate) waitIfBlocked(ctx context.Context) {
 	g.mu.Lock()
 	until := g.blocked
 	g.mu.Unlock()
 	if d := time.Until(until); d > 0 {
-		time.Sleep(d)
+		select {
+		case <-ctx.Done():
+		case <-time.After(d):
+		}
 	}
 }
 
@@ -119,7 +123,7 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	)
 
 	for attempt := 0; ; attempt++ {
-		t.waitOnGate()
+		t.waitOnGate(req.Context())
 
 		resp, err = t.inner.RoundTrip(req)
 		if !shouldRetry(resp, err) {
@@ -139,7 +143,11 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		if rl.isSonarRateLimit() {
 			t.extendGate(time.Now().Add(wait))
 		}
-		time.Sleep(jitter(wait))
+		select {
+		case <-req.Context().Done():
+			return resp, req.Context().Err()
+		case <-time.After(jitter(wait)):
+		}
 	}
 }
 
@@ -258,9 +266,9 @@ func clampRetryAfter(server, scheduled time.Duration) time.Duration {
 	return d
 }
 
-func (t *retryTransport) waitOnGate() {
+func (t *retryTransport) waitOnGate(ctx context.Context) {
 	if t.gate != nil {
-		t.gate.waitIfBlocked()
+		t.gate.waitIfBlocked(ctx)
 	}
 }
 

--- a/lib/sq-api-go/retry.go
+++ b/lib/sq-api-go/retry.go
@@ -8,16 +8,46 @@ import (
 	"io"
 	"math/rand/v2"
 	"net/http"
+	"sync"
 	"time"
 )
 
-// defaultBackoff is the base wait duration between retry attempts.
-// Attempt 1 fails → wait defaultBackoff[0] before attempt 2, etc.
+// defaultBackoff is the base wait duration between retries triggered by
+// 5xx responses or network errors. Attempt 1 fails → wait
+// defaultBackoff[0] before attempt 2, etc.
 var defaultBackoff = []time.Duration{
 	100 * time.Millisecond,
 	200 * time.Millisecond,
 	400 * time.Millisecond,
 }
+
+// sqc429Backoff is the long retry schedule applied when a 429 response
+// is classified as KindSQCRateLimit. SonarQube Cloud's documented
+// guidance is to "wait a few minutes before retrying" — the per-attempt
+// values escalate so a busy-cluster blip recovers quickly while a
+// sustained limit gives the bucket time to refill.
+var sqc429Backoff = []time.Duration{
+	5 * time.Second,
+	15 * time.Second,
+	30 * time.Second,
+	60 * time.Second,
+	120 * time.Second,
+	300 * time.Second,
+}
+
+// nonSQC429Backoff is the short schedule applied when a 429 response is
+// classified as KindCloudflareRateLimit or KindUnknown429. The first
+// (and only) retry happens quickly so a transient mis-classification
+// recovers, but the transport refuses to pause for minutes against an
+// upstream WAF block that may need operator intervention.
+var nonSQC429Backoff = []time.Duration{
+	2 * time.Second,
+}
+
+// retryAfterCap bounds the wall-clock pause induced by an honored
+// Retry-After header. Without this, a misconfigured proxy could ask us
+// to wait hours — well past any reasonable migration tolerance.
+const retryAfterCap = 300 * time.Second
 
 // retryableStatusCodes are HTTP status codes that warrant a retry.
 // 429 (rate limit) and 5xx (server errors) are retried.
@@ -35,14 +65,51 @@ var retryableStatusCodes = map[int]bool{
 // current attempt number (1-based), and total attempts.
 type RetryLogFunc func(method, url string, status, attempt, total int)
 
-// retryTransport is an http.RoundTripper that retries failed requests with
-// exponential backoff plus up to 50% random jitter.
+// rateLimitGate is a shared barrier that holds new requests when an
+// SQC-classified 429 has been observed, until the chosen backoff has
+// elapsed. Concurrent workers all park on the same deadline instead of
+// each independently burning through retries against an exhausted
+// bucket. Only Sonar-classified 429s extend the gate; Cloudflare/unknown
+// 429s fail fast and do not pause sibling requests.
+type rateLimitGate struct {
+	mu      sync.Mutex
+	blocked time.Time
+}
+
+func (g *rateLimitGate) waitIfBlocked() {
+	g.mu.Lock()
+	until := g.blocked
+	g.mu.Unlock()
+	if d := time.Until(until); d > 0 {
+		time.Sleep(d)
+	}
+}
+
+func (g *rateLimitGate) extend(until time.Time) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if until.After(g.blocked) {
+		g.blocked = until
+	}
+}
+
+// retryTransport is an http.RoundTripper that retries failed requests
+// with classification-aware backoff. 5xx and network errors use the
+// default schedule. 429 responses are classified by classify429 and use
+// the longer sqc429Backoff for application-layer SQC rate limits or the
+// shorter nonSQC429Backoff for Cloudflare/unknown 429s.
 //
-// Total attempts = len(backoff) + 1.
+// sqcBackoff and nonSQCBackoff are optional overrides. When nil, the
+// transport falls back to backoff — preserving the single-schedule
+// behavior expected by existing tests built on NewRetryTransport.
 type retryTransport struct {
-	inner   http.RoundTripper
-	backoff []time.Duration
-	logFn   RetryLogFunc // nil = no logging (backward compatible)
+	inner         http.RoundTripper
+	backoff       []time.Duration
+	sqcBackoff    []time.Duration
+	nonSQCBackoff []time.Duration
+	logFn         RetryLogFunc
+	observer      RateLimitObserver
+	gate          *rateLimitGate
 }
 
 func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -51,34 +118,184 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		err  error
 	)
 
-	totalAttempts := len(t.backoff) + 1
+	for attempt := 0; ; attempt++ {
+		t.waitOnGate()
 
-	for attempt := range totalAttempts {
 		resp, err = t.inner.RoundTrip(req)
-
-		if err == nil && !retryableStatusCodes[resp.StatusCode] {
-			return resp, nil
+		if !shouldRetry(resp, err) {
+			return resp, err
 		}
 
-		// Drain and close the body before retrying so the connection can be reused.
-		if resp != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			resp.Body.Close()
+		rl := t.observeRateLimit(resp)
+		drainAndClose(resp)
+
+		wait, total, more := t.nextWait(rl, attempt)
+		t.fireObserver(rl, chosenWaitOrZero(wait, more))
+		if !more {
+			return resp, err
 		}
 
-		if attempt < len(t.backoff) {
-			status := 0
-			if resp != nil {
-				status = resp.StatusCode
-			}
-			if t.logFn != nil {
-				t.logFn(req.Method, req.URL.Path, status, attempt+1, totalAttempts)
-			}
-			time.Sleep(jitter(t.backoff[attempt]))
+		t.logAttempt(req, resp, attempt, total)
+		if rl.isSonarRateLimit() {
+			t.extendGate(time.Now().Add(wait))
 		}
+		time.Sleep(jitter(wait))
 	}
+}
 
-	return resp, err
+// chosenWaitOrZero returns wait when a retry will follow, or zero when
+// the transport is about to give up. The observer records the zero so
+// the report can distinguish "this 429 cost N seconds of pause" from
+// "this 429 killed the task outright."
+func chosenWaitOrZero(wait time.Duration, more bool) time.Duration {
+	if more {
+		return wait
+	}
+	return 0
+}
+
+// shouldRetry reports whether the (resp, err) pair from inner.RoundTrip
+// warrants another attempt. Network errors (nil resp or non-nil err)
+// always retry; otherwise the status code must be in retryableStatusCodes.
+func shouldRetry(resp *http.Response, err error) bool {
+	if err != nil || resp == nil {
+		return true
+	}
+	return retryableStatusCodes[resp.StatusCode]
+}
+
+// drainAndClose empties the response body so the underlying connection
+// can be reused, then closes it. Safe to call with a nil response.
+func drainAndClose(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}
+
+// rateLimitInfo summarises what was learned from inspecting a 429
+// response. For non-429 outcomes (5xx, network errors) all fields are
+// zero values, signalling "use the default schedule, no observer call".
+type rateLimitInfo struct {
+	kind       RateLimitKind
+	retryAfter time.Duration
+	body       []byte
+	headers    http.Header
+	is429      bool
+}
+
+func (r rateLimitInfo) isSonarRateLimit() bool {
+	return r.is429 && r.kind == KindSQCRateLimit
+}
+
+// observeRateLimit reads a 429 response's body and headers, classifies
+// it, and returns a rateLimitInfo describing what was found. The body
+// is consumed but not yet closed — drainAndClose handles the remainder
+// and connection cleanup afterwards. For non-429 responses it returns
+// the zero rateLimitInfo without touching the body.
+func (t *retryTransport) observeRateLimit(resp *http.Response) rateLimitInfo {
+	if resp == nil || resp.StatusCode != http.StatusTooManyRequests {
+		return rateLimitInfo{}
+	}
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, bodySnippetMax+1))
+	return rateLimitInfo{
+		kind:       classify429(resp.Header, body),
+		retryAfter: parseRetryAfter(resp.Header),
+		body:       body,
+		headers:    resp.Header,
+		is429:      true,
+	}
+}
+
+// nextWait picks the duration to sleep before the next attempt. Returns
+// (wait, totalAttempts, more) where `more` is false when no further
+// retries are available — the caller should return the current response
+// to its caller.
+func (t *retryTransport) nextWait(rl rateLimitInfo, attempt int) (time.Duration, int, bool) {
+	schedule := t.scheduleFor(rl)
+	total := len(schedule) + 1
+	if attempt >= len(schedule) {
+		return 0, total, false
+	}
+	base := schedule[attempt]
+	if rl.is429 && rl.retryAfter > 0 {
+		base = clampRetryAfter(rl.retryAfter, base)
+	}
+	return base, total, true
+}
+
+// scheduleFor returns the backoff schedule that applies to the current
+// retryable outcome. 429s use the kind-specific schedule (with
+// fallback to the default when the override is nil); 5xx and network
+// errors use the default schedule.
+func (t *retryTransport) scheduleFor(rl rateLimitInfo) []time.Duration {
+	if !rl.is429 {
+		return t.backoff
+	}
+	override := t.nonSQCBackoff
+	if rl.kind == KindSQCRateLimit {
+		override = t.sqcBackoff
+	}
+	if override != nil {
+		return override
+	}
+	return t.backoff
+}
+
+// clampRetryAfter returns a duration not less than scheduled and not
+// more than retryAfterCap. Honoring Retry-After lets the server's
+// hint take precedence over our schedule when it's longer; the cap
+// protects against pathological hints.
+func clampRetryAfter(server, scheduled time.Duration) time.Duration {
+	d := server
+	if scheduled > d {
+		d = scheduled
+	}
+	if d > retryAfterCap {
+		d = retryAfterCap
+	}
+	return d
+}
+
+func (t *retryTransport) waitOnGate() {
+	if t.gate != nil {
+		t.gate.waitIfBlocked()
+	}
+}
+
+func (t *retryTransport) extendGate(until time.Time) {
+	if t.gate != nil {
+		t.gate.extend(until)
+	}
+}
+
+func (t *retryTransport) logAttempt(req *http.Request, resp *http.Response, attempt, total int) {
+	if t.logFn == nil {
+		return
+	}
+	status := 0
+	if resp != nil {
+		status = resp.StatusCode
+	}
+	t.logFn(req.Method, req.URL.Path, status, attempt+1, total)
+}
+
+// fireObserver delivers the rate-limit event to the configured callback.
+// Called from observeRateLimit so subsequent body draining and retry
+// decisions don't race with observer-side accounting.
+func (t *retryTransport) fireObserver(rl rateLimitInfo, wait time.Duration) {
+	if t.observer == nil || !rl.is429 {
+		return
+	}
+	t.observer(RateLimitEvent{
+		Kind:        rl.kind,
+		RetryAfter:  rl.retryAfter,
+		WaitChosen:  wait,
+		BodySnippet: snapshotBody(rl.body),
+		Headers:     snapshotHeaders(rl.headers),
+		ObservedAt:  time.Now(),
+	})
 }
 
 // jitter adds a random amount up to 50% of d to d.

--- a/lib/sq-api-go/retry.go
+++ b/lib/sq-api-go/retry.go
@@ -89,12 +89,32 @@ func (g *rateLimitGate) waitIfBlocked(ctx context.Context) {
 	}
 }
 
-func (g *rateLimitGate) extend(until time.Time) {
+// extend pushes the gate's deadline out to `until` (no-op if `until` is
+// not later than the current deadline) and returns the wall-clock
+// duration this call adds beyond what was already pending. When several
+// concurrent requests park on the same window, only the first one
+// reports the full wait; subsequent extends with the same or earlier
+// deadlines return 0. When a new 429 arrives after the previous window
+// expired, the prior unpaused gap is excluded from the returned delta.
+// Callers use this to record wall-clock pause time accurately rather
+// than summing per-request waits, which would over-count under high
+// concurrency.
+func (g *rateLimitGate) extend(until time.Time) (added time.Duration) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	now := time.Now()
+	effectivePrev := g.blocked
+	if effectivePrev.Before(now) {
+		effectivePrev = now
+	}
 	if until.After(g.blocked) {
 		g.blocked = until
 	}
+	added = g.blocked.Sub(effectivePrev)
+	if added < 0 {
+		added = 0
+	}
+	return added
 }
 
 // retryTransport is an http.RoundTripper that retries failed requests
@@ -134,15 +154,21 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		drainAndClose(resp)
 
 		wait, total, more := t.nextWait(rl, attempt)
-		t.fireObserver(rl, chosenWaitOrZero(wait, more))
+		chosenWait := chosenWaitOrZero(wait, more)
+		wallClockAdded := time.Duration(0)
+		if more {
+			if rl.isSonarRateLimit() {
+				wallClockAdded = t.extendGate(time.Now().Add(wait))
+			} else {
+				wallClockAdded = chosenWait
+			}
+		}
+		t.fireObserver(rl, chosenWait, wallClockAdded)
 		if !more {
 			return resp, err
 		}
 
 		t.logAttempt(req, resp, attempt, total)
-		if rl.isSonarRateLimit() {
-			t.extendGate(time.Now().Add(wait))
-		}
 		select {
 		case <-req.Context().Done():
 			return resp, req.Context().Err()
@@ -272,10 +298,11 @@ func (t *retryTransport) waitOnGate(ctx context.Context) {
 	}
 }
 
-func (t *retryTransport) extendGate(until time.Time) {
-	if t.gate != nil {
-		t.gate.extend(until)
+func (t *retryTransport) extendGate(until time.Time) time.Duration {
+	if t.gate == nil {
+		return 0
 	}
+	return t.gate.extend(until)
 }
 
 func (t *retryTransport) logAttempt(req *http.Request, resp *http.Response, attempt, total int) {
@@ -290,19 +317,22 @@ func (t *retryTransport) logAttempt(req *http.Request, resp *http.Response, atte
 }
 
 // fireObserver delivers the rate-limit event to the configured callback.
-// Called from observeRateLimit so subsequent body draining and retry
-// decisions don't race with observer-side accounting.
-func (t *retryTransport) fireObserver(rl rateLimitInfo, wait time.Duration) {
+// wait is what this request will sleep; wallClockAdded is the
+// gate-deduplicated wall-clock pause this event actually contributed
+// (equals wait for non-gated 429s, 0 for piggy-back gated waits, or the
+// delta beyond the prior window for an extending gated wait).
+func (t *retryTransport) fireObserver(rl rateLimitInfo, wait, wallClockAdded time.Duration) {
 	if t.observer == nil || !rl.is429 {
 		return
 	}
 	t.observer(RateLimitEvent{
-		Kind:        rl.kind,
-		RetryAfter:  rl.retryAfter,
-		WaitChosen:  wait,
-		BodySnippet: snapshotBody(rl.body),
-		Headers:     snapshotHeaders(rl.headers),
-		ObservedAt:  time.Now(),
+		Kind:           rl.kind,
+		RetryAfter:     rl.retryAfter,
+		WaitChosen:     wait,
+		WallClockAdded: wallClockAdded,
+		BodySnippet:    snapshotBody(rl.body),
+		Headers:        snapshotHeaders(rl.headers),
+		ObservedAt:     time.Now(),
 	})
 }
 

--- a/lib/sq-api-go/retry.go
+++ b/lib/sq-api-go/retry.go
@@ -219,7 +219,7 @@ func (t *retryTransport) nextWait(rl rateLimitInfo, attempt int) (time.Duration,
 		return 0, total, false
 	}
 	base := schedule[attempt]
-	if rl.is429 && rl.retryAfter > 0 {
+	if rl.isSonarRateLimit() && rl.retryAfter > 0 {
 		base = clampRetryAfter(rl.retryAfter, base)
 	}
 	return base, total, true


### PR DESCRIPTION
Add SQC API rate-limit detection, classification, and PDF warning per issue #203
This pull request introduces comprehensive tracking and reporting of API rate limiting events during migration runs. It adds a new mechanism to observe, accumulate, and persist rate limit events, and surfaces them in the generated migration summary and PDF report when they have a material impact. The changes also include thorough unit tests for the new functionality.

**Key changes include:**

**Rate limit tracking and persistence:**
- Added a new `RateLimitTracker` in `migrate/ratelimit.go` to observe and accumulate HTTP 429 (rate limit) events, including detailed information about each event, and to write a JSON artefact (`rate_limit_events.json`) summarizing these events at the end of a migration run. This artefact is only written if any rate limiting was observed.
- Integrated the `RateLimitTracker` into the migration workflow in `migrate.go`, so that all rate limit events are tracked and the artefact is written in the run directory. [[1]](diffhunk://#diff-62e7291cfe384a46e83e902f2dffc38e9e6e729e6222adfb0f0df104a8cc3acaL110-R123) [[2]](diffhunk://#diff-62e7291cfe384a46e83e902f2dffc38e9e6e729e6222adfb0f0df104a8cc3acaR183-R188)

**Reporting and PDF rendering:**
- Implemented logic in `summary/ratelimit.go` to read and interpret the rate limit artefact, determining whether rate limiting materially impacted the run (e.g., caused failures, significant delays, or non-standard 429s), and to summarize this information for the report.
- Updated the summary collection and PDF rendering code to include a prominent warning box in the PDF report when significant rate limiting was detected, with human-friendly explanations and diagnostic details. [[1]](diffhunk://#diff-2801286d88f0d6070d8d230bce1c73c96da0150db14be6f062ef727bb4fc2854R74) [[2]](diffhunk://#diff-d389e4e68a8c840b58b0892c68a2325ef0fa73a0dc07e2ead99d81940a0a29a4R118-R121)

**Testing and dependencies:**
- Added a comprehensive test suite for the new tracker in `ratelimit_test.go`, covering concurrency, event accumulation, and correct file output.
- Introduced new dependencies (`testify`, `go-spew`, `go-difflib`, `yaml.v3`) for improved testing and tooling.

These changes ensure that operators are clearly informed of any rate limiting that may have affected migration performance or outcomes, and provide actionable diagnostics in the migration artefacts and reports.