### PR TITLE
Issue #334: retry settings calls through SQC post-create indexing lag

### DIFF
--- a/go/internal/migrate/project_indexing_retry.go
+++ b/go/internal/migrate/project_indexing_retry.go
@@ -1,0 +1,100 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+// SonarCloud indexes a freshly-created project asynchronously, and the
+// settings and search endpoints become consistent on independent
+// timelines (#334). A POST /api/projects/create returns 200 well
+// before GET /api/settings/list_definitions / POST /api/settings/set
+// acknowledge the project. Empirically the gap routinely exceeds 30
+// seconds for a subset of projects, so a pre-task wait at the create
+// site cannot reliably predict downstream readiness — different
+// endpoints have different indexing pipelines.
+//
+// The pragmatic fix is to retry the actual write/read call when it
+// fails with a 404 "Project doesn't exist". Each call pays the wait
+// only when it is actually too early, in parallel with concurrent
+// goroutines.
+//
+// Vars (not consts) so test code can set them to near-zero values
+// without coupling production timing to test speed.
+var (
+	projectIndexingRetryInitialDelay = 500 * time.Millisecond
+	projectIndexingRetryMaxDelay     = 5 * time.Second
+	projectIndexingRetryMaxAttempts  = 8
+)
+
+// retryOnProjectNotFound runs op and, when it fails with a SonarCloud
+// 404 "Project doesn't exist" — the known post-create indexing-lag
+// signature (#334) — retries with exponential backoff up to
+// projectIndexingRetryMaxAttempts attempts. Non-404 errors and
+// successes return immediately. Returns the last error if all retries
+// are exhausted.
+//
+// Each time a retry is scheduled, logger.Debug emits a line with the
+// attempt count, the delay before the next try, and the caller-supplied
+// `attrs` (typically the project key, org, and setting key). A nil
+// logger silences the log; the retry behavior is unchanged. The Debug
+// level keeps the line silent at normal verbosity yet visible under
+// `--debug` for the operator who wants to see the indexing-lag
+// recovery in flight.
+func retryOnProjectNotFound(ctx context.Context, logger *slog.Logger, op func() error, attrs ...any) error {
+	delay := projectIndexingRetryInitialDelay
+	var err error
+	for attempt := 0; attempt < projectIndexingRetryMaxAttempts; attempt++ {
+		err = op()
+		if err == nil || !isProjectNotFound(err) {
+			return err
+		}
+		if logger != nil {
+			fields := []any{
+				"attempt", attempt + 1,
+				"max_attempts", projectIndexingRetryMaxAttempts,
+				"retry_in", delay.String(),
+			}
+			fields = append(fields, attrs...)
+			logger.Debug("SQC project not yet indexed, waiting before retry", fields...)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+		delay *= 2
+		if delay > projectIndexingRetryMaxDelay {
+			delay = projectIndexingRetryMaxDelay
+		}
+	}
+	return err
+}
+
+// isProjectNotFound returns true for the specific SonarCloud signature
+// that indicates "the project exists in the database but the index for
+// this endpoint hasn't caught up yet" — HTTP 404 with a message
+// mentioning "project" and "doesn't exist". This is narrower than
+// sqapi.IsNotFound (which is any 404) so we don't accidentally retry
+// genuine missing-component errors that are not indexing-related.
+func isProjectNotFound(err error) bool {
+	var apiErr *sqapi.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		return false
+	}
+	msg := strings.ToLower(apiErr.Message())
+	return strings.Contains(msg, "project") && strings.Contains(msg, "doesn't exist")
+}

--- a/go/internal/migrate/project_indexing_retry_test.go
+++ b/go/internal/migrate/project_indexing_retry_test.go
@@ -1,0 +1,255 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+// shortenIndexingRetryTiming sets the package-level retry timing to
+// near-zero so tests don't burn real seconds in the backoff. Cleanup
+// restores the production values.
+func shortenIndexingRetryTiming(t *testing.T) {
+	t.Helper()
+	origInitial := projectIndexingRetryInitialDelay
+	origMax := projectIndexingRetryMaxDelay
+	origAttempts := projectIndexingRetryMaxAttempts
+	projectIndexingRetryInitialDelay = 1 * time.Millisecond
+	projectIndexingRetryMaxDelay = 4 * time.Millisecond
+	projectIndexingRetryMaxAttempts = 5
+	t.Cleanup(func() {
+		projectIndexingRetryInitialDelay = origInitial
+		projectIndexingRetryMaxDelay = origMax
+		projectIndexingRetryMaxAttempts = origAttempts
+	})
+}
+
+func projectNotFoundErr() error {
+	return &sqapi.APIError{
+		StatusCode: 404,
+		Method:     "POST",
+		URL:        "https://sonarcloud.io/api/settings/set",
+		Body:       `{"errors":[{"msg":"Project doesn't exist"}]}`,
+	}
+}
+
+func TestIsProjectNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("boom"), false},
+		{"404 with project-doesn't-exist message", projectNotFoundErr(), true},
+		{
+			"404 with unrelated message",
+			&sqapi.APIError{StatusCode: 404, Body: `{"errors":[{"msg":"Component not found"}]}`},
+			false,
+		},
+		{
+			"500 with project-doesn't-exist message — not a 404",
+			&sqapi.APIError{StatusCode: 500, Body: `{"errors":[{"msg":"Project doesn't exist"}]}`},
+			false,
+		},
+		{
+			"403 forbidden",
+			&sqapi.APIError{StatusCode: 403, Body: `{"errors":[{"msg":"Insufficient privileges"}]}`},
+			false,
+		},
+		{
+			"404 message capitalization variant",
+			&sqapi.APIError{StatusCode: 404, Body: `{"errors":[{"msg":"PROJECT DOESN'T EXIST"}]}`},
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isProjectNotFound(c.err); got != c.want {
+				t.Errorf("isProjectNotFound(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRetryOnProjectNotFoundImmediate(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	calls := 0
+	err := retryOnProjectNotFound(context.Background(), nil, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected nil err, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected exactly 1 call, got %d", calls)
+	}
+}
+
+func TestRetryOnProjectNotFoundAfterTransientNotFound(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	calls := 0
+	err := retryOnProjectNotFound(context.Background(), nil, func() error {
+		calls++
+		if calls < 3 {
+			return projectNotFoundErr()
+		}
+		return nil
+	})
+	if err != nil {
+		t.Errorf("expected nil err after retries, got %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected exactly 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryOnProjectNotFoundNon404PassesThrough(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	calls := 0
+	nonRetryable := errors.New("nope")
+	err := retryOnProjectNotFound(context.Background(), nil, func() error {
+		calls++
+		return nonRetryable
+	})
+	if !errors.Is(err, nonRetryable) {
+		t.Errorf("expected non-retryable error to surface unchanged, got %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("non-retryable error must not retry, got %d calls", calls)
+	}
+}
+
+func TestRetryOnProjectNotFoundExhaustion(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	calls := 0
+	err := retryOnProjectNotFound(context.Background(), nil, func() error {
+		calls++
+		return projectNotFoundErr()
+	})
+	if !isProjectNotFound(err) {
+		t.Errorf("expected the last 404 error to surface, got %v", err)
+	}
+	if calls != projectIndexingRetryMaxAttempts {
+		t.Errorf("expected exactly %d calls, got %d", projectIndexingRetryMaxAttempts, calls)
+	}
+}
+
+func TestRetryOnProjectNotFoundCtxCancellation(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	// Slow the schedule a bit so the cancel actually fires before
+	// the next attempt.
+	projectIndexingRetryInitialDelay = 50 * time.Millisecond
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
+	calls := 0
+	err := retryOnProjectNotFound(ctx, nil, func() error {
+		calls++
+		return projectNotFoundErr()
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	if calls >= projectIndexingRetryMaxAttempts {
+		t.Errorf("ctx cancel should have stopped early, got %d calls", calls)
+	}
+}
+
+// Each scheduled retry must emit a Debug line so operators running
+// with --debug can see the indexing-lag recovery in flight (#334).
+func TestRetryOnProjectNotFoundEmitsDebugLog(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	calls := 0
+	err := retryOnProjectNotFound(context.Background(), logger, func() error {
+		calls++
+		if calls < 3 {
+			return projectNotFoundErr()
+		}
+		return nil
+	}, "endpoint", "/api/settings/set", "project", "org1_projA")
+
+	if err != nil {
+		t.Fatalf("expected eventual success, got %v", err)
+	}
+	out := buf.String()
+	// Two retries (calls 1 and 2 both returned 404, call 3 succeeded)
+	// → two Debug lines.
+	if got := strings.Count(out, "SQC project not yet indexed"); got != 2 {
+		t.Errorf("expected exactly 2 retry-debug lines, got %d in:\n%s", got, out)
+	}
+	// Each line carries the caller-supplied context plus the per-
+	// attempt fields the helper appends.
+	for _, want := range []string{
+		`attempt=1`,
+		`attempt=2`,
+		`endpoint=/api/settings/set`,
+		`project=org1_projA`,
+		`retry_in=`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected log to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// A nil logger must keep working without panicking — the helper is
+// usable from contexts that don't have a logger handy (e.g., direct
+// unit tests of internal call sites).
+func TestRetryOnProjectNotFoundNilLogger(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+	calls := 0
+	err := retryOnProjectNotFound(context.Background(), nil, func() error {
+		calls++
+		if calls < 2 {
+			return projectNotFoundErr()
+		}
+		return nil
+	}, "project", "anything")
+	if err != nil {
+		t.Errorf("nil logger should not affect retry success: got err %v", err)
+	}
+	if calls != 2 {
+		t.Errorf("expected 2 calls with nil logger, got %d", calls)
+	}
+}
+
+// Production timing must stay generous enough to absorb the empirical
+// 30s+ SQC indexing-lag window observed in #334. Lock it in so a
+// future tweak that drops below ~20s shows up in code review.
+func TestRetryBudgetCoversIndexingWindow(t *testing.T) {
+	if projectIndexingRetryMaxAttempts < 6 {
+		t.Errorf("expected >=6 attempts to span the SQC indexing window, got %d", projectIndexingRetryMaxAttempts)
+	}
+	// Compute the upper bound of the cumulative wait: each delay is
+	// doubled up to maxDelay, summed over (maxAttempts-1) sleeps.
+	delay := projectIndexingRetryInitialDelay
+	var total time.Duration
+	for i := 0; i < projectIndexingRetryMaxAttempts-1; i++ {
+		total += delay
+		delay *= 2
+		if delay > projectIndexingRetryMaxDelay {
+			delay = projectIndexingRetryMaxDelay
+		}
+	}
+	if total < 20*time.Second {
+		t.Errorf("retry budget %s is too short for SQC's >=30s indexing window", total)
+	}
+}

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -494,7 +494,11 @@ func propagateGlobalsToProjects(ctx context.Context, e *Executor,
 				}
 				e.Logger.Debug("setProjectSettings: propagating SQS global to project",
 					"project", pm.CloudKey, "key", entry.key, "org", pm.OrgKey)
-				err := applySettingByDef(gctx, e, pm.CloudKey, pm.OrgKey, entry.raw, entry.key, entry.def, true)
+				// Retry through the SQC project-indexing window
+				// (#334). Same hazard as setGlobalSettings fan-out.
+				err := retryOnProjectNotFound(gctx, e.Logger, func() error {
+					return applySettingByDef(gctx, e, pm.CloudKey, pm.OrgKey, entry.raw, entry.key, entry.def, true)
+				}, "endpoint", "/api/settings/set", "project", pm.CloudKey, "org", pm.OrgKey, "setting_key", entry.key)
 				switch {
 				case errors.Is(err, errSettingEmpty):
 					return nil

--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -914,7 +914,13 @@ func fanOutGlobalToProjects(ctx context.Context, e *Executor, raw json.RawMessag
 			skipped = append(skipped, pm.CloudKey)
 			continue
 		}
-		err := applySettingByDef(ctx, e, pm.CloudKey, pm.OrgKey, raw, key, def, true)
+		// Retry the per-project apply when SQC reports the project
+		// as not-yet-indexed (#334). The indexing-lag window is
+		// independent of /api/projects/search readiness so we can
+		// only handle it at the call site.
+		err := retryOnProjectNotFound(ctx, e.Logger, func() error {
+			return applySettingByDef(ctx, e, pm.CloudKey, pm.OrgKey, raw, key, def, true)
+		}, "endpoint", "/api/settings/set", "project", pm.CloudKey, "org", org, "setting_key", key)
 		switch {
 		case errors.Is(err, errSettingEmpty):
 			// nothing to do

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -646,6 +646,105 @@ func TestRunSetGlobalSettingsFanOutSkipsPerProjectOverrides(t *testing.T) {
 	}
 }
 
+// Issue #334: when SQC's settings endpoint hasn't finished indexing a
+// freshly-created project, POST /api/settings/set returns 404
+// "Project doesn't exist". The fan-out must retry through that
+// window and succeed instead of marking the project as failed.
+func TestRunSetGlobalSettingsFanOutRetriesIndexingNotFound(t *testing.T) {
+	shortenIndexingRetryTiming(t)
+
+	cloudMux := http.NewServeMux()
+
+	// Per-project state: each cloud_project_key gets `notFoundAttempts`
+	// 404s before its first 204. Tracks the total attempts seen so the
+	// test can assert "we retried, then succeeded".
+	const notFoundAttempts = 3
+	var (
+		mu              sync.Mutex
+		attemptsByProj  = map[string]int{}
+		successByProj   = map[string]int{}
+	)
+	cloudMux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		project := r.FormValue("component")
+		mu.Lock()
+		defer mu.Unlock()
+		if project == "" {
+			// Org-scope attempt — reject so the code falls back to
+			// per-project fan-out (the path under test).
+			http.Error(w, `{"errors":[{"msg":"Provided property can't be set at organization level: `+r.FormValue("key")+`"}]}`, http.StatusBadRequest)
+			return
+		}
+		attemptsByProj[project]++
+		if attemptsByProj[project] <= notFoundAttempts {
+			http.Error(w, `{"errors":[{"msg":"Project doesn't exist"}]}`, http.StatusNotFound)
+			return
+		}
+		successByProj[project]++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mountSettingsDefinitionsScoped(cloudMux,
+		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
+		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
+	)
+	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+	cloudSrv := httptest.NewServer(cloudMux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	var logBuf bytes.Buffer
+	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+		{"key": "sonar.coverage.jacoco.xmlReportPaths", "values": []string{"**/jacoco*.xml"}},
+	})
+	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
+	})
+	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"sonarcloud_org_key": "org1"},
+	})
+	pw, _ := e.Store.Writer("createProjects")
+	for _, key := range []string{"projA", "projB"} {
+		b, _ := json.Marshal(map[string]any{
+			"key": key, "server_url": testServerURL,
+			"sonarcloud_org_key": "org1", "cloud_project_key": "org1_" + key,
+		})
+		pw.WriteOne(b)
+	}
+
+	if err := runSetGlobalSettings(context.Background(), e); err != nil {
+		t.Fatalf("runSetGlobalSettings: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Both projects must end up succeeded after retries.
+	for _, proj := range []string{"org1_projA", "org1_projB"} {
+		if successByProj[proj] != 1 {
+			t.Errorf("project %s: expected exactly one final success, got %d (attempts=%d)",
+				proj, successByProj[proj], attemptsByProj[proj])
+		}
+		// Each project should have hit the endpoint notFoundAttempts+1 times
+		// (the 404 burst plus the successful 204).
+		if attemptsByProj[proj] != notFoundAttempts+1 {
+			t.Errorf("project %s: expected %d total attempts, got %d", proj, notFoundAttempts+1, attemptsByProj[proj])
+		}
+	}
+	// The retry must be silent — no "project fan-out failed" warn line
+	// should appear, since the eventual outcome was success.
+	if strings.Contains(logBuf.String(), "setGlobalSettings: project fan-out failed") {
+		t.Errorf("expected no fan-out failure warning after retry success, got:\n%s", logBuf.String())
+	}
+}
+
 // Customized PROPERTY_SET setting → sent via fieldValues= shape.
 func TestRunSetGlobalSettingsPropertySet(t *testing.T) {
 	hits, _ := runGlobalSettingsTest(t,
@@ -857,6 +956,12 @@ func TestRenderValueSummary(t *testing.T) {
 // to "failed" and the wording reflects what actually happened so the
 // operator isn't misled.
 func TestRunSetGlobalSettingsFanOutAllFailedRendersAsFailed(t *testing.T) {
+	// #334 retry treats "Project doesn't exist" as a transient
+	// indexing-lag signal and burns the full retry budget before
+	// surfacing the failure. Shorten it here — this test wants the
+	// permanent-failure path, not the retry path.
+	shortenIndexingRetryTiming(t)
+
 	cloudMux := http.NewServeMux()
 	cloudMux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
@@ -937,6 +1042,10 @@ func TestRunSetGlobalSettingsFanOutAllFailedRendersAsFailed(t *testing.T) {
 // bucket, and the Detail wording reflects the actual N/M counts
 // instead of falsely claiming "all projects".
 func TestRunSetGlobalSettingsFanOutPartialRendersAsPartial(t *testing.T) {
+	// See TestRunSetGlobalSettingsFanOutAllFailedRendersAsFailed for
+	// why the indexing-retry timing is shortened here (#334).
+	shortenIndexingRetryTiming(t)
+
 	cloudMux := http.NewServeMux()
 	var failProject = "org1_projA"
 	cloudMux.HandleFunc("POST /api/settings/set", func(w http.ResponseWriter, r *http.Request) {

--- a/go/internal/migrate/tasks_settings_helpers.go
+++ b/go/internal/migrate/tasks_settings_helpers.go
@@ -75,7 +75,17 @@ func loadProjectScopedSettingDefinitionsForOrgs(ctx context.Context, e *Executor
 	}
 	out := make(map[string]map[string]types.SettingDefinition, len(probeByOrg))
 	for org, probe := range probeByOrg {
-		defs, err := e.Cloud.Settings.ListDefinitions(ctx, org, probe)
+		// SQC's project-scope list_definitions can 404 with "Project
+		// doesn't exist" for several seconds after createProjects
+		// returns — independent indexing lag (#334). Retry through
+		// that window so the probe succeeds on the freshly-created
+		// project.
+		var defs []types.SettingDefinition
+		err := retryOnProjectNotFound(ctx, e.Logger, func() error {
+			var inner error
+			defs, inner = e.Cloud.Settings.ListDefinitions(ctx, org, probe)
+			return inner
+		}, "endpoint", "/api/settings/list_definitions", "org", org, "probe_project", probe)
 		if err != nil {
 			logAPIWarn(e.Logger, taskName+": project-scope list_definitions failed", err, "org", org, "probe_project", probe)
 			out[org] = map[string]types.SettingDefinition{}


### PR DESCRIPTION
## Summary
- Fixes #334. After `POST /api/projects/create` returns 200, SonarCloud takes up to ~30 seconds (sometimes longer) before the newly-created project is searchable by `/api/settings/list_definitions` and writable via `/api/settings/set`. The two endpoints index on independent timelines, so a pre-task wait at the create site cannot reliably predict downstream readiness — empirically verified in the user-reported reproducer (30s of ListDefinitions-based waiting still left `/api/settings/set` returning 404 for several projects).
- **Fix:** retry at the call site. When a settings call returns 404 with a message containing "Project … doesn't exist", `retryOnProjectNotFound` retries with exponential backoff (500ms → 5s cap, 8 attempts, ~27.5s ceiling per call) until the index catches up.
- Wraps three known affected sites:
  - `loadProjectScopedSettingDefinitionsForOrgs` — the per-org probe.
  - `fanOutGlobalToProjects` — the per-project `applySettingByDef` in `setGlobalSettings`'s org-level fallback (the user's reported 404 path).
  - `setProjectSettings` — the per-project propagation loop (same hazard, not yet seen in user logs).
- Each scheduled retry emits a Debug line carrying `endpoint`, `project`, `org`, `setting_key`, `attempt`, `max_attempts`, and `retry_in` so an operator running with `--debug` can watch the indexing-lag recovery in flight. Silent at normal verbosity.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/migrate/` clean
- [x] Unit tests cover the predicate (7 status+message combos), the retry helper (immediate, after-N, non-404 pass-through, exhaustion, ctx-cancel, nil-logger, Debug-log emission, production-budget guard)
- [x] Integration test `TestRunSetGlobalSettingsFanOutRetriesIndexingNotFound` reproduces the user's exact "fan-out failed" warning when the retry is stripped and passes once restored
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
