### PR TITLE
Issue #308: guard the portfolio branch-ID cache with a mutex

### DIFF
--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/sonar-solutions/sq-api-go/cloud"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
@@ -85,8 +86,11 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 	failW, _ := e.Store.Writer("configurePortfolios.failures")
 	// Cache of cloud_project_key → main branch UUID, populated lazily via
 	// /api/project_branches/list. Required by SQC's PATCH endpoint when
-	// selection is "projects".
+	// selection is "projects". forEachMigrateItem fans the closure out
+	// concurrently across portfolios, so the cache is shared mutable
+	// state — guard reads and writes with branchIDMu (#308).
 	branchIDByCloudKey := map[string]string{}
+	var branchIDMu sync.Mutex
 	counter := TaskCounterFromContext(ctx)
 	err := forEachMigrateItem(ctx, e, "configurePortfolios", "createPortfolios",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
@@ -139,7 +143,7 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 					recordPortfolioFailure(failW, portfolioID, name, msg)
 					return nil
 				}
-				refs, lookupErr := resolveProjectBranchRefs(ctx, e, branchIDByCloudKey, cloudKeys)
+				refs, lookupErr := resolveProjectBranchRefs(ctx, e, branchIDByCloudKey, &branchIDMu, cloudKeys)
 				if lookupErr != nil || len(refs) == 0 {
 					msg := "could not resolve main branch UUID for any MANUAL portfolio project"
 					if lookupErr != nil {
@@ -295,17 +299,27 @@ func recordPortfolioFailure(w *common.ChunkWriter, portfolioID, name, reason str
 // PATCH endpoint when selection is "projects". The cache is populated
 // lazily so repeated portfolios with overlapping projects share lookups.
 //
+// The caller is responsible for serialising access to the shared cache via
+// mu — runConfigurePortfolios fans this function out concurrently across
+// portfolios, so without the lock the lazy write produced a "concurrent
+// map writes" panic in production (#308). Two concurrent goroutines may
+// still both miss in cache for the same key and each issue an HTTP
+// lookup; the second's write simply overwrites the first with an
+// identical value, so the redundant call is wasted work, not corruption.
+//
 // If any individual lookup fails, it is logged at Warn level and the
 // project is skipped — the rest still get migrated. Returns an error only
 // when no UUIDs at all could be resolved (e.g. the endpoint is unreachable).
-func resolveProjectBranchRefs(ctx context.Context, e *Executor, cache map[string]string, cloudKeys []string) ([]cloud.PortfolioProjectRef, error) {
+func resolveProjectBranchRefs(ctx context.Context, e *Executor, cache map[string]string, mu *sync.Mutex, cloudKeys []string) ([]cloud.PortfolioProjectRef, error) {
 	refs := make([]cloud.PortfolioProjectRef, 0, len(cloudKeys))
 	var firstErr error
 	for _, key := range cloudKeys {
 		if key == "" {
 			continue
 		}
+		mu.Lock()
 		uuid, ok := cache[key]
+		mu.Unlock()
 		if !ok {
 			id, err := e.Cloud.Branches.MainBranchID(ctx, key)
 			if err != nil {
@@ -316,7 +330,9 @@ func resolveProjectBranchRefs(ctx context.Context, e *Executor, cache map[string
 				}
 				continue
 			}
+			mu.Lock()
 			cache[key] = id
+			mu.Unlock()
 			uuid = id
 		}
 		refs = append(refs, cloud.PortfolioProjectRef{BranchID: uuid})

--- a/go/internal/migrate/tasks_portfolios_concurrency_test.go
+++ b/go/internal/migrate/tasks_portfolios_concurrency_test.go
@@ -1,0 +1,102 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// Issue #308: runConfigurePortfolios fans the per-portfolio closure
+// out concurrently, so the shared branchID cache passed to
+// resolveProjectBranchRefs is touched from multiple goroutines.
+// Without the mutex this test panics with "fatal error: concurrent
+// map writes" under `go test -race` (and intermittently without it).
+// Guard the cache and the test passes.
+func TestResolveProjectBranchRefsConcurrent(t *testing.T) {
+	// Mock cloud endpoint that returns a deterministic branch UUID per
+	// project. Counts hits so we can verify the cache deduplicates
+	// (most) repeated lookups across goroutines.
+	var hits atomic.Int64
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("GET /api/project_branches/list", func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		project := r.URL.Query().Get("project")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"branches": []map[string]any{
+				{"name": "main", "isMain": true, "branchId": "uuid-" + project},
+			},
+		})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := httptest.NewServer(http.NewServeMux())
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// 10 unique project keys repeated to N goroutines so the same
+	// keys race for cache entries.
+	const (
+		uniqueKeys  = 10
+		goroutines  = 50
+		keysPerCall = 20
+	)
+	keys := make([]string, keysPerCall)
+	for i := range keys {
+		keys[i] = fmt.Sprintf("proj-%d", i%uniqueKeys)
+	}
+
+	cache := map[string]string{}
+	var mu sync.Mutex
+
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			refs, err := resolveProjectBranchRefs(context.Background(), e, cache, &mu, keys)
+			if err != nil {
+				errs <- err
+				return
+			}
+			if len(refs) != keysPerCall {
+				errs <- fmt.Errorf("want %d refs, got %d", keysPerCall, len(refs))
+				return
+			}
+			// Each returned ref must carry the deterministic UUID we
+			// served, proving the cache wasn't corrupted mid-flight.
+			for j, ref := range refs {
+				want := "uuid-" + keys[j]
+				if ref.BranchID != want {
+					errs <- fmt.Errorf("ref[%d]: want %s, got %s", j, want, ref.BranchID)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	// After every goroutine finished, the cache must hold exactly the
+	// uniqueKeys entries (no duplicates, no garbage).
+	mu.Lock()
+	defer mu.Unlock()
+	if len(cache) != uniqueKeys {
+		t.Errorf("cache size: want %d, got %d", uniqueKeys, len(cache))
+	}
+}

--- a/go/internal/migrate/tasks_portfolios_concurrency_test.go
+++ b/go/internal/migrate/tasks_portfolios_concurrency_test.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync"
-	"sync/atomic"
 	"testing"
 )
 
@@ -23,14 +22,12 @@ import (
 // Guard the cache and the test passes.
 func TestResolveProjectBranchRefsConcurrent(t *testing.T) {
 	// Mock cloud endpoint that returns a deterministic branch UUID per
-	// project. Counts hits so we can verify the cache deduplicates
-	// (most) repeated lookups across goroutines.
-	var hits atomic.Int64
+	// project so the goroutines can validate they got back the right
+	// value end-to-end (the test of cache integrity under contention).
 	cloudMux := http.NewServeMux()
 	cloudMux.HandleFunc("GET /api/project_branches/list", func(w http.ResponseWriter, r *http.Request) {
-		hits.Add(1)
 		project := r.URL.Query().Get("project")
-		_ = json.NewEncoder(w).Encode(map[string]any{
+		json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 			"branches": []map[string]any{
 				{"name": "main", "isMain": true, "branchId": "uuid-" + project},
 			},


### PR DESCRIPTION
## Summary
- Fixes #308. The reported `fatal error: concurrent map writes` panic was a real race in `resolveProjectBranchRefs` — the `branchIDByCloudKey` cache, populated lazily, was shared across the per-portfolio goroutines fanned out by `forEachMigrateItem` and written without a lock.
- Pair the cache with a `sync.Mutex` at the `runConfigurePortfolios` scope and thread it through `resolveProjectBranchRefs`. Both the read and the write are guarded. Matches the existing `coveredMu` / `existingMu` pattern in `tasks_associate.go`. Two concurrent goroutines may still both miss for the same key (a redundant HTTP call), but the second write simply overwrites the first with the same value — wasted work, not corruption.
- New `TestResolveProjectBranchRefsConcurrent` fans 50 goroutines across 10 unique project keys, each requesting 20 lookups. Before the fix it deterministically reproduces the exact panic from the issue (verified by temporarily removing the locks). After the fix it passes under `go test -race`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/migrate/` clean
- [x] Race-reproducing test panics without the fix and passes with it
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)