### PR TITLE
Issue #348: project-keyed per-issue progress + friendlier task label

### DIFF
--- a/go/internal/common/progress.go
+++ b/go/internal/common/progress.go
@@ -147,18 +147,36 @@ var ProgressLogInterval = map[string]int64{
 	"syncHotspotMetadata": 10,
 }
 
+// ProgressLogLabel optionally renames the message label used by
+// NewProgressLogger. Tasks not in the map fall back to using the
+// task name as the label (no behaviour change for them). Lets the
+// log stream show ergonomic sentence-case labels instead of camelCase
+// task names — e.g. the syncIssueMetadata task progress reads
+// "Projects issue sync:" so operators tailing a busy run can tell
+// it apart from the per-project per-issue lines that include the
+// project key (#348).
+var ProgressLogLabel = map[string]string{
+	"syncIssueMetadata":   "Projects issue sync:",
+	"syncHotspotMetadata": "Projects hotspot sync:",
+}
+
 // NewProgressLogger creates a progress logger for the given task and
 // expected total. Uses the per-task entry in ProgressLogInterval when
 // present, else the 20-item default. Always caps interval at total so
 // the very last item still emits a "100%" line via the n==total
-// branch in Increment.
+// branch in Increment. The message label is the per-task entry in
+// ProgressLogLabel when present, else the raw task name (#348).
 func NewProgressLogger(logger *slog.Logger, task string, total int) *ProgressLogger {
 	// Default cadence is 20 items (#326 / #340).
 	interval := int64(20)
 	if explicit, ok := ProgressLogInterval[task]; ok && explicit > 0 {
 		interval = explicit
 	}
-	return &ProgressLogger{task: task, total: total, logger: logger, interval: capAtTotal(interval, total)}
+	label := task
+	if l, ok := ProgressLogLabel[task]; ok {
+		label = l
+	}
+	return &ProgressLogger{task: label, total: total, logger: logger, interval: capAtTotal(interval, total)}
 }
 
 // NewProgressLoggerWithInterval creates a ProgressLogger with an

--- a/go/internal/common/progress_test.go
+++ b/go/internal/common/progress_test.go
@@ -92,8 +92,12 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 		{"getProfileBackups", 3800, 500, 500, "getProfileBackups 500/3800 - 13%"},
 		{"updateRuleTags", 79910, 1000, 1000, "updateRuleTags 1000/79910 - 1%"},
 		{"importProjectData", 500, 20, 20, "importProjectData 20/500 - 4%"},
-		{"syncIssueMetadata", 123, 10, 10, "syncIssueMetadata 10/123 - 8%"},
-		{"syncHotspotMetadata", 42, 10, 10, "syncHotspotMetadata 10/42 - 23%"},
+		// syncIssueMetadata / syncHotspotMetadata use a ProgressLogLabel
+		// override (#348) so the operator-visible log reads "Projects
+		// issue sync:" / "Projects hotspot sync:" instead of the
+		// camelCase task name.
+		{"syncIssueMetadata", 123, 10, 10, "Projects issue sync: 10/123 - 8%"},
+		{"syncHotspotMetadata", 42, 10, 10, "Projects hotspot sync: 10/42 - 23%"},
 	}
 	for _, c := range cases {
 		t.Run(c.task, func(t *testing.T) {
@@ -114,6 +118,34 @@ func TestProgressLoggerHonoursPerTaskInterval(t *testing.T) {
 				t.Errorf("want first log to contain %q, got: %s", c.wantFirstLine, buf.String())
 			}
 		})
+	}
+}
+
+// #348: NewProgressLogger uses ProgressLogLabel when the task name has
+// an override there, falling back to the raw task name otherwise. Verify
+// both branches at once: a task with an override (syncIssueMetadata),
+// and an unregistered task name (raw passthrough).
+func TestProgressLoggerHonoursLabelOverride(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// Task with override.
+	prog := NewProgressLogger(logger, "syncIssueMetadata", 100)
+	for i := 0; i < 10; i++ {
+		prog.Increment()
+	}
+	if !strings.Contains(buf.String(), "Projects issue sync: 10/100 - 10%") {
+		t.Errorf("expected override label in log, got: %s", buf.String())
+	}
+
+	// Task without override — raw name comes through.
+	buf.Reset()
+	prog = NewProgressLogger(logger, "unregisteredTask", 100)
+	for i := 0; i < 20; i++ {
+		prog.Increment()
+	}
+	if !strings.Contains(buf.String(), "unregisteredTask 20/100 - 20%") {
+		t.Errorf("expected raw task name in log, got: %s", buf.String())
 	}
 }
 

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -398,6 +398,28 @@ func TestRunProjectSyncLoop(t *testing.T) {
 		}
 	})
 
+	// Issue #348: the production caller (syncProjectIssues) builds
+	// the label as "Project key <cloudKey> issue sync:" so the
+	// operator can disentangle interleaved per-project lines when
+	// several projects sync in parallel.
+	t.Run("issue sync label carries project key (#348)", func(t *testing.T) {
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+		e := &Executor{Sem: make(chan struct{}, 4), Logger: logger}
+
+		const cloudKey = "myorg_some_project_key"
+		label := "Project key " + cloudKey + " issue sync:"
+		items := make([]int, 20)
+		runProjectSyncLoop(context.Background(), e, items, label, 20,
+			func(_ context.Context, _ int) {})
+
+		out := buf.String()
+		want := "Project key myorg_some_project_key issue sync: 20/20 - 100%"
+		if !strings.Contains(out, want) {
+			t.Errorf("want log line %q, got:\n%s", want, out)
+		}
+	})
+
 	t.Run("hotspot sync cadence at every 10", func(t *testing.T) {
 		var buf bytes.Buffer
 		logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -214,15 +214,19 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	}
 
 	// Sync pairs concurrently with bounded parallelism, emitting a
-	// per-project "Hotspot sync: N/M - X%" line every 10 completions
-	// (#300). buildHotspotPairs already filters to the actionable
-	// set, so len(matchedPairs) is the right denominator. The shared
-	// runProjectSyncLoop handles the errgroup, the semaphore bound,
-	// and the progress logger.
+	// per-project "Project key <key> hotspot sync: N/M - X%" line
+	// every 10 completions (#300 / #348). The label includes the
+	// cloud project key so an operator tailing the log can
+	// disentangle the lines coming from concurrent projects' inner
+	// loops (#348). buildHotspotPairs already filters to the
+	// actionable set, so len(matchedPairs) is the right
+	// denominator. runProjectSyncLoop handles the errgroup, the
+	// semaphore bound, and the progress logger.
 	//
 	// matchedPairs is fully built BEFORE launching goroutines. Each goroutine
 	// operates on exactly ONE pair -- no cross-pair sharing, no race conditions.
-	runProjectSyncLoop(ctx, e, matchedPairs, "Hotspot sync:", 10,
+	label := "Project key " + input.CloudKey + " hotspot sync:"
+	runProjectSyncLoop(ctx, e, matchedPairs, label, 10,
 		func(gctx context.Context, pair hotspotPair) {
 			if err := syncOneHotspot(gctx, e, pair); err != nil {
 				counter.Fail()

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -364,16 +364,20 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 	)
 
 	// 6. Sync pairs with bounded concurrency, emitting a per-
-	// project "Issue sync: N/M - X%" line every 20 completions
-	// (#300). The shared runProjectSyncLoop handles the errgroup,
-	// the semaphore bound, and the progress logger.
+	// project "Project key <key> issue sync: N/M - X%" line every
+	// 20 completions (#300 / #348). The label includes the cloud
+	// project key so an operator tailing the log can disentangle
+	// the lines coming from concurrent projects' inner loops
+	// (issue #348). runProjectSyncLoop handles the errgroup, the
+	// semaphore bound, and the progress logger.
 	//
 	// RACE-CONDITION SAFETY:
 	//   - actionable slice is read-only during this phase.
 	//   - Each goroutine receives exactly ONE issuePair by value.
 	//   - counter uses atomic operations (existing pattern).
 	//   - No shared mutable state is accessed.
-	runProjectSyncLoop(ctx, e, actionable, "Issue sync:", 20,
+	label := "Project key " + cloudKey + " issue sync:"
+	runProjectSyncLoop(ctx, e, actionable, label, 20,
 		func(gctx context.Context, pair issuePair) {
 			syncOnePair(gctx, e, pair, counter)
 		})


### PR DESCRIPTION
## Summary
- Fixes #348. When several projects sync issues / hotspots in parallel, the inner per-issue progress lines all read `Issue sync: N/M - X%` and interleave in the log — operators can't tell which project each fragment belongs to.

Two changes, applied symmetrically to issue and hotspot sync:

1. **Per-issue / per-hotspot progress label now carries the cloud project key**:
   ```
   Project key migration-tool-test-gh_demo:github-actions-mono-dotnet issue sync: 1120/8327 - 13%
   Project key migration-tool-test-gh_demo:github-actions-mono-dotnet hotspot sync: 60/240 - 25%
   ```
   Built at the `syncProjectIssues` / `syncProjectHotspots` call site.
2. **Outer per-project progress reads as a sentence-case label** instead of the camelCase task name:
   ```
   Projects issue sync: 143/227 - 63%
   Projects hotspot sync: 143/227 - 63%
   ```
   New `ProgressLogLabel` map in `common/progress.go` — `NewProgressLogger` consults it for an optional label override. Tasks without an entry keep using the raw task name (no behaviour change). Cadence still follows the existing #340 `ProgressLogInterval` tuning (every 10 projects).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/{common,migrate}/` clean
- [x] Updated per-task table in `common/progress_test.go` for the new labels; new `TestProgressLoggerHonoursLabelOverride` covers the override mechanism + raw-name fallback
- [x] New `TestRunProjectSyncLoop/issue sync label carries project key (#348)` asserts the dynamic-label shape `syncProjectIssues` now builds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
