### PR TITLE
Issue #333: merge task summary and duration into one log line

### DIFF
--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
@@ -310,17 +311,45 @@ func NewTaskCounter(task string) *TaskCounter {
 	return &TaskCounter{task: task}
 }
 
+// taskCounterCtxKey scopes the per-task counter inside the task's
+// context (#333). runPhase injects a fresh counter so the merged
+// "task summary" log can be emitted from a single place after the
+// task returns.
+type taskCounterCtxKey struct{}
+
+// WithTaskCounter returns a child context carrying the given counter.
+func WithTaskCounter(ctx context.Context, c *TaskCounter) context.Context {
+	return context.WithValue(ctx, taskCounterCtxKey{}, c)
+}
+
+// TaskCounterFromContext returns the counter injected by runPhase, or
+// a throwaway counter if none is present (so tests and ad-hoc Run
+// invocations that bypass runPhase still compile and run).
+func TaskCounterFromContext(ctx context.Context) *TaskCounter {
+	if c, ok := ctx.Value(taskCounterCtxKey{}).(*TaskCounter); ok && c != nil {
+		return c
+	}
+	return NewTaskCounter("")
+}
+
 // Success increments the success count.
 func (c *TaskCounter) Success() { c.succeeded.Add(1) }
 
 // Fail increments the failure count.
 func (c *TaskCounter) Fail() { c.failed.Add(1) }
 
-// LogSummary logs the final counts. Only logs if there were any operations.
-func (c *TaskCounter) LogSummary(logger *slog.Logger) {
+// LogSummary emits the end-of-task INFO log. When the counter saw at
+// least one Success/Fail it logs a "task summary" line that carries
+// both the counts and the elapsed duration (#333 — merged from the
+// previously-separate "Task X: Duration ..." line). When the counter
+// is empty (setup-style tasks that don't track per-item outcomes), it
+// falls back to the plain duration line so every task still ends with
+// exactly one closing log entry.
+func (c *TaskCounter) LogSummary(logger *slog.Logger, duration time.Duration) {
 	s, f := c.succeeded.Load(), c.failed.Load()
 	total := s + f
 	if total == 0 {
+		common.LogTaskDuration(logger, c.task, duration)
 		return
 	}
 	logger.Info("task summary",
@@ -328,6 +357,7 @@ func (c *TaskCounter) LogSummary(logger *slog.Logger) {
 		"succeeded", s,
 		"failed", f,
 		"total", total,
+		"duration", common.FormatHMSMillis(duration),
 	)
 }
 

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
@@ -265,7 +266,8 @@ func TestTaskCounterFailAndSummary(t *testing.T) {
 	c.Success()
 	c.Success()
 	c.Fail()
-	c.LogSummary(logger)
+	// #333: LogSummary now carries duration alongside the counts.
+	c.LogSummary(logger, 54139*time.Millisecond)
 
 	output := buf.String()
 	if !strings.Contains(output, "succeeded=2") {
@@ -277,17 +279,32 @@ func TestTaskCounterFailAndSummary(t *testing.T) {
 	if !strings.Contains(output, "total=3") {
 		t.Errorf("expected total=3, got: %s", output)
 	}
+	if !strings.Contains(output, "duration=00:00:54.139") {
+		t.Errorf("expected duration=00:00:54.139 attribute, got: %s", output)
+	}
+	// The combined log must be a single "task summary" line — not two
+	// separate lines (the regression #333 patched).
+	if strings.Count(output, "\n") != 1 {
+		t.Errorf("expected exactly one log line, got: %s", output)
+	}
 }
 
+// #333: an empty counter (no Success/Fail recorded) falls back to the
+// plain "Task X: Duration ..." line so every task still emits exactly
+// one closing log entry.
 func TestTaskCounterEmptySummary(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	c := NewTaskCounter("empty")
-	c.LogSummary(logger)
+	c.LogSummary(logger, 250*time.Millisecond)
 
-	if buf.Len() > 0 {
-		t.Errorf("expected no output for empty counter, got: %s", buf.String())
+	output := buf.String()
+	if !strings.Contains(output, "Task empty: Duration 00:00:00.250") {
+		t.Errorf("expected standalone duration line, got: %s", output)
+	}
+	if strings.Contains(output, "succeeded=") {
+		t.Errorf("empty counter should not emit succeeded/failed attrs, got: %s", output)
 	}
 }
 

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -276,7 +276,9 @@ func runPhase(ctx context.Context, e *Executor, taskNames []string, registry map
 		e.Logger.Info("running task", "task", name)
 		g.Go(func() error {
 			taskStart := time.Now()
-			runErr := def.Run(ctx, e)
+			counter := NewTaskCounter(name)
+			taskCtx := WithTaskCounter(ctx, counter)
+			runErr := def.Run(taskCtx, e)
 			elapsed := time.Since(taskStart)
 			tm.addTask(TaskTiming{
 				Phase:    phaseIdx,
@@ -285,10 +287,11 @@ func runPhase(ctx context.Context, e *Executor, taskNames []string, registry map
 				OK:       runErr == nil,
 				Err:      errString(runErr),
 			})
-			// Per-task end-of-run timing line (#311). Emitted on
-			// both success and failure paths so operators tailing
-			// the log always see a closing bookend.
-			common.LogTaskDuration(e.Logger, name, elapsed)
+			// Single end-of-task INFO log carrying counts + duration
+			// (#311 + #333). When the task didn't record any per-
+			// item outcomes the helper falls back to a plain
+			// duration line.
+			counter.LogSummary(e.Logger, elapsed)
 			if runErr != nil {
 				e.Logger.Error("task failed", "task", name, "err", runErr)
 				return fmt.Errorf("task %s: %w", name, runErr)

--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -150,10 +150,12 @@ func runResetPhase(ctx context.Context, e *Executor, taskNames []string, registr
 		e.Logger.Info("running task", "task", name)
 		g.Go(func() error {
 			taskStart := time.Now()
-			err := def.Run(ctx, e)
-			// Per-task end-of-run timing line (#311), emitted on
-			// both success and failure paths.
-			common.LogTaskDuration(e.Logger, name, time.Since(taskStart))
+			counter := NewTaskCounter(name)
+			taskCtx := WithTaskCounter(ctx, counter)
+			err := def.Run(taskCtx, e)
+			// Single end-of-task INFO log carrying counts + duration
+			// (#311 + #333). Empty counter → plain duration line.
+			counter.LogSummary(e.Logger, time.Since(taskStart))
 			if err != nil {
 				return fmt.Errorf("task %s: %w", name, err)
 			}

--- a/go/internal/migrate/tasks_alm.go
+++ b/go/internal/migrate/tasks_alm.go
@@ -93,7 +93,7 @@ func runMatchProjectRepos(ctx context.Context, e *Executor) error {
 }
 
 func runSetProjectBinding(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("setProjectBinding")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "setProjectBinding", "matchProjectRepos",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			projID := extractField(item, "project_id")
@@ -117,7 +117,6 @@ func runSetProjectBinding(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 

--- a/go/internal/migrate/tasks_analyze_profiles.go
+++ b/go/internal/migrate/tasks_analyze_profiles.go
@@ -20,7 +20,7 @@ import (
 // No SonarQube Cloud API calls are made — this task is a pure
 // re-read of extract data, so it's safe to re-run.
 func runAnalyzeProfileRules(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("analyzeProfileRules")
+	counter := TaskCounterFromContext(ctx)
 
 	// Pre-load extract data once and index it.
 	activeByProfile := indexExtractByServerAndField(e, "getActiveProfileRules", "profileKey")
@@ -58,7 +58,6 @@ func runAnalyzeProfileRules(ctx context.Context, e *Executor) error {
 			counter.Success()
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -156,7 +156,7 @@ func runSetProjectProfiles(ctx context.Context, e *Executor) error {
 		projectLookup[server+srcKey] = projTarget{cloudKey: cloudKey, orgKey: orgKey}
 	}
 
-	counter := NewTaskCounter("setProjectProfiles")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProjectProfiles", "getProfileProjects",
 		func(ctx context.Context, ext structure.ExtractItem, w *common.ChunkWriter) error {
 			server := extractField(ext.Data, "serverUrl")
@@ -188,7 +188,6 @@ func runSetProjectProfiles(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -203,7 +202,7 @@ func runSetProjectGates(ctx context.Context, e *Executor) error {
 		gateLookup[orgKey+name] = id
 	}
 
-	counter := NewTaskCounter("setProjectGates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "setProjectGates", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -226,7 +225,6 @@ func runSetProjectGates(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -243,7 +241,7 @@ func runSetProjectGroupPermissions(ctx context.Context, e *Executor) error {
 		}
 	}
 
-	counter := NewTaskCounter("setProjectGroupPermissions")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProjectGroupPermissions", "getProjectGroupsPermissions",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			project := extractField(item.Data, "project")
@@ -254,7 +252,6 @@ func runSetProjectGroupPermissions(ctx context.Context, e *Executor) error {
 			applyGroupPermissions(ctx, e, item.Data, pm, w, counter)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -346,7 +343,7 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	var coveredMu sync.Mutex
 	covered := make(map[string]map[string]bool, len(projectKeyMap))
 
-	counter := NewTaskCounter("setProjectSettings")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProjectSettings", "getProjectSettings",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			// projectSettingsTask enriches each setting with "project": <key>
@@ -412,7 +409,6 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 			return nil
 		})
 	if err != nil {
-		counter.LogSummary(e.Logger)
 		return err
 	}
 
@@ -421,11 +417,9 @@ func runSetProjectSettings(ctx context.Context, e *Executor) error {
 	// settings) and #191 (external analyzer settings) — and any future
 	// global setting that has no SQC org-level counterpart.
 	if err := propagateGlobalsToProjects(ctx, e, projectKeyMap, defsByOrg, projectDefsByOrg, covered, counter); err != nil {
-		counter.LogSummary(e.Logger)
 		return err
 	}
 
-	counter.LogSummary(e.Logger)
 	return nil
 }
 
@@ -585,7 +579,7 @@ func runSetNewCodePeriods(ctx context.Context, e *Executor) error {
 	// SonarCloud built-in default (previous_version).
 	orgDefaultType, orgDefaultValue := projectScopeOrgDefaultNCD(e)
 
-	counter := NewTaskCounter("setNewCodePeriods")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setNewCodePeriods", "getNewCodePeriods",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			projectKey := extractField(item.Data, "projectKey")
@@ -689,7 +683,6 @@ func runSetNewCodePeriods(ctx context.Context, e *Executor) error {
 			_ = w.WriteOne(item.Data)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -813,7 +806,7 @@ func runSetGlobalNewCodePeriod(ctx context.Context, e *Executor) error {
 
 	orgItems, _ := e.Store.ReadAll("generateOrganizationMappings")
 	seen := make(map[string]struct{})
-	counter := NewTaskCounter("setGlobalNewCodePeriod")
+	counter := TaskCounterFromContext(ctx)
 
 	// Build per-org outcomes so the report's Global Settings section
 	// can render one row per (NCD, org) just like every other global
@@ -890,7 +883,6 @@ func runSetGlobalNewCodePeriod(ctx context.Context, e *Executor) error {
 			Detail: "Applied (" + ncdSummary + ")",
 		})
 	}
-	counter.LogSummary(e.Logger)
 
 	// Write a single record describing the migration so the report
 	// section picks it up. Using key="newCodePeriod" — a synthetic
@@ -923,7 +915,7 @@ func runSetProjectTags(ctx context.Context, e *Executor) error {
 		}
 	}
 
-	counter := NewTaskCounter("setProjectTags")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProjectTags", "getProjectTags",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			projectKey := extractField(item.Data, "projectKey")
@@ -947,7 +939,6 @@ func runSetProjectTags(ctx context.Context, e *Executor) error {
 			_ = w.WriteOne(item.Data)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -1009,7 +1000,7 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 		return known[name+"\x00"+urlStr]
 	}
 
-	counter := NewTaskCounter("setProjectLinks")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProjectLinks", "getProjectLinks",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			projectKey := extractField(item.Data, "projectKey")
@@ -1069,7 +1060,6 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 			}))
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -1131,7 +1121,7 @@ func runSetProjectWebhooks(ctx context.Context, e *Executor) error {
 		return known[name+"\x00"+urlStr]
 	}
 
-	counter := NewTaskCounter("setProjectWebhooks")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProjectWebhooks", "getProjectWebhooks",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			projectKey := extractField(item.Data, "projectKey")
@@ -1172,7 +1162,6 @@ func runSetProjectWebhooks(ctx context.Context, e *Executor) error {
 			}))
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -1293,7 +1282,7 @@ func runSetGlobalWebhooks(ctx context.Context, e *Executor) error {
 		return known[name+"\x00"+urlStr]
 	}
 
-	counter := NewTaskCounter("setGlobalWebhooks")
+	counter := TaskCounterFromContext(ctx)
 	w, _ := e.Store.Writer("setGlobalWebhooks")
 	for _, hook := range webhooks {
 		name := extractField(hook.Data, "name")
@@ -1333,6 +1322,5 @@ func runSetGlobalWebhooks(ctx context.Context, e *Executor) error {
 			}
 		}
 	}
-	counter.LogSummary(e.Logger)
 	return nil
 }

--- a/go/internal/migrate/tasks_configure.go
+++ b/go/internal/migrate/tasks_configure.go
@@ -59,7 +59,7 @@ func configureTasks() []TaskDef {
 }
 
 func runSetProfileParent(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("setProfileParent")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItemFiltered(ctx, e, "setProfileParent", "createProfiles",
 		func(item json.RawMessage) bool {
 			return extractField(item, "parent_name") != ""
@@ -79,12 +79,11 @@ func runSetProfileParent(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runRestoreProfiles(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("restoreProfiles")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "restoreProfiles", "getProfileBackups",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -116,7 +115,6 @@ func runRestoreProfiles(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -126,7 +124,7 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 	// conditions were either remapped to a close SQC equivalent (#143) or
 	// dropped because no SQC equivalent exists.
 	notesW, _ := e.Store.Writer("addGateConditions.notes")
-	counter := NewTaskCounter("addGateConditions")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "addGateConditions", "getGateConditions",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -256,7 +254,6 @@ func runAddGateConditions(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -339,7 +336,7 @@ func clearTargetGateConditions(ctx context.Context, e *Executor, counter *TaskCo
 }
 
 func runSetDefaultProfiles(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("setDefaultProfiles")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItemFiltered(ctx, e, "setDefaultProfiles", "createProfiles",
 		func(item json.RawMessage) bool {
 			return extractBool(item, "is_default")
@@ -358,12 +355,11 @@ func runSetDefaultProfiles(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runSetDefaultGates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("setDefaultGates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItemFiltered(ctx, e, "setDefaultGates", "createGates",
 		func(item json.RawMessage) bool {
 			return extractBool(item, "is_default")
@@ -385,12 +381,11 @@ func runSetDefaultGates(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runSetDefaultTemplates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("setDefaultTemplates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItemFiltered(ctx, e, "setDefaultTemplates", "createPermissionTemplates",
 		func(item json.RawMessage) bool {
 			return extractBool(item, "is_default")
@@ -408,6 +403,5 @@ func runSetDefaultTemplates(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -53,7 +53,7 @@ func createTasks() []TaskDef {
 }
 
 func runCreateProjects(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("createProjects")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "createProjects", "generateProjectMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -119,12 +119,11 @@ func runCreateProjects(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runCreateProfiles(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("createProfiles")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItemFiltered(ctx, e, "createProfiles", "generateProfileMappings",
 		func(item json.RawMessage) bool {
 			lang := extractField(item, "language")
@@ -167,12 +166,11 @@ func runCreateProfiles(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runCreateGates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("createGates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "createGates", "generateGateMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -219,12 +217,11 @@ func runCreateGates(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runCreateGroups(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("createGroups")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "createGroups", "generateGroupMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -270,12 +267,11 @@ func runCreateGroups(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runCreatePermissionTemplates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("createPermissionTemplates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "createPermissionTemplates", "generateTemplateMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -320,7 +316,6 @@ func runCreatePermissionTemplates(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -347,7 +342,7 @@ func runCreatePortfolios(ctx context.Context, e *Executor) error {
 	// generatePortfolioMappings + getPortfolioProjects join.
 	emptySourceKeys := buildEmptyPortfolioSet(e)
 
-	counter := NewTaskCounter("createPortfolios")
+	counter := TaskCounterFromContext(ctx)
 	err = forEachMigrateItem(ctx, e, "createPortfolios", "generatePortfolioMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			name := extractField(item, "name")
@@ -386,7 +381,6 @@ func runCreatePortfolios(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -146,7 +146,7 @@ func deleteTasks() []TaskDef {
 }
 
 func runDeleteProjects(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("deleteProjects")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "deleteProjects", "getCreatedProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			key := extractField(item, "key")
@@ -164,7 +164,6 @@ func runDeleteProjects(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -176,7 +175,7 @@ func runDeleteProjects(ctx context.Context, e *Executor) error {
 // by the time this runs the built-in is the per-language default and
 // the previously-default custom profile is deletable.
 func runDeleteProfiles(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("deleteProfiles")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "deleteProfiles", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -209,7 +208,6 @@ func runDeleteProfiles(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -221,7 +219,7 @@ func runDeleteProfiles(ctx context.Context, e *Executor) error {
 // runs the built-in Sonar way is the org's default and the
 // previously-default custom gate is destroyable.
 func runDeleteGates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("deleteGates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "deleteGates", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -254,7 +252,6 @@ func runDeleteGates(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -269,7 +266,7 @@ func runDeleteGates(ctx context.Context, e *Executor) error {
 // everything the migration created, including the helper
 // migration-scanners / migration-viewers groups.
 func runDeleteGroups(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("deleteGroups")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "deleteGroups", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -303,12 +300,11 @@ func runDeleteGroups(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runDeleteTemplates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("deleteTemplates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "deleteTemplates", "createPermissionTemplates",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			templateID := extractField(item, "cloud_template_id")
@@ -325,12 +321,11 @@ func runDeleteTemplates(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runDeletePortfolios(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("deletePortfolios")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "deletePortfolios", "createPortfolios",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			portfolioID := extractField(item, "cloud_portfolio_id")
@@ -346,7 +341,6 @@ func runDeletePortfolios(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -358,7 +352,7 @@ func runDeletePortfolios(ctx context.Context, e *Executor) error {
 // no upstream create*/generate* dependency is pulled into reset's
 // plan.
 func runResetGlobalSettings(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("resetGlobalSettings")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "resetGlobalSettings", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -397,7 +391,6 @@ func runResetGlobalSettings(ctx context.Context, e *Executor) error {
 			counter.Success()
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -414,7 +407,7 @@ func runResetGlobalSettings(ctx context.Context, e *Executor) error {
 // non-built-in default, and posts /api/qualityprofiles/set_default
 // for that language + built-in profile name.
 func runResetDefaultProfiles(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("resetDefaultProfiles")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "resetDefaultProfiles", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -468,7 +461,6 @@ func runResetDefaultProfiles(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -491,7 +483,7 @@ func summariseProfiles(profiles []types.QualityProfile) string {
 // the current default; without this step the custom default gate
 // survives reset. Issue #213.
 func runResetDefaultGates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("resetDefaultGates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "resetDefaultGates", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -539,7 +531,6 @@ func runResetDefaultGates(ctx context.Context, e *Executor) error {
 			counter.Success()
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -199,9 +199,12 @@ type syncHotspotResult struct {
 }
 
 // syncProjectHotspots synchronises hotspot metadata for a single project.
+// A per-project counter is kept alongside the top-level task counter so each
+// project gets its own "task summary" line (#333 merge-format).
 func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInput) (syncHotspotResult, error) {
+	projStart := time.Now()
 	counter := NewTaskCounter("syncHotspotMetadata:" + input.CloudKey)
-	defer counter.LogSummary(e.Logger)
+	defer func() { counter.LogSummary(e.Logger, time.Since(projStart)) }()
 
 	matchedPairs, allCount, err := buildHotspotPairs(ctx, e, input)
 	if err != nil {

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -273,7 +273,7 @@ func isExpectedTransitionError(err error) bool {
 // the issue metadata (transitions, comments, tags) from the SQS extract
 // to the corresponding Cloud issues.
 func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("syncIssueMetadata")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "syncIssueMetadata", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			cloudKey := extractField(item, "cloud_project_key")
@@ -285,7 +285,6 @@ func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 			}
 			return syncProjectIssues(ctx, e, cloudKey, orgKey, serverURL, serverKey, counter)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 

--- a/go/internal/migrate/tasks_permissions.go
+++ b/go/internal/migrate/tasks_permissions.go
@@ -103,7 +103,7 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 		return nil
 	}
 
-	counter := NewTaskCounter("grantMigrationUserProjectPermissions")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "grantMigrationUserProjectPermissions", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -128,12 +128,11 @@ func runGrantMigrationUserProjectPermissions(ctx context.Context, e *Executor) e
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runCreateMigrationGroups(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("createMigrationGroups")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "createMigrationGroups", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -169,7 +168,6 @@ func runCreateMigrationGroups(ctx context.Context, e *Executor) error {
 			})
 			return w.WriteOne(result)
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -184,7 +182,7 @@ func runAddMigrationUserToMigrationGroups(ctx context.Context, e *Executor) erro
 		return nil
 	}
 
-	counter := NewTaskCounter("addMigrationUserToMigrationGroups")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "addMigrationUserToMigrationGroups", "createMigrationGroups",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			orgKey := extractField(item, "sonarcloud_org_key")
@@ -199,12 +197,11 @@ func runAddMigrationUserToMigrationGroups(ctx context.Context, e *Executor) erro
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runAddMigrationGroupToTemplates(ctx context.Context, e *Executor) error {
-	counter := NewTaskCounter("addMigrationGroupToTemplates")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "addMigrationGroupToTemplates", "createPermissionTemplates",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			templateID := extractField(item, "cloud_template_id")
@@ -232,7 +229,6 @@ func runAddMigrationGroupToTemplates(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -240,7 +236,7 @@ func runSetOrgGroupPermissions(ctx context.Context, e *Executor) error {
 	// Build org lookup.
 	orgKeys := buildServerOrgLookup(e)
 
-	counter := NewTaskCounter("setOrgGroupPermissions")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setOrgGroupPermissions", "getGroups",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			name := extractField(item.Data, "name")
@@ -255,7 +251,6 @@ func runSetOrgGroupPermissions(ctx context.Context, e *Executor) error {
 			_ = w.WriteOne(item.Data)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -295,7 +290,7 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 		})
 	}
 
-	counter := NewTaskCounter("setProfileGroupPermissions")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "setProfileGroupPermissions", "getProfileGroups",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			profileKey := extractField(item.Data, "profileKey")
@@ -319,7 +314,6 @@ func runSetProfileGroupPermissions(ctx context.Context, e *Executor) error {
 			_ = w.WriteOne(item.Data)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
@@ -395,7 +389,7 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 	applied := make(map[triple]bool)
 	var appliedMu sync.Mutex
 
-	counter := NewTaskCounter("setTemplateGroupPermissions")
+	counter := TaskCounterFromContext(ctx)
 
 	apply := func(ctx context.Context, srvURL string, data json.RawMessage) {
 		srcTemplateID := extractField(data, "templateId")
@@ -448,10 +442,8 @@ func runSetTemplateGroupPermissions(ctx context.Context, e *Executor) error {
 				apply(ctx, item.ServerURL, item.Data)
 				return nil
 			}); err != nil {
-			counter.LogSummary(e.Logger)
 			return err
 		}
 	}
-	counter.LogSummary(e.Logger)
 	return nil
 }

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -87,7 +87,7 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 	// /api/project_branches/list. Required by SQC's PATCH endpoint when
 	// selection is "projects".
 	branchIDByCloudKey := map[string]string{}
-	counter := NewTaskCounter("configurePortfolios")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "configurePortfolios", "createPortfolios",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			selectionMode := strings.ToUpper(extractField(item, "selection_mode"))
@@ -174,7 +174,6 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 			}
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 

--- a/go/internal/migrate/tasks_rules.go
+++ b/go/internal/migrate/tasks_rules.go
@@ -32,7 +32,7 @@ func ruleTasks() []TaskDef {
 func runUpdateRuleTags(ctx context.Context, e *Executor) error {
 	orgKeys := buildServerOrgLookup(e)
 
-	counter := NewTaskCounter("updateRuleTags")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "updateRuleTags", "getRuleDetails",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			ruleKey := extractField(item.Data, "key")
@@ -56,14 +56,13 @@ func runUpdateRuleTags(ctx context.Context, e *Executor) error {
 			_ = w.WriteOne(item.Data)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }
 
 func runUpdateRuleDescriptions(ctx context.Context, e *Executor) error {
 	orgKeys := buildServerOrgLookup(e)
 
-	counter := NewTaskCounter("updateRuleDescriptions")
+	counter := TaskCounterFromContext(ctx)
 	err := forEachExtractItem(ctx, e, "updateRuleDescriptions", "getRuleDetails",
 		func(ctx context.Context, item structure.ExtractItem, w *common.ChunkWriter) error {
 			ruleKey := extractField(item.Data, "key")
@@ -87,6 +86,5 @@ func runUpdateRuleDescriptions(ctx context.Context, e *Executor) error {
 			_ = w.WriteOne(item.Data)
 			return nil
 		})
-	counter.LogSummary(e.Logger)
 	return err
 }

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -517,7 +517,7 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 	// would race against — and potentially overwrite — those values.
 	overrideCovered := buildPerProjectOverrideCoverage(e)
 
-	counter := NewTaskCounter("setGlobalSettings")
+	counter := TaskCounterFromContext(ctx)
 	w, err := e.Store.Writer("setGlobalSettings")
 	if err != nil {
 		return err
@@ -632,7 +632,6 @@ func runSetGlobalSettings(ctx context.Context, e *Executor) error {
 		mu.Unlock()
 	}
 
-	counter.LogSummary(e.Logger)
 	return nil
 }
 

--- a/go/internal/migrate/timing_log_test.go
+++ b/go/internal/migrate/timing_log_test.go
@@ -45,6 +45,55 @@ func TestRunPhaseEmitsTaskDurationLog(t *testing.T) {
 	}
 }
 
+// #333: when the injected counter records Success / Fail, runPhase
+// emits one combined "task summary" line carrying counts + duration
+// instead of the previous separate summary + duration pair.
+func TestRunPhaseEmitsMergedSummaryWhenCounterRecorded(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	registry := map[string]*TaskDef{
+		"countingTask": {
+			Name: "countingTask",
+			Run: func(ctx context.Context, _ *Executor) error {
+				c := TaskCounterFromContext(ctx)
+				c.Success()
+				c.Success()
+				c.Fail()
+				return nil
+			},
+		},
+	}
+
+	e := &Executor{
+		Sem:    make(chan struct{}, 4),
+		Logger: logger,
+	}
+	tm := &RunTimings{}
+
+	if err := runPhase(context.Background(), e, []string{"countingTask"}, registry, 1, tm); err != nil {
+		t.Fatalf("runPhase: %v", err)
+	}
+
+	out := buf.String()
+	if !regexp.MustCompile(`msg="task summary"`).MatchString(out) {
+		t.Errorf("expected merged task summary line, got:\n%s", out)
+	}
+	if !regexp.MustCompile(`task=countingTask`).MatchString(out) {
+		t.Errorf("expected task=countingTask attr, got:\n%s", out)
+	}
+	if !regexp.MustCompile(`succeeded=2 failed=1 total=3`).MatchString(out) {
+		t.Errorf("expected counts in merged line, got:\n%s", out)
+	}
+	if !regexp.MustCompile(`duration=\d{2}:\d{2}:\d{2}\.\d{3}`).MatchString(out) {
+		t.Errorf("expected duration attr in merged line, got:\n%s", out)
+	}
+	// Exactly one closing log entry — no "Task ...: Duration" line.
+	if regexp.MustCompile(`Task countingTask: Duration`).MatchString(out) {
+		t.Errorf("merged summary should suppress the separate duration line, got:\n%s", out)
+	}
+}
+
 // On failure the task still gets a closing duration line — the
 // log bookend must not depend on success.
 func TestRunPhaseEmitsTaskDurationLogOnFailure(t *testing.T) {


### PR DESCRIPTION
## Summary
- Fixes #333. Tasks with a `TaskCounter` previously emitted two adjacent INFO lines on completion (`"task summary"` then `"Task X: Duration ..."`). They now emit a single merged `"task summary"` line carrying counts and duration together.
- Achieved by moving `TaskCounter` ownership into `runPhase`: it creates the counter, injects it via `WithTaskCounter(ctx, ...)`, runs the task, then calls `counter.LogSummary(logger, elapsed)`. Empty counters fall back to the existing standalone `Task X: Duration hh:mm:ss.xxx` line so every task still closes with exactly one entry.
- 49 `NewTaskCounter` / `counter.LogSummary` call sites across 12 task files become a single `TaskCounterFromContext(ctx)` lookup. The per-project sub-counter in `syncProjectHotspots` (a distinct concept) keeps its own line, updated to the new signature.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] New `TestRunPhaseEmitsMergedSummaryWhenCounterRecorded` asserts the merged single-line shape; existing `TestTaskCounterFailAndSummary` / `TestTaskCounterEmptySummary` updated for the new signature and fallback behavior
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)