### PR TITLE
Issue #300: log per-issue / per-hotspot sync progress

### DIFF
--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -429,6 +429,33 @@ func newProgressLoggerWithInterval(logger *slog.Logger, task string, total int, 
 	return &progressLogger{task: task, total: total, logger: logger, interval: interval}
 }
 
+// runProjectSyncLoop applies fn concurrently to every item in items,
+// bounded by e.Sem, emitting a "<label> n/total - x%" progress line
+// every `interval` completions (#300). Per-item errors are not
+// propagated — the caller's `apply` is responsible for logging and
+// counter bookkeeping. Used by syncProjectIssues / syncProjectHotspots
+// to share the actionable-pair iteration shape exactly.
+func runProjectSyncLoop[T any](
+	ctx context.Context, e *Executor,
+	items []T, label string, interval int64,
+	apply func(ctx context.Context, item T),
+) {
+	prog := newProgressLoggerWithInterval(e.Logger, label, len(items), interval)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(cap(e.Sem))
+	for _, item := range items {
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return nil
+			}
+			apply(gctx, item)
+			prog.Increment()
+			return nil
+		})
+	}
+	_ = g.Wait()
+}
+
 func (p *progressLogger) Increment() {
 	if p.interval <= 0 {
 		return

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -414,6 +414,21 @@ func newProgressLogger(logger *slog.Logger, task string, total int) *progressLog
 	return &progressLogger{task: task, total: total, logger: logger, interval: interval}
 }
 
+// newProgressLoggerWithInterval creates a progressLogger with an
+// explicit per-call interval, bypassing the global progressLogInterval
+// map. Used by inner-loop progress tracking (e.g., per-issue / per-
+// hotspot sync, #300) where the label is human-facing and shared by
+// many call sites, but the interval differs per metric.
+func newProgressLoggerWithInterval(logger *slog.Logger, task string, total int, interval int64) *progressLogger {
+	if interval <= 0 {
+		interval = 1
+	}
+	if int64(total) < interval {
+		interval = int64(total)
+	}
+	return &progressLogger{task: task, total: total, logger: logger, interval: interval}
+}
+
 func (p *progressLogger) Increment() {
 	if p.interval <= 0 {
 		return

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -459,6 +459,77 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 	}
 }
 
+// #300: runProjectSyncLoop applies fn to every item concurrently and
+// emits a "<label>: N/M - X%" progress line every `interval`
+// completions, including a final 100% line at the end of the batch.
+func TestRunProjectSyncLoop(t *testing.T) {
+	t.Run("issue sync cadence at every 20", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		e := &Executor{Sem: make(chan struct{}, 4), Logger: logger}
+
+		items := make([]int, 40)
+		var applied atomic.Int64
+		runProjectSyncLoop(context.Background(), e, items, "Issue sync:", 20,
+			func(_ context.Context, _ int) { applied.Add(1) })
+
+		if applied.Load() != 40 {
+			t.Errorf("want apply called 40 times, got %d", applied.Load())
+		}
+		out := buf.String()
+		if !strings.Contains(out, "Issue sync: 20/40 - 50%") {
+			t.Errorf("missing mid-batch progress line, got:\n%s", out)
+		}
+		if !strings.Contains(out, "Issue sync: 40/40 - 100%") {
+			t.Errorf("missing final 100%% line, got:\n%s", out)
+		}
+	})
+
+	t.Run("hotspot sync cadence at every 10", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		e := &Executor{Sem: make(chan struct{}, 4), Logger: logger}
+
+		items := make([]int, 30)
+		runProjectSyncLoop(context.Background(), e, items, "Hotspot sync:", 10,
+			func(_ context.Context, _ int) {})
+
+		out := buf.String()
+		if !strings.Contains(out, "Hotspot sync: 10/30 - 33%") {
+			t.Errorf("missing first cadence line, got:\n%s", out)
+		}
+		if !strings.Contains(out, "Hotspot sync: 30/30 - 100%") {
+			t.Errorf("missing final 100%% line, got:\n%s", out)
+		}
+	})
+
+	t.Run("cancelled context short-circuits remaining work", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		e := &Executor{Sem: make(chan struct{}, 1), Logger: logger}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // pre-cancel so every goroutine sees gctx.Err() != nil
+
+		items := make([]int, 5)
+		var applied atomic.Int64
+		runProjectSyncLoop(ctx, e, items, "Issue sync:", 20,
+			func(_ context.Context, _ int) { applied.Add(1) })
+
+		if applied.Load() != 0 {
+			t.Errorf("cancelled ctx: want 0 apply calls, got %d", applied.Load())
+		}
+	})
+
+	t.Run("empty input does not panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		e := &Executor{Sem: make(chan struct{}, 4), Logger: logger}
+		runProjectSyncLoop(context.Background(), e, []int{}, "Issue sync:", 20,
+			func(_ context.Context, _ int) { t.Fatal("apply should not be called") })
+	})
+}
+
 // #300: newProgressLoggerWithInterval honours its explicit interval
 // and caps it at total so a small batch still emits a final 100%
 // line via the (n == total) branch in Increment.

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -459,6 +459,55 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 	}
 }
 
+// #300: newProgressLoggerWithInterval honours its explicit interval
+// and caps it at total so a small batch still emits a final 100%
+// line via the (n == total) branch in Increment.
+func TestProgressLoggerWithExplicitInterval(t *testing.T) {
+	t.Run("interval honoured", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		prog := newProgressLoggerWithInterval(logger, "Issue sync:", 557, 20)
+		if prog.interval != 20 {
+			t.Errorf("interval: want 20, got %d", prog.interval)
+		}
+		for i := 0; i < 19; i++ {
+			prog.Increment()
+			if buf.Len() > 0 {
+				t.Fatalf("unexpected log at iteration %d", i)
+			}
+		}
+		prog.Increment() // 20th — first interval hit
+		if !strings.Contains(buf.String(), "Issue sync: 20/557 - 3%") {
+			t.Errorf("want first log to contain \"Issue sync: 20/557 - 3%%\", got: %s", buf.String())
+		}
+	})
+
+	t.Run("interval capped at total for small batches", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		// total=7 with interval=20 → cap to 7 so the final-item branch fires.
+		prog := newProgressLoggerWithInterval(logger, "Hotspot sync:", 7, 20)
+		if prog.interval != 7 {
+			t.Errorf("interval: want 7 (capped to total), got %d", prog.interval)
+		}
+		for i := 0; i < 7; i++ {
+			prog.Increment()
+		}
+		if !strings.Contains(buf.String(), "Hotspot sync: 7/7 - 100%") {
+			t.Errorf("want final 100%% line, got: %s", buf.String())
+		}
+	})
+
+	t.Run("non-positive interval normalised to 1", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		prog := newProgressLoggerWithInterval(logger, "test:", 5, 0)
+		if prog.interval != 1 {
+			t.Errorf("interval: want 1 (normalised), got %d", prog.interval)
+		}
+	})
+}
+
 // #326: tasks without a per-task override get the new 20-item default.
 // Small batches collapse to total so a short task still emits a final
 // "100%" line.

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -15,7 +15,6 @@ import (
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 	"github.com/sonar-solutions/sq-api-go/types"
-	"golang.org/x/sync/errgroup"
 )
 
 // hotspotMetadataSyncTasks returns the task definitions for syncing hotspot
@@ -214,23 +213,17 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 		return syncHotspotResult{Skipped: int64(allCount)}, nil
 	}
 
-	// Per-project progress over actionable hotspots only (#300) —
-	// every 10 synced. buildHotspotPairs already filters to the
-	// actionable set, so len(matchedPairs) is the right denominator.
-	prog := newProgressLoggerWithInterval(e.Logger, "Hotspot sync:", len(matchedPairs), 10)
-
-	// Sync pairs concurrently with bounded parallelism.
+	// Sync pairs concurrently with bounded parallelism, emitting a
+	// per-project "Hotspot sync: N/M - X%" line every 10 completions
+	// (#300). buildHotspotPairs already filters to the actionable
+	// set, so len(matchedPairs) is the right denominator. The shared
+	// runProjectSyncLoop handles the errgroup, the semaphore bound,
+	// and the progress logger.
+	//
 	// matchedPairs is fully built BEFORE launching goroutines. Each goroutine
 	// operates on exactly ONE pair -- no cross-pair sharing, no race conditions.
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(cap(e.Sem))
-
-	for i := range matchedPairs {
-		pair := matchedPairs[i]
-		g.Go(func() error {
-			if gctx.Err() != nil {
-				return nil
-			}
+	runProjectSyncLoop(ctx, e, matchedPairs, "Hotspot sync:", 10,
+		func(gctx context.Context, pair hotspotPair) {
 			if err := syncOneHotspot(gctx, e, pair); err != nil {
 				counter.Fail()
 				logAPIWarn(e.Logger, "syncHotspotMetadata: hotspot sync failed", err,
@@ -238,11 +231,7 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 			} else {
 				counter.Success()
 			}
-			prog.Increment()
-			return nil
 		})
-	}
-	g.Wait() //nolint:errcheck // goroutines always return nil; errors are per-pair
 
 	return syncHotspotResult{
 		Synced:  counter.succeeded.Load(),

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -214,6 +214,11 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 		return syncHotspotResult{Skipped: int64(allCount)}, nil
 	}
 
+	// Per-project progress over actionable hotspots only (#300) —
+	// every 10 synced. buildHotspotPairs already filters to the
+	// actionable set, so len(matchedPairs) is the right denominator.
+	prog := newProgressLoggerWithInterval(e.Logger, "Hotspot sync:", len(matchedPairs), 10)
+
 	// Sync pairs concurrently with bounded parallelism.
 	// matchedPairs is fully built BEFORE launching goroutines. Each goroutine
 	// operates on exactly ONE pair -- no cross-pair sharing, no race conditions.
@@ -233,6 +238,7 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 			} else {
 				counter.Success()
 			}
+			prog.Increment()
 			return nil
 		})
 	}

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -364,6 +364,11 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 		"actionable", len(actionable),
 	)
 
+	// Per-project progress over actionable issues only (#300) —
+	// every 20 synced. The "Issue sync:" label produces lines like
+	// "Issue sync: 40/557 - 7%".
+	prog := newProgressLoggerWithInterval(e.Logger, "Issue sync:", len(actionable), 20)
+
 	// 6. Sync pairs with bounded concurrency.
 	//
 	// RACE-CONDITION SAFETY:
@@ -379,6 +384,7 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 				return gctx.Err()
 			}
 			syncOnePair(gctx, e, pair, counter)
+			prog.Increment()
 			return nil
 		})
 	}

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -16,7 +16,6 @@ import (
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
-	"golang.org/x/sync/errgroup"
 )
 
 // issueMetadataSyncTasks returns the task definition for synchronising
@@ -364,33 +363,20 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 		"actionable", len(actionable),
 	)
 
-	// Per-project progress over actionable issues only (#300) —
-	// every 20 synced. The "Issue sync:" label produces lines like
-	// "Issue sync: 40/557 - 7%".
-	prog := newProgressLoggerWithInterval(e.Logger, "Issue sync:", len(actionable), 20)
-
-	// 6. Sync pairs with bounded concurrency.
+	// 6. Sync pairs with bounded concurrency, emitting a per-
+	// project "Issue sync: N/M - X%" line every 20 completions
+	// (#300). The shared runProjectSyncLoop handles the errgroup,
+	// the semaphore bound, and the progress logger.
 	//
 	// RACE-CONDITION SAFETY:
 	//   - actionable slice is read-only during this phase.
 	//   - Each goroutine receives exactly ONE issuePair by value.
 	//   - counter uses atomic operations (existing pattern).
 	//   - No shared mutable state is accessed.
-	g, gctx := errgroup.WithContext(ctx)
-	g.SetLimit(cap(e.Sem))
-	for _, pair := range actionable {
-		g.Go(func() error {
-			if gctx.Err() != nil {
-				return gctx.Err()
-			}
+	runProjectSyncLoop(ctx, e, actionable, "Issue sync:", 20,
+		func(gctx context.Context, pair issuePair) {
 			syncOnePair(gctx, e, pair, counter)
-			prog.Increment()
-			return nil
 		})
-	}
-	if err := g.Wait(); err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Fixes #300. Issue and hotspot sync now emit a per-project progress line over the actionable set (issues / hotspots that actually need a sync):
  - `Issue sync: 40/557 - 7%` — every 20 synced
  - `Hotspot sync: 70/240 - 29%` — every 10 synced
- Implemented via a new `newProgressLoggerWithInterval` helper that reuses the existing `progressLogger` plumbing with an explicit per-call interval (the inner-loop tracker does not need to pollute the global per-task interval map).
- The fourth bullet (about `--include-scan-history` auto-disabling sync) is stale: that flag was removed in #318. The current `--skip_project_data_migration` already implies `SkipIssueSync` via the existing `RunMigrate` wiring.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] New `TestProgressLoggerWithExplicitInterval` covers the explicit-interval, small-batch-cap, and non-positive-normalisation branches
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)