### PR TITLE
Issue #350 follow-up: subtract rule default tags + restore manualSeverity

### DIFF
--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -40,16 +40,27 @@ func issueMetadataSyncTasks() []TaskDef {
 // matchableIssue is a normalised issue representation used to pair source
 // (SQS extract) issues with their Cloud counterparts. The struct is
 // intentionally flat so that matching and filtering logic stays simple.
+//
+// Tags holds ONLY the user-added subset (issue.tags minus the rule's
+// default tags+sysTags). The raw /api/issues/search response folds
+// rule defaults into every issue's tags array, so the unsubtracted
+// list is useless as a "manual triage" signal — see ruleTagDefaults
+// (#352 follow-up).
+//
+// ManualSeverity mirrors the `manualSeverity` boolean on the SQ Server
+// API response: true means a user has explicitly overridden the issue's
+// severity vs the rule default.
 type matchableIssue struct {
-	Key        string
-	Rule       string
-	Component  string
-	Line       int
-	Status     string
-	Resolution string
-	Tags       []string
-	Comments   []issueComment
-	Assignee   string
+	Key            string
+	Rule           string
+	Component      string
+	Line           int
+	Status         string
+	Resolution     string
+	Tags           []string
+	Comments       []issueComment
+	Assignee       string
+	ManualSeverity bool
 }
 
 // issueComment is a normalised comment attached to a matchableIssue.
@@ -185,25 +196,27 @@ const metadataSyncTag = "metadata-synchronized"
 // are skipped to avoid unnecessary API calls.
 //
 // Triggers (per #350):
-//   - Triage state: status ACCEPTED, or resolution FALSE-POSITIVE / WONTFIX.
-//     CONFIRMED is intentionally excluded per the issue spec. WONTFIX is
-//     the legacy resolution that became ACCEPTED in MQR — kept here so
-//     older SQ servers and pre-MQR issues still match.
-//   - Custom tags.
+//   - Triage state: status ACCEPTED / FALSE_POSITIVE (modern unified
+//     issueStatus enum, post-10.4), or legacy resolution FALSE-POSITIVE
+//     / WONTFIX. CONFIRMED is intentionally excluded per the issue spec.
+//   - manualSeverity == true on the API response — user has overridden
+//     the rule's default severity.
+//   - User-added tags (rule defaults already subtracted at load time).
 //   - Any comment on the issue.
 //
 // Assignee was previously a trigger but was dropped per the issue spec:
 // auto-assigned issues (e.g. via "default assignee") are common and
 // inflate the actionable set without carrying real triage signal.
-//
-// Manual-severity overrides are not detected here yet — they require a
-// rule-default comparison (issue.severity vs rule.severity in Std mode,
-// issue.impacts vs rule.impacts in MQR mode) and are slated for the
-// changelog/rule-join follow-up pass.
 func hasManualChanges(iss matchableIssue) bool {
 	status := strings.ToUpper(iss.Status)
 	resolution := strings.ToUpper(iss.Resolution)
-	if status == "ACCEPTED" || resolution == "FALSE-POSITIVE" || resolution == "WONTFIX" {
+	if status == "ACCEPTED" || status == "FALSE_POSITIVE" {
+		return true
+	}
+	if resolution == "FALSE-POSITIVE" || resolution == "WONTFIX" {
+		return true
+	}
+	if iss.ManualSeverity {
 		return true
 	}
 	if len(iss.Tags) > 0 {
@@ -282,8 +295,13 @@ func isExpectedTransitionError(err error) bool {
 // runSyncIssueMetadata iterates every migrated project and synchronises
 // the issue metadata (transitions, comments, tags) from the SQS extract
 // to the corresponding Cloud issues.
+//
+// Rule-default tags are indexed ONCE up front and shared across all
+// projects — the index is read-only after construction so it's safe
+// to fan out concurrently.
 func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 	counter := TaskCounterFromContext(ctx)
+	ruleDefaults := loadRuleTagDefaults(e)
 	err := forEachMigrateItem(ctx, e, "syncIssueMetadata", "createProjects",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
 			cloudKey := extractField(item, "cloud_project_key")
@@ -293,7 +311,7 @@ func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 			if cloudKey == "" || orgKey == "" {
 				return nil
 			}
-			return syncProjectIssues(ctx, e, cloudKey, orgKey, serverURL, serverKey, counter)
+			return syncProjectIssues(ctx, e, cloudKey, orgKey, serverURL, serverKey, counter, ruleDefaults)
 		})
 	return err
 }
@@ -311,9 +329,9 @@ func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 //  5. Pre-filter (hasManualChanges)
 //  6. Sync pairs with bounded concurrency
 //  7. Log summary
-func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serverURL, serverKey string, counter *TaskCounter) error {
+func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serverURL, serverKey string, counter *TaskCounter, ruleDefaults *ruleTagDefaults) error {
 	// 1. Load source issues from extract data.
-	sourceIssues := loadMatchableIssues(e, serverURL, serverKey)
+	sourceIssues := loadMatchableIssues(e, serverURL, serverKey, ruleDefaults)
 	if len(sourceIssues) == 0 {
 		e.Logger.Debug("syncIssueMetadata: no source issues", "project", cloudKey)
 		return nil
@@ -370,6 +388,8 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 
 	e.Logger.Info("syncIssueMetadata: syncing pairs",
 		"project", cloudKey,
+		"source_total", len(sourceIssues),
+		"cloud_total", len(cloudIssues),
 		"matched", len(matchedPairs),
 		"actionable", len(actionable),
 	)
@@ -513,11 +533,83 @@ func syncIssueTags(ctx context.Context, e *Executor, cloudKey string, sourceTags
 // Extract loaders
 // ---------------------------------------------------------------------------
 
+// ruleTagDefaults indexes the default tag set (rule.tags ∪ rule.sysTags)
+// by serverURL → ruleKey. Issue extracts fold these defaults into every
+// issue's `tags` array, so a plain `len(tags) > 0` check would treat
+// every issue as user-tagged. Subtracting these defaults at load time
+// keeps `matchableIssue.Tags` honest as a "user-added tags" signal
+// (#352 follow-up).
+type ruleTagDefaults struct {
+	bySrv map[string]map[string]map[string]struct{}
+}
+
+// loadRuleTagDefaults reads the getRuleDetails extract and indexes
+// each rule's default tag set. Safe to call when the extract is
+// missing or empty — returns a non-nil receiver that simply yields no
+// subtraction, in which case issue.Tags falls back to the raw API
+// values (the pre-fix behaviour, no worse than what shipped).
+func loadRuleTagDefaults(e *Executor) *ruleTagDefaults {
+	r := &ruleTagDefaults{bySrv: make(map[string]map[string]map[string]struct{})}
+	items, err := readExtractItems(e, "getRuleDetails")
+	if err != nil {
+		return r
+	}
+	for _, item := range items {
+		key := extractField(item.Data, "key")
+		if key == "" {
+			continue
+		}
+		defaults := make(map[string]struct{})
+		for _, t := range extractStringArray(item.Data, "tags") {
+			defaults[t] = struct{}{}
+		}
+		for _, t := range extractStringArray(item.Data, "sysTags") {
+			defaults[t] = struct{}{}
+		}
+		inner := r.bySrv[item.ServerURL]
+		if inner == nil {
+			inner = make(map[string]map[string]struct{})
+			r.bySrv[item.ServerURL] = inner
+		}
+		inner[key] = defaults
+	}
+	return r
+}
+
+// UserTagsOnly returns the subset of allTags that are NOT default tags
+// on the given rule. When the rule isn't indexed (missing extract,
+// stale cache) the input is returned unchanged — the caller pays the
+// cost of an over-trigger, which is no worse than the pre-fix behaviour.
+func (r *ruleTagDefaults) UserTagsOnly(serverURL, ruleKey string, allTags []string) []string {
+	if r == nil || len(allTags) == 0 {
+		return allTags
+	}
+	inner := r.bySrv[serverURL]
+	if inner == nil {
+		return allTags
+	}
+	defaults, ok := inner[ruleKey]
+	if !ok {
+		return allTags
+	}
+	out := make([]string, 0, len(allTags))
+	for _, t := range allTags {
+		if _, isDefault := defaults[t]; !isDefault {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
 // loadMatchableIssues reads the extracted SQS issues for a project and
 // converts them to matchableIssue values. Issues with CLOSED status or
 // FIXED resolution are excluded because they have no Cloud counterpart
 // (the scan report does not reproduce them).
-func loadMatchableIssues(e *Executor, serverURL, serverKey string) []matchableIssue {
+//
+// ruleDefaults is used to strip rule-default tags from each issue's
+// tag list so that matchableIssue.Tags holds only the user-added tags
+// — see the type doc on ruleTagDefaults.
+func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults *ruleTagDefaults) []matchableIssue {
 	items, err := readExtractItems(e, "getProjectIssuesFull")
 	if err != nil {
 		return nil
@@ -546,18 +638,20 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string) []matchableIs
 		line := int(extractInt32Field(item.Data, "line"))
 
 		comments := parseIssueComments(item.Data)
-		tags := extractStringArray(item.Data, "tags")
+		rule := extractField(item.Data, "rule")
+		userTags := ruleDefaults.UserTagsOnly(serverURL, rule, extractStringArray(item.Data, "tags"))
 
 		issues = append(issues, matchableIssue{
-			Key:        extractField(item.Data, "key"),
-			Rule:       extractField(item.Data, "rule"),
-			Component:  extractField(item.Data, "component"),
-			Line:       line,
-			Status:     extractField(item.Data, "status"),
-			Resolution: extractField(item.Data, "resolution"),
-			Tags:       tags,
-			Comments:   comments,
-			Assignee:   extractField(item.Data, "assignee"),
+			Key:            extractField(item.Data, "key"),
+			Rule:           rule,
+			Component:      extractField(item.Data, "component"),
+			Line:           line,
+			Status:         extractField(item.Data, "status"),
+			Resolution:     extractField(item.Data, "resolution"),
+			Tags:           userTags,
+			Comments:       comments,
+			Assignee:       extractField(item.Data, "assignee"),
+			ManualSeverity: extractBool(item.Data, "manualSeverity"),
 		})
 	}
 	return issues

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -105,11 +105,19 @@ func TestHasManualChanges(t *testing.T) {
 		// Triage state — primary triggers.
 		{name: "status ACCEPTED", iss: matchableIssue{Status: "ACCEPTED"}, want: true},
 		{name: "status accepted lowercase", iss: matchableIssue{Status: "accepted"}, want: true},
-		{name: "resolution FALSE-POSITIVE", iss: matchableIssue{Status: "RESOLVED", Resolution: "FALSE-POSITIVE"}, want: true},
+		// Modern unified status enum — issueStatus folded into the
+		// `status` field on post-10.4 servers.
+		{name: "status FALSE_POSITIVE (modern)", iss: matchableIssue{Status: "FALSE_POSITIVE"}, want: true},
+		{name: "status false_positive lowercase", iss: matchableIssue{Status: "false_positive"}, want: true},
+		// Legacy resolution surface (pre-10.4 servers).
+		{name: "resolution FALSE-POSITIVE (legacy)", iss: matchableIssue{Status: "RESOLVED", Resolution: "FALSE-POSITIVE"}, want: true},
 		{name: "resolution false-positive lowercase", iss: matchableIssue{Status: "RESOLVED", Resolution: "false-positive"}, want: true},
 		{name: "resolution WONTFIX (legacy)", iss: matchableIssue{Status: "RESOLVED", Resolution: "WONTFIX"}, want: true},
-		// Tags trigger.
-		{name: "tags only", iss: matchableIssue{Status: "OPEN", Tags: []string{"security"}}, want: true},
+		// manualSeverity trigger.
+		{name: "manualSeverity only", iss: matchableIssue{Status: "OPEN", ManualSeverity: true}, want: true},
+		// User tags trigger (matchableIssue.Tags is already
+		// user-only — rule defaults are subtracted at load time).
+		{name: "user tags only", iss: matchableIssue{Status: "OPEN", Tags: []string{"flagged-by-team"}}, want: true},
 		// Comments trigger.
 		{name: "comments only", iss: matchableIssue{Status: "OPEN", Comments: []issueComment{comment}}, want: true},
 		// Anti-triggers per #350 spec.
@@ -120,6 +128,7 @@ func TestHasManualChanges(t *testing.T) {
 		// Combinations — any one signal flips it.
 		{name: "CONFIRMED + comment — sync", iss: matchableIssue{Status: "CONFIRMED", Comments: []issueComment{comment}}, want: true},
 		{name: "assignee + tags — sync (via tags)", iss: matchableIssue{Status: "OPEN", Assignee: "bob", Tags: []string{"flagged"}}, want: true},
+		{name: "manualSeverity + OPEN no other — sync", iss: matchableIssue{Status: "OPEN", ManualSeverity: true}, want: true},
 	}
 
 	for _, tc := range tests {
@@ -130,4 +139,102 @@ func TestHasManualChanges(t *testing.T) {
 			}
 		})
 	}
+}
+
+// #352-followup: issue.tags from /api/issues/search is the union of
+// the rule's tags+sysTags and any user-added tags. The "rule defaults"
+// alone trigger `len(tags) > 0` on essentially every issue, so we
+// subtract them at load time.
+func TestRuleTagDefaultsUserTagsOnly(t *testing.T) {
+	r := &ruleTagDefaults{
+		bySrv: map[string]map[string]map[string]struct{}{
+			"https://server1": {
+				"java:S1481": setOf("unused", "convention"),
+				"java:S2095":  setOf("cwe", "denial-of-service", "security"),
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		serverURL string
+		ruleKey   string
+		allTags   []string
+		want      []string
+	}{
+		{
+			name: "all tags are rule defaults — returns empty",
+			serverURL: "https://server1", ruleKey: "java:S1481",
+			allTags: []string{"unused", "convention"},
+			want:    []string{},
+		},
+		{
+			name: "rule defaults stripped, user tags retained",
+			serverURL: "https://server1", ruleKey: "java:S2095",
+			allTags: []string{"cwe", "denial-of-service", "security", "flagged-by-team", "needs-investigation"},
+			want:    []string{"flagged-by-team", "needs-investigation"},
+		},
+		{
+			name: "rule not indexed — fallback returns input unchanged",
+			serverURL: "https://server1", ruleKey: "kotlin:S100",
+			allTags: []string{"convention"},
+			want:    []string{"convention"},
+		},
+		{
+			name: "server not indexed — fallback returns input unchanged",
+			serverURL: "https://other-server", ruleKey: "java:S1481",
+			allTags: []string{"unused"},
+			want:    []string{"unused"},
+		},
+		{
+			name: "empty input — returns empty",
+			serverURL: "https://server1", ruleKey: "java:S1481",
+			allTags: nil,
+			want:    nil,
+		},
+		{
+			name: "user tags only (no rule defaults present)",
+			serverURL: "https://server1", ruleKey: "java:S1481",
+			allTags: []string{"team-quarantine"},
+			want:    []string{"team-quarantine"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := r.UserTagsOnly(tc.serverURL, tc.ruleKey, tc.allTags)
+			if !equalStrings(got, tc.want) {
+				t.Errorf("UserTagsOnly(%q, %q, %v) = %v, want %v", tc.serverURL, tc.ruleKey, tc.allTags, got, tc.want)
+			}
+		})
+	}
+
+	// Nil receiver — guards a caller that hasn't loaded the index.
+	t.Run("nil receiver — passthrough", func(t *testing.T) {
+		var nilR *ruleTagDefaults
+		got := nilR.UserTagsOnly("https://server1", "java:S1481", []string{"cwe"})
+		if !equalStrings(got, []string{"cwe"}) {
+			t.Errorf("nil receiver should pass through, got %v", got)
+		}
+	})
+}
+
+func setOf(tags ...string) map[string]struct{} {
+	out := make(map[string]struct{}, len(tags))
+	for _, t := range tags {
+		out[t] = struct{}{}
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
## Summary

Follow-up to #352. The first cut of the source-side filter still synced **almost every issue** because `/api/issues/search` returns `issue.tags` = (rule's `tags`) ∪ (rule's `sysTags`) ∪ (user-added). Every issue against a rule with `sysTags: ["cwe"]` or `["unused"]` tripped the `len(tags) > 0` trigger.

Smoke test against a 20k-issue extract from the user's reference run:
- **pre-fix actionable**: 20,319 / 20,345 (**99.9%**)
- **post-fix actionable**: 3 / 20,345 (**0.01%**)

Four changes:

1. **New `ruleTagDefaults` index** built from `getRuleDetails`. Maps each rule's `tags ∪ sysTags`. Loaded once per `syncIssueMetadata` run and reused across projects. `loadMatchableIssues` subtracts these defaults from `issue.tags` so `matchableIssue.Tags` is *user-added tags only*.
2. **`ManualSeverity` field restored** on `matchableIssue`. The boolean IS in the `/api/issues/search` response (null/false for unset; true when overridden). When true, `hasManualChanges` treats it as a sync trigger.
3. **`hasManualChanges` matches `status == FALSE_POSITIVE`** (modern unified `issueStatus` enum on post-10.4 servers), not just `resolution == FALSE-POSITIVE` (legacy form).
4. **`syncIssueMetadata: syncing pairs` log line** now reports `source_total` and `cloud_total` alongside `matched`/`actionable`, so operators can read the filter ratio directly — previously hotspots logged this but issues didn't.

## Why we missed it the first time

The PR's verification was unit tests + smoke test logic, but no end-to-end run against real extract data. The `tags` field looked authoritative in the API schema — the fact that rules contribute their default `sysTags` into every issue's tag list isn't obvious from the field name. Running the new filter against the user's real `getProjectIssuesFull` output surfaced the 99.9% pass-through immediately.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/migrate/` clean
- [x] Extended `TestHasManualChanges` covering `manualSeverity` trigger, modern `FALSE_POSITIVE` status, and a renamed `user tags` case (since `Tags` now means user-only)
- [x] New `TestRuleTagDefaultsUserTagsOnly` table covering: all-defaults → empty, partial-defaults → keep user subset, rule not indexed → passthrough, server not indexed → passthrough, empty input → empty, nil receiver → passthrough
- [x] Smoke test against 20k-issue real extract: actionable dropped from 99.9% → 0.01%
- [ ] CI green
- [ ] End-to-end migration run on the reference project still produces correct sync (user validation on `issue-sync-optimization`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)