### PR TITLE
Issue #356: targeted per-source-issue search + a/b/c sync stats

### DIFF
--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -8,13 +8,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
-	"github.com/sonar-solutions/sq-api-go/types"
 )
 
 // hotspotMetadataSyncTasks returns the task definitions for syncing hotspot
@@ -59,63 +60,19 @@ type hotspotPair struct {
 }
 
 // ---------------------------------------------------------------------------
-// Matching helpers
+// Actionable filtering (source-side, #350 / #356)
 // ---------------------------------------------------------------------------
 
-// buildHotspotMatchKey produces "ruleKey|filePath|line" for FIFO matching.
-// The component prefix (everything up to and including the first colon after
-// the project key) is stripped so that source and Cloud components can be
-// compared by relative file path alone.
-func buildHotspotMatchKey(h matchableHotspot, projectKey string) string {
-	if h.RuleKey == "" || h.Component == "" || h.Line <= 0 {
-		return ""
-	}
-	filePath := h.Component
-	prefix := projectKey + ":"
-	if strings.HasPrefix(filePath, prefix) {
-		filePath = filePath[len(prefix):]
-	}
-	return fmt.Sprintf("%s|%s|%d", h.RuleKey, filePath, h.Line)
-}
-
-// matchHotspots performs FIFO matching between source and cloud hotspot
-// slices. For each unique match key the first unmatched source hotspot is
-// paired with the first unmatched cloud hotspot that shares the same key.
-// This is identical in semantics to matchIssues.
-func matchHotspots(sources, clouds []matchableHotspot, sourceProject, cloudProject string) []hotspotPair {
-	// Build cloud buckets keyed by match key.
-	type bucket struct {
-		items []matchableHotspot
-		idx   int // next unconsumed index
-	}
-	cloudBuckets := make(map[string]*bucket)
-	for _, c := range clouds {
-		k := buildHotspotMatchKey(c, cloudProject)
-		if k == "" {
-			continue
-		}
-		b, ok := cloudBuckets[k]
-		if !ok {
-			b = &bucket{}
-			cloudBuckets[k] = b
-		}
-		b.items = append(b.items, c)
-	}
-
-	var pairs []hotspotPair
-	for _, s := range sources {
-		k := buildHotspotMatchKey(s, sourceProject)
-		if k == "" {
-			continue
-		}
-		b, ok := cloudBuckets[k]
-		if !ok || b.idx >= len(b.items) {
-			continue
-		}
-		pairs = append(pairs, hotspotPair{source: s, cloud: b.items[b.idx]})
-		b.idx++
-	}
-	return pairs
+// hotspotHasManualChanges mirrors hasManualChanges for issues: returns
+// true when the source hotspot carries metadata worth migrating to
+// Cloud. Same criteria as the previous filterActionableHotspotPairs
+// (#350) — REVIEWED with a real review resolution, or any comment —
+// but applied source-side BEFORE we look at Cloud (#356).
+func hotspotHasManualChanges(h matchableHotspot) bool {
+	status := strings.ToUpper(h.Status)
+	resolution := strings.ToUpper(h.Resolution)
+	reviewed := status == "REVIEWED" && (resolution == "SAFE" || resolution == "ACKNOWLEDGED" || resolution == "FIXED")
+	return reviewed || len(h.Comments) > 0
 }
 
 // ---------------------------------------------------------------------------
@@ -157,22 +114,19 @@ func runSyncHotspotMetadata(ctx context.Context, e *Executor) error {
 				return nil
 			}
 
-			result, err := syncProjectHotspots(ctx, e, syncHotspotInput{
+			result := syncProjectHotspots(ctx, e, syncHotspotInput{
 				CloudKey:  cloudKey,
 				OrgKey:    orgKey,
 				ServerURL: serverURL,
 				ServerKey: serverKey,
 			})
-			if err != nil {
-				logAPIWarn(e.Logger, "syncHotspotMetadata: project failed", err,
-					"project", cloudKey)
-			}
 
 			record, _ := json.Marshal(map[string]any{
 				"cloud_project_key": cloudKey,
-				"synced":            result.Synced,
-				"skipped":           result.Skipped,
-				"failed":            result.Failed,
+				"synced":            result.Stats.A,
+				"line_mismatch":     result.Stats.B,
+				"not_found":         result.Stats.C,
+				"actionable":        result.Stats.Actionable,
 				"error":             result.Error,
 			})
 			return w.WriteOne(record)
@@ -190,124 +144,183 @@ type syncHotspotInput struct {
 	ServerKey string
 }
 
+// syncHotspotResult holds the per-project sync outcome. Stats carries
+// the a/b/c breakdown (#356); Error captures a fatal lookup failure
+// that prevented the project from being processed at all.
 type syncHotspotResult struct {
-	Synced  int64
-	Skipped int64
-	Failed  int64
-	Error   string
+	Stats projectSyncStats
+	Error string
 }
 
-// syncProjectHotspots synchronises hotspot metadata for a single project.
-// A per-project counter is kept alongside the top-level task counter so each
-// project gets its own "task summary" line (#333 merge-format).
-func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInput) (syncHotspotResult, error) {
+// syncProjectHotspots synchronises hotspot metadata for a single
+// project using the targeted per-actionable-source-hotspot search
+// approach introduced in #356. Replaces the previous fetch-all + FIFO
+// match scheme.
+func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInput) syncHotspotResult {
 	projStart := time.Now()
 	counter := NewTaskCounter("syncHotspotMetadata:" + input.CloudKey)
 	defer func() { counter.LogSummary(e.Logger, time.Since(projStart)) }()
 
-	matchedPairs, allCount, err := buildHotspotPairs(ctx, e, input)
-	if err != nil {
-		return syncHotspotResult{Error: err.Error()}, err
-	}
-	if len(matchedPairs) == 0 {
-		return syncHotspotResult{Skipped: int64(allCount)}, nil
-	}
+	var result syncHotspotResult
 
-	// Sync pairs concurrently with bounded parallelism, emitting a
-	// per-project "Project key <key> hotspot sync: N/M - X%" line
-	// every 10 completions (#300 / #348). The label includes the
-	// cloud project key so an operator tailing the log can
-	// disentangle the lines coming from concurrent projects' inner
-	// loops (#348). buildHotspotPairs already filters to the
-	// actionable set, so len(matchedPairs) is the right
-	// denominator. runProjectSyncLoop handles the errgroup, the
-	// semaphore bound, and the progress logger.
-	//
-	// matchedPairs is fully built BEFORE launching goroutines. Each goroutine
-	// operates on exactly ONE pair -- no cross-pair sharing, no race conditions.
-	label := "Project key " + input.CloudKey + " hotspot sync:"
-	runProjectSyncLoop(ctx, e, matchedPairs, label, 10,
-		func(gctx context.Context, pair hotspotPair) {
-			if err := syncOneHotspot(gctx, e, pair); err != nil {
-				counter.Fail()
-				logAPIWarn(e.Logger, "syncHotspotMetadata: hotspot sync failed", err,
-					"source_key", pair.source.Key, "cloud_key", pair.cloud.Key)
-			} else {
-				counter.Success()
-			}
-		})
-
-	return syncHotspotResult{
-		Synced:  counter.succeeded.Load(),
-		Skipped: int64(allCount - len(matchedPairs)),
-		Failed:  counter.failed.Load(),
-	}, nil
-}
-
-// filterActionableHotspotPairs returns pairs that need any work (#350):
-// REVIEWED with a real review resolution (SAFE / ACKNOWLEDGED / FIXED),
-// OR any hotspot with source comments to migrate.
-//
-// Previously every REVIEWED hotspot was actionable, but a REVIEWED
-// status with no resolution carries no payload to sync — narrowing on
-// resolution drops those zero-work pairs before the per-pair fetch.
-func filterActionableHotspotPairs(pairs []hotspotPair) []hotspotPair {
-	var actionable []hotspotPair
-	for _, p := range pairs {
-		status := strings.ToUpper(p.source.Status)
-		resolution := strings.ToUpper(p.source.Resolution)
-		reviewed := status == "REVIEWED" && (resolution == "SAFE" || resolution == "ACKNOWLEDGED" || resolution == "FIXED")
-		if reviewed || len(p.source.Comments) > 0 {
-			actionable = append(actionable, p)
-		}
-	}
-	return actionable
-}
-
-// buildHotspotPairs loads, indexes, matches, and filters hotspot pairs for a
-// project. Returns only actionable pairs that need syncing.
-func buildHotspotPairs(ctx context.Context, e *Executor, input syncHotspotInput) ([]hotspotPair, int, error) {
+	// 1. Load + pre-filter source hotspots to the actionable set.
 	sourceHotspots, err := loadMatchableHotspots(e, input.ServerURL, input.ServerKey)
 	if err != nil {
-		return nil, 0, err
+		result.Error = err.Error()
+		logAPIWarn(e.Logger, "syncHotspotMetadata: load source hotspots failed", err, "project", input.CloudKey)
+		return result
 	}
 	if len(sourceHotspots) == 0 {
-		return nil, 0, nil
+		return result
+	}
+	var actionable []matchableHotspot
+	for _, h := range sourceHotspots {
+		if hotspotHasManualChanges(h) {
+			actionable = append(actionable, h)
+		}
+	}
+	result.Stats.Actionable = int64(len(actionable))
+	if len(actionable) == 0 {
+		e.Logger.Debug("syncHotspotMetadata: no actionable source hotspots after filter", "project", input.CloudKey, "source_total", len(sourceHotspots))
+		return result
 	}
 
+	// 2. Wait for Cloud indexing — proves the CE task is done.
 	_ = waitForCloudIndexing(ctx, func() (int, error) {
 		return e.Cloud.Hotspots.Count(ctx, input.CloudKey, input.OrgKey)
 	})
 
-	cloudAPIHotspots, err := e.Cloud.Hotspots.SearchAll(ctx, input.CloudKey, input.OrgKey)
-	if err != nil {
-		return nil, 0, err
-	}
-	cloudHotspots := loadCloudMatchableHotspots(cloudAPIHotspots)
-
-	// Source had hotspots worth syncing, but Cloud has none. Most
-	// common cause: the project-data CE task for this project failed
-	// (or was skipped), so the report was never indexed and Cloud
-	// has no hotspots yet. Surface that explicitly at INFO so the
-	// operator can correlate the skip with the upstream failure. #299.
-	if len(cloudHotspots) == 0 {
-		e.Logger.Info("syncHotspotMetadata: skipping project — no Cloud hotspots to match (project-data CE task likely failed or was skipped)",
-			"project", input.CloudKey, "source_hotspots", len(sourceHotspots))
-		return nil, 0, nil
-	}
-
-	allPairs := matchHotspots(sourceHotspots, cloudHotspots, input.ServerKey, input.CloudKey)
-	actionable := filterActionableHotspotPairs(allPairs)
-
-	e.Logger.Info("syncHotspotMetadata: matched pairs",
+	e.Logger.Info("syncHotspotMetadata: syncing pairs",
 		"project", input.CloudKey,
 		"source_total", len(sourceHotspots),
-		"cloud_total", len(cloudHotspots),
-		"matched", len(allPairs),
 		"actionable", len(actionable),
 	)
 
-	return actionable, len(allPairs), nil
+	// 3 + 4. Per-actionable-source: targeted search + resolve by
+	// (ruleKey, line). Race-safety: actionable is read-only, each
+	// goroutine takes one hotspot by value, stats counters are
+	// atomic.
+	var a, b, c atomic.Int64
+	label := "Project key " + input.CloudKey + " hotspot sync:"
+	runProjectSyncLoop(ctx, e, actionable, label, 10,
+		func(gctx context.Context, src matchableHotspot) {
+			outcome := resolveAndSyncHotspot(gctx, e, input.CloudKey, input.OrgKey, input.ServerKey, src, counter)
+			switch outcome {
+			case syncOutcomeSynced:
+				a.Add(1)
+			case syncOutcomeLineMismatch:
+				b.Add(1)
+			case syncOutcomeNotFound:
+				c.Add(1)
+			}
+		})
+	result.Stats.A = a.Load()
+	result.Stats.B = b.Load()
+	result.Stats.C = c.Load()
+	return result
+}
+
+// resolveAndSyncHotspot searches Cloud for hotspots in the source
+// hotspot's file, then resolves by (ruleKey, line). Returns the case
+// a/b/c/lookup outcome.
+func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, sourceKey string, src matchableHotspot, counter *TaskCounter) syncOutcome {
+	filePath := src.Component
+	prefix := sourceKey + ":"
+	if strings.HasPrefix(filePath, prefix) {
+		filePath = filePath[len(prefix):]
+	}
+	if filePath == "" || src.RuleKey == "" || src.Line <= 0 {
+		e.Logger.Debug("syncHotspotMetadata: source hotspot not matchable", "key", src.Key, "rule", src.RuleKey, "component", src.Component, "line", src.Line)
+		return syncOutcomeNotFound
+	}
+	candidates, err := findCloudHotspotCandidates(ctx, e, cloudKey, orgKey, filePath)
+	if err != nil {
+		logAPIWarn(e.Logger, "syncHotspotMetadata: cloud candidate lookup failed", err,
+			"project", cloudKey, "source_key", src.Key, "file", filePath)
+		return syncOutcomeLookupError
+	}
+	target, outcome := classifyHotspotCandidatesByLine(candidates, src.RuleKey, src.Line)
+	switch outcome {
+	case syncOutcomeSynced:
+		pair := hotspotPair{source: src, cloud: target}
+		if err := syncOneHotspot(ctx, e, pair); err != nil {
+			counter.Fail()
+			logAPIWarn(e.Logger, "syncHotspotMetadata: hotspot sync failed", err,
+				"source_key", src.Key, "cloud_key", target.Key)
+		} else {
+			counter.Success()
+		}
+	case syncOutcomeNotFound:
+		e.Logger.Debug("syncHotspotMetadata: no cloud counterpart on source line", "source_key", src.Key, "rule", src.RuleKey, "file", filePath, "line", src.Line)
+	case syncOutcomeLineMismatch:
+		keys := make([]string, 0)
+		for _, c := range candidates {
+			if c.RuleKey == src.RuleKey && c.Line == src.Line {
+				keys = append(keys, c.Key)
+			}
+		}
+		e.Logger.Debug("syncHotspotMetadata: multiple cloud counterparts on source line, skipping", "source_key", src.Key, "rule", src.RuleKey, "file", filePath, "line", src.Line, "candidates", keys)
+	}
+	return outcome
+}
+
+// classifyHotspotCandidatesByLine is the hotspot counterpart of
+// classifyIssueCandidatesByLine. The hotspot search isn't scoped by
+// rule on the cloud side, so we filter on (ruleKey, line) here.
+func classifyHotspotCandidatesByLine(candidates []matchableHotspot, sourceRule string, sourceLine int) (matchableHotspot, syncOutcome) {
+	var pick matchableHotspot
+	matches := 0
+	for _, c := range candidates {
+		if c.RuleKey == sourceRule && c.Line == sourceLine {
+			matches++
+			if matches == 1 {
+				pick = c
+			}
+		}
+	}
+	switch matches {
+	case 0:
+		return matchableHotspot{}, syncOutcomeNotFound
+	case 1:
+		return pick, syncOutcomeSynced
+	default:
+		return matchableHotspot{}, syncOutcomeLineMismatch
+	}
+}
+
+// findCloudHotspotCandidates queries /api/hotspots/search?files=…
+// for cloud hotspots in a single file. Hotspots are scarce enough
+// that we can skip the rule filter here and resolve in memory; the
+// /api/hotspots/search endpoint also does not accept a rules
+// parameter.
+//
+// Uses e.Raw (the cloud-side raw client) because the typed
+// HotspotsClient's SearchAll doesn't expose a per-file filter.
+func findCloudHotspotCandidates(ctx context.Context, e *Executor, cloudKey, orgKey, filePath string) ([]matchableHotspot, error) {
+	params := url.Values{}
+	params.Set("projectKey", cloudKey)
+	params.Set("files", filePath)
+	if orgKey != "" {
+		params.Set("organization", orgKey)
+	}
+	items, err := e.Raw.GetPaginated(ctx, common.PaginatedOpts{
+		Path:      "api/hotspots/search",
+		Params:    params,
+		ResultKey: "hotspots",
+		PageLimit: 5, // hotspots-in-one-file is small; cap for safety
+	})
+	if err != nil {
+		return nil, err
+	}
+	out := make([]matchableHotspot, 0, len(items))
+	for _, raw := range items {
+		h := parseMatchableHotspot(raw)
+		if h.Key == "" {
+			continue
+		}
+		out = append(out, h)
+	}
+	return out, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -531,27 +544,6 @@ func extractNestedField(data json.RawMessage, outerKey, innerKey string) string 
 		return ""
 	}
 	return extractField(nested, innerKey)
-}
-
-// ---------------------------------------------------------------------------
-// Loading Cloud hotspots
-// ---------------------------------------------------------------------------
-
-// loadCloudMatchableHotspots converts Cloud API Hotspot structs into
-// matchableHotspot structs suitable for FIFO matching.
-func loadCloudMatchableHotspots(hotspots []types.Hotspot) []matchableHotspot {
-	result := make([]matchableHotspot, 0, len(hotspots))
-	for _, h := range hotspots {
-		result = append(result, matchableHotspot{
-			Key:        h.Key,
-			RuleKey:    h.RuleKey,
-			Component:  h.Component,
-			Line:       h.Line,
-			Status:     h.Status,
-			Resolution: h.Resolution,
-		})
-	}
-	return result
 }
 
 // ---------------------------------------------------------------------------

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -8,110 +8,101 @@ import (
 	"testing"
 )
 
-func TestFilterActionableHotspotPairs(t *testing.T) {
+// #356: filter now runs source-side directly on matchableHotspot —
+// no longer pair-based, since we no longer pre-match against the
+// full Cloud hotspot list before filtering.
+func TestHotspotHasManualChanges(t *testing.T) {
 	comment := hotspotComment{Login: "alice", Markdown: "please review"}
 
 	tests := []struct {
-		name           string
-		pairs          []hotspotPair
-		wantActionable int
+		name string
+		h    matchableHotspot
+		want bool
 	}{
-		{
-			name:           "empty input",
-			pairs:          nil,
-			wantActionable: 0,
-		},
-		{
-			name: "TO_REVIEW without comments is not actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "TO_REVIEW", Comments: nil}},
-			},
-			wantActionable: 0,
-		},
-		{
-			name: "TO_REVIEW with comments is actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "TO_REVIEW", Comments: []hotspotComment{comment}}},
-			},
-			wantActionable: 1,
-		},
-		// #350: REVIEWED without a real resolution carries nothing to
-		// sync — drop those.
-		{
-			name: "REVIEWED with no resolution is NOT actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "", Comments: nil}},
-			},
-			wantActionable: 0,
-		},
-		{
-			name: "REVIEWED + SAFE is actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "SAFE", Comments: nil}},
-			},
-			wantActionable: 1,
-		},
-		{
-			name: "REVIEWED + ACKNOWLEDGED is actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "ACKNOWLEDGED", Comments: nil}},
-			},
-			wantActionable: 1,
-		},
-		{
-			name: "REVIEWED + FIXED is actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "FIXED", Comments: nil}},
-			},
-			wantActionable: 1,
-		},
-		{
-			name: "REVIEWED + unknown resolution is NOT actionable without comments",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "WHATEVER", Comments: nil}},
-			},
-			wantActionable: 0,
-		},
-		{
-			name: "REVIEWED + unknown resolution still picked up via comments",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "WHATEVER", Comments: []hotspotComment{comment}}},
-			},
-			wantActionable: 1,
-		},
-		{
-			name: "REVIEWED + SAFE with comments is actionable",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "SAFE", Comments: []hotspotComment{comment}}},
-			},
-			wantActionable: 1,
-		},
-		{
-			name: "mixed bag of pairs",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "TO_REVIEW", Comments: nil}},                                            // not actionable
-				{source: matchableHotspot{Status: "TO_REVIEW", Comments: []hotspotComment{comment}}},                      // actionable (comment)
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "", Comments: nil}},                             // NOT actionable (no resolution)
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "SAFE", Comments: nil}},                         // actionable (resolution)
-				{source: matchableHotspot{Status: "REVIEWED", Resolution: "FIXED", Comments: []hotspotComment{comment}}},  // actionable (both)
-			},
-			wantActionable: 3,
-		},
-		{
-			name: "status / resolution comparison is case-insensitive",
-			pairs: []hotspotPair{
-				{source: matchableHotspot{Status: "reviewed", Resolution: "safe", Comments: nil}},
-				{source: matchableHotspot{Status: "Reviewed", Resolution: "Acknowledged", Comments: nil}},
-			},
-			wantActionable: 2,
-		},
+		{name: "TO_REVIEW without comments — skip", h: matchableHotspot{Status: "TO_REVIEW"}, want: false},
+		{name: "TO_REVIEW with comments — sync", h: matchableHotspot{Status: "TO_REVIEW", Comments: []hotspotComment{comment}}, want: true},
+		// #350: REVIEWED without a resolution carries no payload.
+		{name: "REVIEWED no resolution — skip", h: matchableHotspot{Status: "REVIEWED"}, want: false},
+		{name: "REVIEWED + SAFE — sync", h: matchableHotspot{Status: "REVIEWED", Resolution: "SAFE"}, want: true},
+		{name: "REVIEWED + ACKNOWLEDGED — sync", h: matchableHotspot{Status: "REVIEWED", Resolution: "ACKNOWLEDGED"}, want: true},
+		{name: "REVIEWED + FIXED — sync", h: matchableHotspot{Status: "REVIEWED", Resolution: "FIXED"}, want: true},
+		{name: "REVIEWED + unknown resolution — skip", h: matchableHotspot{Status: "REVIEWED", Resolution: "WHATEVER"}, want: false},
+		{name: "REVIEWED + unknown resolution + comment — sync via comment", h: matchableHotspot{Status: "REVIEWED", Resolution: "WHATEVER", Comments: []hotspotComment{comment}}, want: true},
+		{name: "case-insensitive status / resolution", h: matchableHotspot{Status: "reviewed", Resolution: "safe"}, want: true},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := filterActionableHotspotPairs(tc.pairs)
-			if len(got) != tc.wantActionable {
-				t.Errorf("filterActionableHotspotPairs() returned %d pairs, want %d", len(got), tc.wantActionable)
+			got := hotspotHasManualChanges(tc.h)
+			if got != tc.want {
+				t.Errorf("hotspotHasManualChanges(%+v) = %v, want %v", tc.h, got, tc.want)
+			}
+		})
+	}
+}
+
+// #356: hotspot classifier uses (ruleKey, line) because /api/hotspots/search
+// doesn't accept a rules filter — we fetch by file and resolve in
+// memory. 1 → synced, 0 → not_found, n>1 → line_mismatch; mismatched
+// rules / lines are skipped.
+func TestClassifyHotspotCandidatesByLine(t *testing.T) {
+	cand := func(key, rule string, line int) matchableHotspot {
+		return matchableHotspot{Key: key, RuleKey: rule, Line: line}
+	}
+	tests := []struct {
+		name        string
+		candidates  []matchableHotspot
+		sourceRule  string
+		sourceLine  int
+		wantKey     string
+		wantOutcome syncOutcome
+	}{
+		{
+			name:        "exactly one rule+line match — synced (a)",
+			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 42)},
+			sourceRule:  "javasecurity:S1",
+			sourceLine:  42,
+			wantKey:     "h-1",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "match among other rules on same file — synced (a)",
+			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 10), cand("h-2", "javasecurity:S1", 42), cand("h-3", "javasecurity:S2", 42)},
+			sourceRule:  "javasecurity:S1",
+			sourceLine:  42,
+			wantKey:     "h-2",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "two same-rule+line — line_mismatch (b)",
+			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 42), cand("h-2", "javasecurity:S1", 42)},
+			sourceRule:  "javasecurity:S1",
+			sourceLine:  42,
+			wantOutcome: syncOutcomeLineMismatch,
+		},
+		{
+			name:        "different rule on the line — not_found (c)",
+			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S2", 42)},
+			sourceRule:  "javasecurity:S1",
+			sourceLine:  42,
+			wantOutcome: syncOutcomeNotFound,
+		},
+		{
+			name:        "rule matches but on different line — not_found (c)",
+			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 40)},
+			sourceRule:  "javasecurity:S1",
+			sourceLine:  42,
+			wantOutcome: syncOutcomeNotFound,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, outcome := classifyHotspotCandidatesByLine(tc.candidates, tc.sourceRule, tc.sourceLine)
+			if outcome != tc.wantOutcome {
+				t.Errorf("outcome = %v, want %v", outcome, tc.wantOutcome)
+			}
+			if tc.wantOutcome == syncOutcomeSynced && got.Key != tc.wantKey {
+				t.Errorf("pick = %q, want %q", got.Key, tc.wantKey)
 			}
 		})
 	}

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -12,9 +12,11 @@ import (
 	"net/url"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
+	sqtypes "github.com/sonar-solutions/sq-api-go/types"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
 
@@ -81,62 +83,16 @@ type issuePair struct {
 // Matching helpers
 // ---------------------------------------------------------------------------
 
-// buildIssueMatchKey produces a canonical key for matching issues across
-// environments. The component field from SonarQube includes the project
-// key as a prefix ("myproject:src/Foo.java"); we strip it so only the
-// relative file path remains. The key format is "rule|filePath|line".
-//
-// Returns "" if the issue lacks a rule, component, or has a non-positive line.
-func buildIssueMatchKey(iss matchableIssue) string {
-	if iss.Rule == "" || iss.Component == "" || iss.Line <= 0 {
-		return ""
+// stripProjectKeyPrefix removes the leading "projectKey:" segment from a
+// SonarQube component path, returning the bare file path. SonarQube
+// formats components as "projectKey:src/main/java/Foo.java"; the
+// project key is environment-specific but the file path part is the
+// same on source and cloud.
+func stripProjectKeyPrefix(component string) string {
+	if idx := strings.Index(component, ":"); idx >= 0 {
+		return component[idx+1:]
 	}
-	// Strip "projectKey:" prefix from component.
-	filePath := iss.Component
-	if idx := strings.Index(filePath, ":"); idx >= 0 {
-		filePath = filePath[idx+1:]
-	}
-	return fmt.Sprintf("%s|%s|%d", iss.Rule, filePath, iss.Line)
-}
-
-// matchIssues performs FIFO matching: for every source issue, take the first
-// Cloud candidate with the same match key. Each Cloud issue is consumed at
-// most once, preventing one-to-many duplication.
-//
-// The candidate map is built from cloudIssues (key -> []matchableIssue).
-// Source issues are iterated in order; the first available candidate for
-// each key is popped from the front of the slice (FIFO).
-//
-// All data structures are fully built before this function returns; no
-// mutation occurs during any subsequent concurrent phase.
-func matchIssues(sourceIssues, cloudIssues []matchableIssue) []issuePair {
-	// Build candidate map: matchKey -> ordered slice of cloud issues.
-	candidates := make(map[string][]matchableIssue, len(cloudIssues))
-	for _, ci := range cloudIssues {
-		k := buildIssueMatchKey(ci)
-		if k == "" {
-			continue
-		}
-		candidates[k] = append(candidates[k], ci)
-	}
-
-	// FIFO consume: iterate source issues and take the first available
-	// cloud candidate for each match key.
-	var pairs []issuePair
-	for _, si := range sourceIssues {
-		k := buildIssueMatchKey(si)
-		if k == "" {
-			continue
-		}
-		bucket := candidates[k]
-		if len(bucket) == 0 {
-			continue
-		}
-		// Pop the first candidate (FIFO).
-		pairs = append(pairs, issuePair{source: si, cloud: bucket[0]})
-		candidates[k] = bucket[1:]
-	}
-	return pairs
+	return component
 }
 
 // ---------------------------------------------------------------------------
@@ -311,9 +267,31 @@ func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 			if cloudKey == "" || orgKey == "" {
 				return nil
 			}
-			return syncProjectIssues(ctx, e, cloudKey, orgKey, serverURL, serverKey, counter, ruleDefaults)
+			stats := syncProjectIssues(ctx, e, cloudKey, orgKey, serverURL, serverKey, counter, ruleDefaults)
+			record, _ := json.Marshal(map[string]any{
+				"cloud_project_key": cloudKey,
+				"synced":            stats.A,
+				"line_mismatch":     stats.B,
+				"not_found":         stats.C,
+				"actionable":        stats.Actionable,
+			})
+			return w.WriteOne(record)
 		})
 	return err
+}
+
+// projectSyncStats is the per-project breakdown reported back from
+// syncProjectIssues / syncProjectHotspots for #356. A counts case a
+// (1 cloud counterpart on the same line — synced); B counts case b
+// (>1 counterparts on the same line — ambiguous, skipped); C counts
+// case c (no counterpart on the source's line — skipped). Actionable
+// is the size of the input set, so A+B+C ≤ Actionable (some pairs may
+// short-circuit before classification, e.g. lookup errors).
+type projectSyncStats struct {
+	Actionable int64
+	A          int64
+	B          int64
+	C          int64
 }
 
 // ---------------------------------------------------------------------------
@@ -322,98 +300,185 @@ func runSyncIssueMetadata(ctx context.Context, e *Executor) error {
 
 // syncProjectIssues handles the full issue-metadata sync for a single project:
 //
-//  1. Load source issues from extract
-//  2. Wait for Cloud indexing
-//  3. Fetch Cloud issues
-//  4. Match (FIFO)
-//  5. Pre-filter (hasManualChanges)
-//  6. Sync pairs with bounded concurrency
-//  7. Log summary
-func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serverURL, serverKey string, counter *TaskCounter, ruleDefaults *ruleTagDefaults) error {
-	// 1. Load source issues from extract data.
+//  1. Load + pre-filter source issues (only "actionable" via hasManualChanges)
+//  2. Wait for Cloud indexing to complete
+//  3. For each actionable source issue, search Cloud scoped to its file + rule
+//  4. Resolve by line: 1 hit → sync, 0 hits → not_found, >1 → line_mismatch
+//  5. Persist per-project a/b/c stats
+//
+// Replaces the previous fetch-all + FIFO match scheme (#356). The old
+// approach paginated /api/issues/search across every cloud issue in the
+// project (10k cap, O(cloud) per project regardless of source size);
+// the new approach issues one targeted search per ACTIONABLE source
+// issue and resolves it in memory. For projects where actionable is in
+// the dozens, this is dramatically faster — and the 10k cap no longer
+// bites large projects whose total issue count exceeds it.
+func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serverURL, serverKey string, counter *TaskCounter, ruleDefaults *ruleTagDefaults) projectSyncStats {
+	var stats projectSyncStats
+
+	// 1. Load source issues + pre-filter to actionable.
 	sourceIssues := loadMatchableIssues(e, serverURL, serverKey, ruleDefaults)
 	if len(sourceIssues) == 0 {
 		e.Logger.Debug("syncIssueMetadata: no source issues", "project", cloudKey)
-		return nil
+		return stats
+	}
+	var actionable []matchableIssue
+	for _, s := range sourceIssues {
+		if hasManualChanges(s) {
+			actionable = append(actionable, s)
+		}
+	}
+	stats.Actionable = int64(len(actionable))
+	if len(actionable) == 0 {
+		e.Logger.Debug("syncIssueMetadata: no actionable source issues after filter", "project", cloudKey, "source_total", len(sourceIssues))
+		return stats
 	}
 
-	// 2. Wait for Cloud indexing to complete before fetching.
-	err := waitForCloudIndexing(ctx, func() (int, error) {
+	// 2. Wait for Cloud indexing — proves the CE task is done so per-
+	// issue searches return real data.
+	if err := waitForCloudIndexing(ctx, func() (int, error) {
 		params := url.Values{}
 		params.Set("componentKeys", cloudKey)
 		params.Set("organization", orgKey)
 		return e.Cloud.Issues.Count(ctx, params)
-	})
-	if err != nil {
+	}); err != nil {
 		logAPIWarn(e.Logger, "syncIssueMetadata: indexing wait failed", err, "project", cloudKey)
-		return nil // non-fatal
-	}
-
-	// 3. Fetch all Cloud issues for the project.
-	cloudIssues, err := loadCloudMatchableIssues(ctx, e, cloudKey, orgKey)
-	if err != nil {
-		logAPIWarn(e.Logger, "syncIssueMetadata: fetch cloud issues failed", err, "project", cloudKey)
-		return nil // non-fatal — skip project
-	}
-	if len(cloudIssues) == 0 {
-		// Source had issues worth syncing, but Cloud has nothing to
-		// match against. Most common cause: the project-data CE task
-		// for this project failed (or was skipped), so the report was
-		// never indexed and Cloud has no issues yet. Promote to INFO
-		// so the operator can correlate the skip with the upstream
-		// failure log instead of wondering why nothing happened. #299.
-		e.Logger.Info("syncIssueMetadata: skipping project — no Cloud issues to match (project-data CE task likely failed or was skipped)",
-			"project", cloudKey, "source_issues", len(sourceIssues))
-		return nil
-	}
-
-	// 4. Match issues (FIFO). Built entirely before launching goroutines.
-	matchedPairs := matchIssues(sourceIssues, cloudIssues)
-	if len(matchedPairs) == 0 {
-		e.Logger.Debug("syncIssueMetadata: no matched pairs", "project", cloudKey)
-		return nil
-	}
-
-	// 5. Pre-filter: only sync pairs where the source has manual changes.
-	var actionable []issuePair
-	for _, p := range matchedPairs {
-		if hasManualChanges(p.source) {
-			actionable = append(actionable, p)
-		}
-	}
-	if len(actionable) == 0 {
-		e.Logger.Debug("syncIssueMetadata: no actionable pairs after filter", "project", cloudKey)
-		return nil
+		return stats
 	}
 
 	e.Logger.Info("syncIssueMetadata: syncing pairs",
 		"project", cloudKey,
 		"source_total", len(sourceIssues),
-		"cloud_total", len(cloudIssues),
-		"matched", len(matchedPairs),
 		"actionable", len(actionable),
 	)
 
-	// 6. Sync pairs with bounded concurrency, emitting a per-
-	// project "Project key <key> issue sync: N/M - X%" line every
-	// 20 completions (#300 / #348). The label includes the cloud
-	// project key so an operator tailing the log can disentangle
-	// the lines coming from concurrent projects' inner loops
-	// (issue #348). runProjectSyncLoop handles the errgroup, the
-	// semaphore bound, and the progress logger.
-	//
-	// RACE-CONDITION SAFETY:
-	//   - actionable slice is read-only during this phase.
-	//   - Each goroutine receives exactly ONE issuePair by value.
-	//   - counter uses atomic operations (existing pattern).
-	//   - No shared mutable state is accessed.
+	// 3 + 4. Per-actionable-source: targeted search, resolve by line,
+	// dispatch. Counted via atomics on the shared stats. Race-safety:
+	// the actionable slice is read-only, each goroutine receives one
+	// source by value, and stats.{A,B,C} use atomic adds.
+	var a, b, c atomic.Int64
 	label := "Project key " + cloudKey + " issue sync:"
 	runProjectSyncLoop(ctx, e, actionable, label, 20,
-		func(gctx context.Context, pair issuePair) {
-			syncOnePair(gctx, e, pair, counter)
+		func(gctx context.Context, src matchableIssue) {
+			outcome := resolveAndSyncIssue(gctx, e, cloudKey, orgKey, src, counter)
+			switch outcome {
+			case syncOutcomeSynced:
+				a.Add(1)
+			case syncOutcomeLineMismatch:
+				b.Add(1)
+			case syncOutcomeNotFound:
+				c.Add(1)
+			}
 		})
+	stats.A = a.Load()
+	stats.B = b.Load()
+	stats.C = c.Load()
+	return stats
+}
 
-	return nil
+// syncOutcome is the per-source classification produced by
+// resolveAndSyncIssue (#356).
+type syncOutcome int
+
+const (
+	// syncOutcomeSynced — exactly one cloud counterpart on the same
+	// line; pair was sync'd (case a).
+	syncOutcomeSynced syncOutcome = iota
+	// syncOutcomeLineMismatch — multiple cloud counterparts on the
+	// same line (case b); ambiguous, skipped.
+	syncOutcomeLineMismatch
+	// syncOutcomeNotFound — zero cloud counterparts on the source's
+	// line (case c); unexpected for a freshly migrated project,
+	// skipped.
+	syncOutcomeNotFound
+	// syncOutcomeLookupError — the per-source search call failed
+	// (network, 5xx). Reported but not classified into a/b/c so a
+	// noisy network doesn't pollute the near-perfect signal.
+	syncOutcomeLookupError
+)
+
+// resolveAndSyncIssue searches Cloud for counterparts of src, resolves
+// to one by line, and dispatches the sync. Returns the case-a/b/c/lookup
+// outcome.
+func resolveAndSyncIssue(ctx context.Context, e *Executor, cloudKey, orgKey string, src matchableIssue, counter *TaskCounter) syncOutcome {
+	filePath := stripProjectKeyPrefix(src.Component)
+	if filePath == "" || src.Rule == "" || src.Line <= 0 {
+		e.Logger.Debug("syncIssueMetadata: source issue not matchable", "key", src.Key, "rule", src.Rule, "component", src.Component, "line", src.Line)
+		return syncOutcomeNotFound
+	}
+	candidates, err := findCloudIssueCandidates(ctx, e, cloudKey, orgKey, filePath, src.Rule)
+	if err != nil {
+		logAPIWarn(e.Logger, "syncIssueMetadata: cloud candidate lookup failed", err,
+			"project", cloudKey, "source_key", src.Key, "rule", src.Rule, "file", filePath)
+		return syncOutcomeLookupError
+	}
+	target, outcome := classifyIssueCandidatesByLine(candidates, src.Line)
+	switch outcome {
+	case syncOutcomeSynced:
+		syncOnePair(ctx, e, issuePair{source: src, cloud: target}, counter)
+	case syncOutcomeNotFound:
+		e.Logger.Debug("syncIssueMetadata: no cloud counterpart on source line", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line)
+	case syncOutcomeLineMismatch:
+		keys := make([]string, 0)
+		for _, c := range candidates {
+			if c.Line == src.Line {
+				keys = append(keys, c.Key)
+			}
+		}
+		e.Logger.Debug("syncIssueMetadata: multiple cloud counterparts on source line, skipping", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line, "candidates", keys)
+	}
+	return outcome
+}
+
+// classifyIssueCandidatesByLine implements the case a/b/c decision
+// from #356: among candidates returned by /api/issues/search, pick
+// the one on the source's line. 1 → synced, 0 → not_found, n>1 →
+// line_mismatch. Factored out so the per-pair logic is unit testable
+// without HTTP mocking.
+func classifyIssueCandidatesByLine(candidates []matchableIssue, sourceLine int) (matchableIssue, syncOutcome) {
+	var pick matchableIssue
+	matches := 0
+	for _, c := range candidates {
+		if c.Line == sourceLine {
+			matches++
+			if matches == 1 {
+				pick = c
+			}
+		}
+	}
+	switch matches {
+	case 0:
+		return matchableIssue{}, syncOutcomeNotFound
+	case 1:
+		return pick, syncOutcomeSynced
+	default:
+		return matchableIssue{}, syncOutcomeLineMismatch
+	}
+}
+
+// findCloudIssueCandidates queries /api/issues/search for cloud issues
+// matching the given file path + rule. Typical result set is 1–3
+// issues; pagination cost is dwarfed by the savings from no longer
+// fetching every issue in the project.
+func findCloudIssueCandidates(ctx context.Context, e *Executor, cloudKey, orgKey, filePath, ruleKey string) ([]matchableIssue, error) {
+	params := url.Values{}
+	params.Set("componentKeys", cloudKey+":"+filePath)
+	params.Set("organization", orgKey)
+	params.Set("rules", ruleKey)
+	// Same statuses we already use on the source side — we want to be
+	// idempotent against issues that were already migrated in a prior
+	// run (the cloud counterpart may be in ACCEPTED / FALSE_POSITIVE
+	// state already).
+	params.Set("issueStatuses", "OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED")
+	apiIssues, err := e.Cloud.Issues.SearchAll(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]matchableIssue, 0, len(apiIssues))
+	for _, ai := range apiIssues {
+		out = append(out, apiIssueToMatchable(ai))
+	}
+	return out, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -657,44 +722,29 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 	return issues
 }
 
-// loadCloudMatchableIssues fetches all issues from Cloud for a given
-// project and converts them to matchableIssue values.
-func loadCloudMatchableIssues(ctx context.Context, e *Executor, cloudKey, orgKey string) ([]matchableIssue, error) {
-	params := url.Values{}
-	params.Set("componentKeys", cloudKey)
-	params.Set("organization", orgKey)
-	// Fetch all statuses to enable accurate matching.
-	params.Set("statuses", "OPEN,CONFIRMED,REOPENED,RESOLVED,CLOSED")
-
-	apiIssues, err := e.Cloud.Issues.SearchAll(ctx, params)
-	if err != nil {
-		return nil, err
-	}
-
-	issues := make([]matchableIssue, 0, len(apiIssues))
-	for _, ai := range apiIssues {
-		comments := make([]issueComment, 0, len(ai.Comments))
-		for _, c := range ai.Comments {
-			comments = append(comments, issueComment{
-				Login:     c.Login,
-				HTMLText:  c.HTMLText,
-				Markdown:  c.Markdown,
-				CreatedAt: c.CreatedAt,
-			})
-		}
-		issues = append(issues, matchableIssue{
-			Key:        ai.Key,
-			Rule:       ai.Rule,
-			Component:  ai.Component,
-			Line:       ai.Line,
-			Status:     ai.Status,
-			Resolution: ai.Resolution,
-			Tags:       ai.Tags,
-			Comments:   comments,
-			Assignee:   ai.Assignee,
+// apiIssueToMatchable converts an sq-api-go Issue into the local
+// matchableIssue shape used by the sync orchestration.
+func apiIssueToMatchable(ai sqtypes.Issue) matchableIssue {
+	comments := make([]issueComment, 0, len(ai.Comments))
+	for _, c := range ai.Comments {
+		comments = append(comments, issueComment{
+			Login:     c.Login,
+			HTMLText:  c.HTMLText,
+			Markdown:  c.Markdown,
+			CreatedAt: c.CreatedAt,
 		})
 	}
-	return issues, nil
+	return matchableIssue{
+		Key:        ai.Key,
+		Rule:       ai.Rule,
+		Component:  ai.Component,
+		Line:       ai.Line,
+		Status:     ai.Status,
+		Resolution: ai.Resolution,
+		Tags:       ai.Tags,
+		Comments:   comments,
+		Assignee:   ai.Assignee,
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -238,3 +238,97 @@ func equalStrings(a, b []string) bool {
 	}
 	return true
 }
+
+// #356: stripProjectKeyPrefix isolates the file-path part of a
+// SonarQube component identifier. The substitution is essential for
+// the targeted cloud search: we send componentKeys=<cloudKey>:<file>
+// derived from the source's <sourceKey>:<file> string.
+func TestStripProjectKeyPrefix(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "leading project key", in: "myproject:src/main/java/Foo.java", want: "src/main/java/Foo.java"},
+		{name: "nested colon stays after first", in: "myproject:com:foo/Bar.java", want: "com:foo/Bar.java"},
+		{name: "no project prefix", in: "src/main/java/Foo.java", want: "src/main/java/Foo.java"},
+		{name: "empty", in: "", want: ""},
+		{name: "colon only", in: "myproject:", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripProjectKeyPrefix(tc.in)
+			if got != tc.want {
+				t.Errorf("stripProjectKeyPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// #356: case a/b/c classification — exactly the semantics from the
+// issue. 1 cloud counterpart on the source line → synced (a); 0
+// counterparts on the line → not_found (c); 2+ on the same line →
+// line_mismatch (b). Off-line candidates are ignored.
+func TestClassifyIssueCandidatesByLine(t *testing.T) {
+	cand := func(key string, line int) matchableIssue {
+		return matchableIssue{Key: key, Line: line}
+	}
+	tests := []struct {
+		name        string
+		candidates  []matchableIssue
+		sourceLine  int
+		wantKey     string
+		wantOutcome syncOutcome
+	}{
+		{
+			name:        "exactly one match on line — synced (a)",
+			candidates:  []matchableIssue{cand("cloud-1", 42)},
+			sourceLine:  42,
+			wantKey:     "cloud-1",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "one match among off-line candidates — synced (a)",
+			candidates:  []matchableIssue{cand("cloud-a", 40), cand("cloud-b", 42), cand("cloud-c", 44)},
+			sourceLine:  42,
+			wantKey:     "cloud-b",
+			wantOutcome: syncOutcomeSynced,
+		},
+		{
+			name:        "two matches on same line — line_mismatch (b)",
+			candidates:  []matchableIssue{cand("cloud-a", 42), cand("cloud-b", 42)},
+			sourceLine:  42,
+			wantOutcome: syncOutcomeLineMismatch,
+		},
+		{
+			name:        "three matches on same line, one off-line — line_mismatch (b)",
+			candidates:  []matchableIssue{cand("cloud-a", 42), cand("cloud-b", 42), cand("cloud-c", 42), cand("cloud-d", 99)},
+			sourceLine:  42,
+			wantOutcome: syncOutcomeLineMismatch,
+		},
+		{
+			name:        "no matches on line, candidates elsewhere — not_found (c)",
+			candidates:  []matchableIssue{cand("cloud-a", 40), cand("cloud-b", 44)},
+			sourceLine:  42,
+			wantOutcome: syncOutcomeNotFound,
+		},
+		{
+			name:        "empty candidates — not_found (c)",
+			candidates:  nil,
+			sourceLine:  42,
+			wantOutcome: syncOutcomeNotFound,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, outcome := classifyIssueCandidatesByLine(tc.candidates, tc.sourceLine)
+			if outcome != tc.wantOutcome {
+				t.Errorf("outcome = %v, want %v", outcome, tc.wantOutcome)
+			}
+			if tc.wantOutcome == syncOutcomeSynced && got.Key != tc.wantKey {
+				t.Errorf("pick = %q, want %q", got.Key, tc.wantKey)
+			}
+		})
+	}
+}

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -41,6 +41,7 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 	projectDataMap := collectProjectData(store)
 	ncdFallbackMap := collectNCDFallback(store)
 	ncdBranchOverrideSet := collectNCDBranchOverrides(store)
+	syncStatsMap := collectSyncStats(store)
 	extractMapping, _ := structure.GetUniqueExtracts(exportDir)
 
 	var sections []Section
@@ -61,6 +62,15 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 			projectFailures = append(projectFailures, collectProjectSyncSkips(store)...)
 			section.Succeeded, section.NearPerfect, section.Partial = applyProjectFailures(
 				section.Succeeded, section.NearPerfect, section.Partial, projectFailures)
+			// #356 — append a per-project "x/y issues synced (z%)"
+			// line to the project's Detail field. Applied AFTER
+			// applyProjectFailures so it lands on all routed buckets
+			// (Succeeded, NearPerfect, Partial). Predictive reports
+			// suppress this line at render time (sync success cannot
+			// be predicted).
+			attachSyncStats(section.Succeeded, syncStatsMap)
+			attachSyncStats(section.NearPerfect, syncStatsMap)
+			attachSyncStats(section.Partial, syncStatsMap)
 		}
 		sections = append(sections, section)
 	}
@@ -729,6 +739,87 @@ func attachProjectData(projects []EntityItem, scanMap map[string]string) {
 			projects[i].Detail = cloudKey + "|scan:" + status
 		}
 	}
+}
+
+// projectSyncCounts holds the issue/hotspot sync a/b/c counts for a
+// single cloud project. Built by collectSyncStats from the JSONL
+// records syncIssueMetadata and syncHotspotMetadata write per project.
+type projectSyncCounts struct {
+	IssueActionable    int
+	IssueSynced        int
+	HotspotActionable  int
+	HotspotSynced      int
+}
+
+// collectSyncStats reads per-project sync records and returns a map
+// keyed by cloud project key. The per-project record schema is
+// {synced, line_mismatch, not_found, actionable}; only `synced` and
+// `actionable` need to surface in the Details line (#356).
+func collectSyncStats(store *common.DataStore) map[string]projectSyncCounts {
+	out := map[string]projectSyncCounts{}
+	collect := func(taskName string, set func(*projectSyncCounts, int, int)) {
+		items, err := store.ReadAll(taskName)
+		if err != nil {
+			return
+		}
+		for _, raw := range items {
+			key := jsonStr(raw, "cloud_project_key")
+			if key == "" {
+				continue
+			}
+			counts := out[key]
+			set(&counts, jsonInt(raw, "synced"), jsonInt(raw, "actionable"))
+			out[key] = counts
+		}
+	}
+	collect("syncIssueMetadata", func(c *projectSyncCounts, synced, actionable int) {
+		c.IssueSynced = synced
+		c.IssueActionable = actionable
+	})
+	collect("syncHotspotMetadata", func(c *projectSyncCounts, synced, actionable int) {
+		c.HotspotSynced = synced
+		c.HotspotActionable = actionable
+	})
+	return out
+}
+
+// attachSyncStats appends a "|syncStats:i=<synced>/<actionable>(<pct>),h=..."
+// marker to each project's Detail field when at least one of issues
+// or hotspots had actionable items for that project. The renderer
+// parses this marker and emits a one-line "X% of manually-triaged
+// items successfully synchronized" comment (PDF + markdown only —
+// the predictive report skips it because sync success cannot be
+// predicted). #356.
+func attachSyncStats(projects []EntityItem, syncMap map[string]projectSyncCounts) {
+	if len(syncMap) == 0 || len(projects) == 0 {
+		return
+	}
+	for i := range projects {
+		key := projectCloudKey(projects[i].Detail)
+		counts, ok := syncMap[key]
+		if !ok {
+			continue
+		}
+		if counts.IssueActionable == 0 && counts.HotspotActionable == 0 {
+			continue
+		}
+		projects[i].Detail = projects[i].Detail + "|syncStats:" + encodeSyncStats(counts)
+	}
+}
+
+// encodeSyncStats renders projectSyncCounts as a compact marker
+// payload: "i=<synced>/<actionable>,h=<synced>/<actionable>". Either
+// half is omitted when its actionable count is zero so the renderer
+// can simply split-and-render the segments that exist.
+func encodeSyncStats(c projectSyncCounts) string {
+	var parts []string
+	if c.IssueActionable > 0 {
+		parts = append(parts, fmt.Sprintf("i=%d/%d", c.IssueSynced, c.IssueActionable))
+	}
+	if c.HotspotActionable > 0 {
+		parts = append(parts, fmt.Sprintf("h=%d/%d", c.HotspotSynced, c.HotspotActionable))
+	}
+	return strings.Join(parts, ",")
 }
 
 // collectNCDFallback reads the setNewCodePeriods JSONL and returns a

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1155,7 +1156,7 @@ const (
 // bold markers so the PDF renderer can stress it. Other sections keep
 // the bare cloud key as-is.
 func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey bool) string {
-	cloudKey, scan, ncdFallback := parseProjectDetailMarkers(item.Detail)
+	cloudKey, scan, ncdFallback, syncStats := parseProjectDetailMarkers(item.Detail)
 	if hideCloudKey || (predictive && strings.HasPrefix(cloudKey, "predict:")) {
 		cloudKey = ""
 	}
@@ -1175,7 +1176,51 @@ func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey b
 	if scan != "" {
 		parts = append(parts, fmt.Sprintf("project data: %s", scanStatusLabel(scan)))
 	}
+	// #356 — render the per-project "x% of items with manual changes
+	// were successfully synchronized" comment. Suppressed in
+	// predictive reports because sync success cannot be predicted
+	// ahead of the actual migration.
+	if !predictive && syncStats != "" {
+		if line := renderSyncStatsLine(syncStats); line != "" {
+			parts = append(parts, line)
+		}
+	}
 	return strings.Join(parts, "\n")
+}
+
+// renderSyncStatsLine turns an attachSyncStats payload
+// ("i=42/50,h=10/12") into a human-readable line. The marker
+// guarantees each segment has the shape "x=N/M"; we render N/M and
+// the truncated percent.
+func renderSyncStatsLine(payload string) string {
+	var segments []string
+	for _, seg := range strings.Split(payload, ",") {
+		switch {
+		case strings.HasPrefix(seg, "i="):
+			if s := formatSyncStatSegment("issues with manual changes", seg[2:]); s != "" {
+				segments = append(segments, s)
+			}
+		case strings.HasPrefix(seg, "h="):
+			if s := formatSyncStatSegment("hotspots with manual changes", seg[2:]); s != "" {
+				segments = append(segments, s)
+			}
+		}
+	}
+	return strings.Join(segments, "; ")
+}
+
+func formatSyncStatSegment(label, fraction string) string {
+	slash := strings.Index(fraction, "/")
+	if slash <= 0 {
+		return ""
+	}
+	synced, err1 := strconv.Atoi(fraction[:slash])
+	actionable, err2 := strconv.Atoi(fraction[slash+1:])
+	if err1 != nil || err2 != nil || actionable <= 0 {
+		return ""
+	}
+	pct := synced * 100 / actionable
+	return fmt.Sprintf("%d%% of %s synced (%d/%d)", pct, label, synced, actionable)
 }
 
 // partialDetails formats the Details column for a Partial / NearPerfect
@@ -1299,12 +1344,20 @@ func parseProjectData(detail string) (string, string) {
 }
 
 // parseProjectDetailMarkers splits a project's Detail string into its
-// three parts: the cloud key, the project-data status (or empty),
-// and the NCD fallback source type (or empty). Marker ordering set
-// by attachNCDFallback puts the NCD marker BEFORE the scan marker.
-func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback string) {
+// constituent parts: the cloud key, the project-data status (or
+// empty), the NCD fallback source type (or empty), and the #356
+// per-project issue/hotspot sync stats payload (or empty). The sync
+// marker is appended last by attachSyncStats so it's stripped FIRST
+// here to avoid being absorbed by the others' suffix matching.
+func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, syncStats string) {
 	cloudKey = detail
-	// scan marker (always last when present).
+	// syncStats marker (always last when present — attachSyncStats
+	// runs at the end of the collect pipeline).
+	if idx := strings.Index(cloudKey, "|syncStats:"); idx >= 0 {
+		syncStats = cloudKey[idx+len("|syncStats:"):]
+		cloudKey = cloudKey[:idx]
+	}
+	// scan marker.
 	if idx := strings.Index(cloudKey, "|scan:"); idx >= 0 {
 		scan = cloudKey[idx+len("|scan:"):]
 		cloudKey = cloudKey[:idx]
@@ -1314,7 +1367,7 @@ func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback strin
 		ncdFallback = cloudKey[idx+len("|ncdFallback:"):]
 		cloudKey = cloudKey[:idx]
 	}
-	return cloudKey, scan, ncdFallback
+	return cloudKey, scan, ncdFallback, syncStats
 }
 
 func scanStatusLabel(status string) string {

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -436,6 +436,47 @@ func TestSuccessDetailsLabelProjectKey(t *testing.T) {
 	}
 }
 
+// #356: per-project sync stats marker renders a one-line "x% of items
+// with manual changes synced" comment, but only in the live migration
+// report — predictive reports suppress it because sync success
+// cannot be predicted ahead of the migration.
+func TestSuccessDetailsSyncStatsLine(t *testing.T) {
+	item := EntityItem{Detail: "acme_proj|syncStats:i=42/50,h=10/12"}
+
+	t.Run("live report renders both segments + cloud key", func(t *testing.T) {
+		got := successDetails(item, false, false, false)
+		for _, want := range []string{"acme_proj", "84% of issues with manual changes synced (42/50)", "83% of hotspots with manual changes synced (10/12)"} {
+			if !strings.Contains(got, want) {
+				t.Errorf("missing %q in:\n%s", want, got)
+			}
+		}
+	})
+	t.Run("predictive report suppresses the line", func(t *testing.T) {
+		got := successDetails(item, true, false, false)
+		if strings.Contains(got, "synced") {
+			t.Errorf("predictive should not render sync stats, got %q", got)
+		}
+		if !strings.Contains(got, "acme_proj") {
+			t.Errorf("expected cloud key still present, got %q", got)
+		}
+	})
+	t.Run("issue-only marker", func(t *testing.T) {
+		got := successDetails(EntityItem{Detail: "p|syncStats:i=0/3"}, false, false, false)
+		if !strings.Contains(got, "0% of issues with manual changes synced (0/3)") {
+			t.Errorf("expected 0%% line, got %q", got)
+		}
+		if strings.Contains(got, "hotspots") {
+			t.Errorf("did not expect hotspot segment, got %q", got)
+		}
+	})
+	t.Run("no marker — no sync line", func(t *testing.T) {
+		got := successDetails(EntityItem{Detail: "plain"}, false, false, false)
+		if strings.Contains(got, "synced") {
+			t.Errorf("did not expect sync line for plain detail, got %q", got)
+		}
+	})
+}
+
 func TestPartialDetailsSplitsScanMarker(t *testing.T) {
 	// Regression: a Partial / NearPerfect project carrying a |scan: marker
 	// in its Detail must have the marker split off onto its own

--- a/go/internal/report/summary/project_failures.go
+++ b/go/internal/report/summary/project_failures.go
@@ -285,13 +285,18 @@ func applyProjectFailures(succeeded, nearPerfect, partial []EntityItem,
 
 // collectProjectSyncSkips reads the per-project status JSONL produced
 // by the data-migration tasks and returns a synthetic []projectFailure
-// covering #228's orange criteria:
+// covering #228's orange criteria plus #356's yellow criteria:
 //
-//   - importProjectData rows with status != "success" → "Project data
-//     migration was skipped" (one per affected branch is collapsed
-//     into a single row per project, listing the failed branches).
-//   - syncHotspotMetadata rows with skipped>0 / failed>0 / error!=""
-//     → "Hotspot status sync was skipped".
+//   - importProjectData rows with status != "success" → Partial,
+//     "Project data migration was skipped" (one row per project,
+//     listing the failed branches).
+//   - syncHotspotMetadata / syncIssueMetadata rows whose source-issue
+//     could not be resolved to a single cloud counterpart on the same
+//     line (line_mismatch > 0 || not_found > 0) → NearPerfect,
+//     "Issue sync had unresolved counterparts" /
+//     "Hotspot sync had unresolved counterparts".
+//   - syncHotspotMetadata / syncIssueMetadata rows with error != ""
+//     → Partial, "<task> errored".
 //
 // The returned failures plug straight into applyProjectFailures.
 func collectProjectSyncSkips(store *common.DataStore) []projectFailure {
@@ -327,37 +332,78 @@ func collectProjectSyncSkips(store *common.DataStore) []projectFailure {
 		})
 	}
 
-	// syncHotspotMetadata — one row per project.
-	hotspotItems, _ := store.ReadAll("syncHotspotMetadata")
-	for _, raw := range hotspotItems {
+	// Per-project issue / hotspot sync rows — Near perfect when b+c > 0,
+	// Partial when a fatal error was captured.
+	out = append(out, collectSyncOutcome(store, "syncIssueMetadata",
+		"Issue sync had unresolved counterparts",
+		"Issue sync errored")...)
+	out = append(out, collectSyncOutcome(store, "syncHotspotMetadata",
+		"Hotspot sync had unresolved counterparts",
+		"Hotspot sync errored")...)
+
+	return out
+}
+
+// collectSyncOutcome reads per-project sync records for a given task
+// (syncIssueMetadata or syncHotspotMetadata) and converts them to
+// projectFailure entries. b/c > 0 yields a NearPerfect failure; a
+// non-empty error yields a Partial one.
+func collectSyncOutcome(store *common.DataStore, taskName, mismatchOp, errorOp string) []projectFailure {
+	items, err := store.ReadAll(taskName)
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	var out []projectFailure
+	for _, raw := range items {
 		key := jsonStr(raw, "cloud_project_key")
 		if key == "" {
 			continue
 		}
-		skipped := jsonInt(raw, "skipped")
-		failed := jsonInt(raw, "failed")
+		lineMismatch := jsonInt(raw, "line_mismatch")
+		notFound := jsonInt(raw, "not_found")
+		actionable := jsonInt(raw, "actionable")
+		synced := jsonInt(raw, "synced")
 		errMsg := jsonStr(raw, "error")
-		if skipped == 0 && failed == 0 && errMsg == "" {
-			continue
-		}
-		parts := []string{}
-		if skipped > 0 {
-			parts = append(parts, fmt.Sprintf("%d skipped", skipped))
-		}
-		if failed > 0 {
-			parts = append(parts, fmt.Sprintf("%d failed", failed))
-		}
-		pf := projectFailure{
-			CloudProjectKey: key,
-			Bucket:          projectBucketPartial,
-			Operation:       "Hotspot status sync was skipped",
-			Detail:          strings.Join(parts, ", "),
+
+		if lineMismatch+notFound > 0 {
+			parts := []string{}
+			if lineMismatch > 0 {
+				parts = append(parts, fmt.Sprintf("%d line mismatches", lineMismatch))
+			}
+			if notFound > 0 {
+				parts = append(parts, fmt.Sprintf("%d not found", notFound))
+			}
+			detail := fmt.Sprintf("%d/%d synced", synced, actionable)
+			if actionable > 0 {
+				detail += fmt.Sprintf(" (%d%%)", percent(synced, actionable))
+			}
+			if len(parts) > 0 {
+				detail += " — " + strings.Join(parts, ", ")
+			}
+			out = append(out, projectFailure{
+				CloudProjectKey: key,
+				Bucket:          projectBucketNearPerfect,
+				Operation:       mismatchOp,
+				Detail:          detail,
+			})
 		}
 		if errMsg != "" {
-			pf.Error = errMsg
+			out = append(out, projectFailure{
+				CloudProjectKey: key,
+				Bucket:          projectBucketPartial,
+				Operation:       errorOp,
+				Error:           errMsg,
+			})
 		}
-		out = append(out, pf)
 	}
-
 	return out
+}
+
+// percent computes 100 * a / total with truncation. Returns 0 when
+// total is zero so callers don't have to guard.
+func percent(a, total int) int {
+	if total <= 0 {
+		return 0
+	}
+	return a * 100 / total
 }


### PR DESCRIPTION
## Summary

Fixes #356. Replaces the previous **fetch-all + FIFO match** issue/hotspot sync with a **per-actionable-source-issue targeted Cloud search**. For each actionable source issue we now query Cloud scoped to its file + rule — typically 1–3 results — and resolve to one cloud counterpart by line.

### Resolution algorithm (per issue spec)

For each actionable source issue with rule `R`, file `F`, line `L`:

1. `GET /api/issues/search?componentKeys=<cloudKey>:<F>&rules=<R>&organization=<org>&issueStatuses=OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED`
2. Filter to results with `line == L`
3. Branch on cardinality:
   - **1** → case **a**, syncOnePair (synced)
   - **0** → case **c**, log debug, skip (`not_found`)
   - **n>1** → case **b**, log debug with all keys, skip (`line_mismatch`)

Hotspots use the same shape via `/api/hotspots/search?projectKey=...&files=...` (the hotspot endpoint doesn't accept `rules`, so we filter `ruleKey + line` in memory).

### Reporting (also per issue spec)

- Per-project a/b/c counts are persisted in the `syncIssueMetadata` / `syncHotspotMetadata` data store records.
- `collectProjectSyncSkips` reads them. When `line_mismatch + not_found > 0`, the project gets a **Near perfect** `projectFailure` so it demotes from Succeeded. Existing bucket precedence keeps projects in worse buckets (Partial / Failed) untouched.
- Per-project Details column in the **PDF + Markdown** migration reports now carries a line like `84% of issues with manual changes synced (42/50); 83% of hotspots with manual changes synced (10/12)` whenever `actionable > 0`.
- The **predictive report** suppresses this line — sync success can't be predicted before the actual migration.

### Dead code removed

`loadCloudMatchableIssues`, `matchIssues`, `buildIssueMatchKey`, `matchHotspots`, `buildHotspotMatchKey`, `filterActionableHotspotPairs`, `buildHotspotPairs`, `loadCloudMatchableHotspots`, `syncHotspotResult`'s `Synced/Skipped/Failed` fields — all no longer reachable. ~460 lines deleted.

## Decisions locked at planning time

- **Search shape**: `componentKeys + rules` per source issue (1 API call per actionable source).
- **Near perfect precedence**: demotes from Succeeded only. Worse statuses stay worse (handled by existing `applyProjectFailures`).
- **Counting granularity**: per project, aggregated at report time.
- **Scope**: issues AND hotspots in this PR for symmetry.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/migrate/ ./internal/report/summary/` clean
- [x] New `TestClassifyIssueCandidatesByLine` table: 1/0/n+1 outcomes, off-line candidates ignored
- [x] New `TestClassifyHotspotCandidatesByLine` table: same shape, plus rule-mismatch and line-mismatch cases
- [x] New `TestStripProjectKeyPrefix` covers leading/no/embedded colons
- [x] Refactored hotspot test (`TestHotspotHasManualChanges`) — now source-side filter instead of pair-based (no more all-cloud-fetch)
- [x] New `TestSuccessDetailsSyncStatsLine` — both segments, predictive gating, issue-only marker, no-marker fallback
- [ ] CI green
- [ ] End-to-end migration on the user's reference run: confirm
  - `syncIssueMetadata` wall-clock drops further vs #350-only (no fetch-all per project)
  - At least one project hits case b or c and shows status `Near perfect`
  - Per-project Details column shows the new line in PDF/Markdown
  - Predictive report does NOT carry the new line

## Out of scope
- Server-side narrowing on the source extract (`issueStatuses=ACCEPTED,FALSE_POSITIVE`) — #350 already narrows at load time.
- Per-branch a/b/c breakdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)