### PR TITLE
Issue #353: surface dropped user permissions in the Details column

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -916,17 +916,21 @@ func collectDroppedUserPermsBySection(exportDir string, mapping structure.Extrac
 			"project", projMap)
 	}
 
-	// Quality Profiles: getProfileUsers carries `profileKey` (source).
-	// Translate via createProfiles' (key → cloud_profile_key).
-	if profMap := buildSourceToCloudMap(store, "createProfiles", "key", "cloud_profile_key"); len(profMap) > 0 {
+	// Quality Profiles: getProfileUsers carries `profileKey` (the
+	// source profile's UUID). createProfiles writes the SAME value
+	// under the `source_profile_key` field — not `key`, which is
+	// reserved for use by the input mappings — so we translate via
+	// source_profile_key → cloud_profile_key.
+	if profMap := buildSourceToCloudMap(store, "createProfiles", "source_profile_key", "cloud_profile_key"); len(profMap) > 0 {
 		out["Quality Profiles"] = aggregateUserPermsByEntity(exportDir, mapping,
 			[]string{"getProfileUsers"}, "profileKey", profMap)
 	}
 
 	// Permission Templates: getTemplateUsersScanners +
-	// getTemplateUsersViewers both carry `templateId` (source).
-	// Translate via createPermissionTemplates' (id → cloud_template_id).
-	if tplMap := buildSourceToCloudMap(store, "createPermissionTemplates", "id", "cloud_template_id"); len(tplMap) > 0 {
+	// getTemplateUsersViewers both carry `templateId` (the source
+	// template's UUID). createPermissionTemplates writes the same
+	// value under `source_template_key`.
+	if tplMap := buildSourceToCloudMap(store, "createPermissionTemplates", "source_template_key", "cloud_template_id"); len(tplMap) > 0 {
 		out["Permission Templates"] = aggregateUserPermsByEntity(exportDir, mapping,
 			[]string{"getTemplateUsersScanners", "getTemplateUsersViewers"},
 			"templateId", tplMap)

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -44,6 +45,14 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 	ncdBranchOverrideSet := collectNCDBranchOverrides(store)
 	syncStatsMap := collectSyncStats(store)
 	extractMapping, _ := structure.GetUniqueExtracts(exportDir)
+	// #353 — per-object dropped-user-permission counts: SonarQube Cloud
+	// has no API to grant permissions to individual users, so any user
+	// permission found on a source object is dropped at migration time.
+	// Surface that as a per-row "Permissions granted to N users have
+	// been dropped" line via a |userPerms: marker. The status of the
+	// object itself stays Succeeded — this is informational, not a
+	// failure.
+	droppedPerms := collectDroppedUserPermsBySection(exportDir, extractMapping, store)
 
 	var sections []Section
 	for _, def := range sectionDefs {
@@ -72,6 +81,15 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 			attachSyncStats(section.Succeeded, syncStatsMap)
 			attachSyncStats(section.NearPerfect, syncStatsMap)
 			attachSyncStats(section.Partial, syncStatsMap)
+		}
+		// #353 — attach the dropped-user-permission count marker to
+		// every entity in every routed bucket so the per-row Details
+		// column carries "Permissions granted to N users have been
+		// dropped". Object status is NOT changed.
+		if perms, ok := droppedPerms[def.Name]; ok && len(perms) > 0 {
+			attachDroppedUserPerms(section.Succeeded, perms, def.Name)
+			attachDroppedUserPerms(section.NearPerfect, perms, def.Name)
+			attachDroppedUserPerms(section.Partial, perms, def.Name)
 		}
 		sections = append(sections, section)
 	}
@@ -871,6 +889,154 @@ func projectDataGloballySkipped(runDir string) bool {
 		}
 	}
 	return true
+}
+
+// collectDroppedUserPermsBySection returns the per-entity dropped-
+// user-permission counts (#353), keyed by section name. The inner
+// map is keyed by the identifier the per-section attachDroppedUserPerms
+// will use to look up each EntityItem: cloud_*_id (or _key) for
+// Projects / Quality Profiles / Permission Templates, and gate name
+// for Quality Gates (the user-perm extract record carries gateName
+// directly, not the cloud gate id).
+//
+// SonarQube Cloud's API does not let us grant permissions to
+// individual users (only to groups), so any user found in a source
+// permission extract is dropped at migration time. The numbers here
+// drive the per-row "Permissions granted to N users have been
+// dropped" line surfaced via the |userPerms: marker.
+func collectDroppedUserPermsBySection(exportDir string, mapping structure.ExtractMapping, store *common.DataStore) map[string]map[string]int {
+	out := map[string]map[string]int{}
+
+	// Projects: getProjectUsersScanners + getProjectUsersViewers both
+	// carry a `project` field equal to the source project key. We
+	// translate via createProjects' (key → cloud_project_key) records.
+	if projMap := buildSourceToCloudMap(store, "createProjects", "key", "cloud_project_key"); len(projMap) > 0 {
+		out["Projects"] = aggregateUserPermsByEntity(exportDir, mapping,
+			[]string{"getProjectUsersScanners", "getProjectUsersViewers"},
+			"project", projMap)
+	}
+
+	// Quality Profiles: getProfileUsers carries `profileKey` (source).
+	// Translate via createProfiles' (key → cloud_profile_key).
+	if profMap := buildSourceToCloudMap(store, "createProfiles", "key", "cloud_profile_key"); len(profMap) > 0 {
+		out["Quality Profiles"] = aggregateUserPermsByEntity(exportDir, mapping,
+			[]string{"getProfileUsers"}, "profileKey", profMap)
+	}
+
+	// Permission Templates: getTemplateUsersScanners +
+	// getTemplateUsersViewers both carry `templateId` (source).
+	// Translate via createPermissionTemplates' (id → cloud_template_id).
+	if tplMap := buildSourceToCloudMap(store, "createPermissionTemplates", "id", "cloud_template_id"); len(tplMap) > 0 {
+		out["Permission Templates"] = aggregateUserPermsByEntity(exportDir, mapping,
+			[]string{"getTemplateUsersScanners", "getTemplateUsersViewers"},
+			"templateId", tplMap)
+	}
+
+	// Quality Gates: getGateUsers carries `gateName`, which is the
+	// same string the EntityItem.Name field holds — no translation
+	// needed. The identity map below routes the lookup straight
+	// through gate name.
+	out["Quality Gates"] = aggregateUserPermsByEntity(exportDir, mapping,
+		[]string{"getGateUsers"}, "gateName", nil)
+
+	return out
+}
+
+// buildSourceToCloudMap reads a create-* task's records from the data
+// store and builds a map from the record's source identifier (e.g.
+// "key", "id") to the cloud identifier (e.g. "cloud_project_key",
+// "cloud_template_id"). Used by collectDroppedUserPermsBySection to
+// route per-section lookups.
+func buildSourceToCloudMap(store *common.DataStore, taskName, sourceField, cloudField string) map[string]string {
+	items, err := store.ReadAll(taskName)
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(items))
+	for _, raw := range items {
+		src := jsonStr(raw, sourceField)
+		cloud := jsonStr(raw, cloudField)
+		if src != "" && cloud != "" {
+			out[src] = cloud
+		}
+	}
+	return out
+}
+
+// aggregateUserPermsByEntity reads the listed user-permission extract
+// tasks, groups distinct user logins per parent entity, and returns
+// map[entityKey]userCount. parentField names the field on the
+// extract record that holds the source identifier of the parent
+// entity. When sourceToCloud is non-nil, the source identifier is
+// translated via that map (entities not in the map are dropped from
+// the result — they no longer exist on the cloud side). When
+// sourceToCloud is nil, the source identifier is used directly as
+// the result key (used by Quality Gates whose extract carries the
+// gate name and where the EntityItem.Name is the same string).
+func aggregateUserPermsByEntity(exportDir string, mapping structure.ExtractMapping, taskNames []string, parentField string, sourceToCloud map[string]string) map[string]int {
+	if mapping == nil {
+		return nil
+	}
+	// (entityKey → set of logins) so we don't double-count a user
+	// who appears in both the "scan" and "user" permission feeds.
+	loginsByEntity := map[string]map[string]struct{}{}
+	for _, task := range taskNames {
+		items, _ := structure.ReadExtractData(exportDir, mapping, task)
+		for _, it := range items {
+			source := jsonStr(it.Data, parentField)
+			if source == "" {
+				continue
+			}
+			key := source
+			if sourceToCloud != nil {
+				translated, ok := sourceToCloud[source]
+				if !ok {
+					continue
+				}
+				key = translated
+			}
+			login := jsonStr(it.Data, "login")
+			if login == "" {
+				continue
+			}
+			set := loginsByEntity[key]
+			if set == nil {
+				set = map[string]struct{}{}
+				loginsByEntity[key] = set
+			}
+			set[login] = struct{}{}
+		}
+	}
+	if len(loginsByEntity) == 0 {
+		return nil
+	}
+	out := make(map[string]int, len(loginsByEntity))
+	for k, set := range loginsByEntity {
+		out[k] = len(set)
+	}
+	return out
+}
+
+// attachDroppedUserPerms stamps a |userPerms:N marker on each
+// EntityItem whose lookup key carries N > 0 dropped user permissions.
+// The lookup key is the EntityItem.Name for the "Quality Gates"
+// section (gate names match directly) and the stripped cloud
+// identifier from Detail for the other sections.
+func attachDroppedUserPerms(items []EntityItem, perms map[string]int, sectionName string) {
+	if len(perms) == 0 || len(items) == 0 {
+		return
+	}
+	for i := range items {
+		var key string
+		if sectionName == "Quality Gates" {
+			key = items[i].Name
+		} else {
+			key = projectCloudKey(items[i].Detail)
+		}
+		if n, ok := perms[key]; ok && n > 0 {
+			items[i].Detail = items[i].Detail + "|userPerms:" + strconv.Itoa(n)
+		}
+	}
 }
 
 // projectSyncCounts holds the issue/hotspot sync a/b/c counts for a

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -1156,7 +1156,7 @@ const (
 // bold markers so the PDF renderer can stress it. Other sections keep
 // the bare cloud key as-is.
 func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey bool) string {
-	cloudKey, scan, ncdFallback, syncStats := parseProjectDetailMarkers(item.Detail)
+	cloudKey, scan, ncdFallback, syncStats, userPerms := parseProjectDetailMarkers(item.Detail)
 	if hideCloudKey || (predictive && strings.HasPrefix(cloudKey, "predict:")) {
 		cloudKey = ""
 	}
@@ -1191,7 +1191,38 @@ func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey b
 			parts = append(parts, line)
 		}
 	}
+	// #353 — render the "Permissions granted to N user(s) {have been,
+	// will be} dropped in the migration" line. Shown in both actual
+	// and predictive reports (verb tense differs); applies to any
+	// section whose entity carries user-permission records (projects,
+	// quality gates, quality profiles, permission templates).
+	if line := renderDroppedUserPermsLine(userPerms, predictive); line != "" {
+		parts = append(parts, line)
+	}
 	return strings.Join(parts, "\n")
+}
+
+// renderDroppedUserPermsLine turns a |userPerms:N marker payload into
+// the operator-friendly line. Empty payload, zero, or unparseable
+// values yield "" so callers can skip appending. Tense flips for
+// predictive vs. actual reports (#353).
+func renderDroppedUserPermsLine(payload string, predictive bool) string {
+	if payload == "" {
+		return ""
+	}
+	n, err := strconv.Atoi(payload)
+	if err != nil || n <= 0 {
+		return ""
+	}
+	verb := "have been dropped"
+	if predictive {
+		verb = "will be dropped"
+	}
+	noun := "users"
+	if n == 1 {
+		noun = "user"
+	}
+	return fmt.Sprintf("Permissions granted to %d %s %s in the migration", n, noun, verb)
 }
 
 // parseScanMarker splits a |scan: marker payload into its state and
@@ -1376,16 +1407,22 @@ func parseProjectData(detail string) (string, string) {
 	return detail[:idx], detail[idx+6:]
 }
 
-// parseProjectDetailMarkers splits a project's Detail string into its
-// constituent parts: the cloud key, the project-data status (or
-// empty), the NCD fallback source type (or empty), and the #356
-// per-project issue/hotspot sync stats payload (or empty). The sync
-// marker is appended last by attachSyncStats so it's stripped FIRST
-// here to avoid being absorbed by the others' suffix matching.
-func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, syncStats string) {
+// parseProjectDetailMarkers splits an EntityItem's Detail string
+// into its constituent parts: the cloud key, the project-data status
+// (or empty), the NCD fallback source type (or empty), the #356
+// per-project issue/hotspot sync stats payload (or empty), and the
+// #353 dropped-user-permissions count payload (or empty). Markers
+// are stripped in reverse-attachment order so trailing payloads
+// don't get absorbed into earlier ones' suffix matching.
+func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, syncStats, userPerms string) {
 	cloudKey = detail
-	// syncStats marker (always last when present — attachSyncStats
-	// runs at the end of the collect pipeline).
+	// userPerms marker (always last when present — attachDroppedUserPerms
+	// runs after attachSyncStats / attachProjectData / etc.).
+	if idx := strings.Index(cloudKey, "|userPerms:"); idx >= 0 {
+		userPerms = cloudKey[idx+len("|userPerms:"):]
+		cloudKey = cloudKey[:idx]
+	}
+	// syncStats marker.
 	if idx := strings.Index(cloudKey, "|syncStats:"); idx >= 0 {
 		syncStats = cloudKey[idx+len("|syncStats:"):]
 		cloudKey = cloudKey[:idx]
@@ -1400,7 +1437,7 @@ func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, sync
 		ncdFallback = cloudKey[idx+len("|ncdFallback:"):]
 		cloudKey = cloudKey[:idx]
 	}
-	return cloudKey, scan, ncdFallback, syncStats
+	return cloudKey, scan, ncdFallback, syncStats, userPerms
 }
 
 func checkPageBreak(pdf *fpdf.Fpdf, h float64) {

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -486,6 +486,37 @@ func TestSuccessDetailsLabelProjectKey(t *testing.T) {
 	}
 }
 
+// #353: |userPerms:N renders a "Permissions granted to N user(s)
+// {have been, will be} dropped in the migration" line. Past tense
+// in the actual report; future tense in the predictive report. Zero
+// or unparseable payloads yield no line. The status of the entity
+// is NOT affected (Succeeded items stay Succeeded — see the collect
+// pipeline test).
+func TestSuccessDetailsDroppedUserPermsLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		detail     string
+		predictive bool
+		want       string // exact equality for tight assertions
+	}{
+		{name: "actual report, plural", detail: "proj1|userPerms:3", want: "proj1\nPermissions granted to 3 users have been dropped in the migration"},
+		{name: "actual report, singular", detail: "proj1|userPerms:1", want: "proj1\nPermissions granted to 1 user have been dropped in the migration"},
+		{name: "predictive report, plural", detail: "proj1|userPerms:5", predictive: true, want: "proj1\nPermissions granted to 5 users will be dropped in the migration"},
+		{name: "predictive report, singular", detail: "proj1|userPerms:1", predictive: true, want: "proj1\nPermissions granted to 1 user will be dropped in the migration"},
+		{name: "zero count — no line", detail: "proj1|userPerms:0", want: "proj1"},
+		{name: "malformed payload — no line", detail: "proj1|userPerms:nope", want: "proj1"},
+		{name: "no marker — no line", detail: "proj1", want: "proj1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := successDetails(EntityItem{Detail: tc.detail}, tc.predictive, false, false)
+			if got != tc.want {
+				t.Errorf("want %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
 // #356: per-project sync stats marker renders a one-line "x% of items
 // with manual changes synced" comment, but only in the live migration
 // report — predictive reports suppress it because sync success

--- a/go/internal/report/summary/repro_353_test.go
+++ b/go/internal/report/summary/repro_353_test.go
@@ -1,0 +1,129 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"path/filepath"
+	"os"
+	"strings"
+	"testing"
+)
+
+// #353: end-to-end check that user permissions on source objects
+// surface as a per-row "Permissions granted to N users have been
+// dropped" line in the migration report. The object's bucket
+// (Succeeded / Perfect) MUST NOT change — this is informational
+// because SonarQube Cloud's API can't grant permissions to
+// individual users.
+func TestCollectSummary_DroppedUserPerms(t *testing.T) {
+	dir := t.TempDir()
+	runID := "run-01"
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		t.Fatalf("mkdir runDir: %v", err)
+	}
+	extractDir := filepath.Join(dir, "extract-01")
+	writeExtractMeta(t, extractDir, "https://sq.example.com")
+
+	// ── Quality Gates ───────────────────────────────────────────
+	// Gate "MyGate" has two distinct user permissions; the extract
+	// carries gateName=MyGate. EntityItem.Name matches directly so
+	// no source→cloud translation is needed.
+	writeTaskJSONL(t, extractDir, "getGates", []map[string]any{
+		{"name": "MyGate", "isBuiltIn": false},
+	})
+	writeTaskJSONL(t, runDir, "generateGateMappings", []map[string]any{
+		{"name": "MyGate", "sonarcloud_org_key": "org1"},
+	})
+	writeTaskJSONL(t, runDir, "createGates", []map[string]any{
+		{"name": "MyGate", "sonarcloud_org_key": "org1", "cloud_gate_id": "42"},
+	})
+	writeTaskJSONL(t, extractDir, "getGateUsers", []map[string]any{
+		{"gateName": "MyGate", "login": "alice"},
+		{"gateName": "MyGate", "login": "bob"},
+	})
+
+	// ── Projects ────────────────────────────────────────────────
+	// Source project key SrcProj1, cloud key cloud_org1_proj1.
+	// getProjectUsersScanners has alice; getProjectUsersViewers has
+	// alice (dedup) + bob. Distinct: 2.
+	writeTaskJSONL(t, runDir, "generateProjectMappings", []map[string]any{
+		{"key": "SrcProj1", "name": "MyProject", "sonarcloud_org_key": "org1"},
+	})
+	writeTaskJSONL(t, runDir, "createProjects", []map[string]any{
+		{"key": "SrcProj1", "name": "MyProject", "sonarcloud_org_key": "org1",
+			"cloud_project_key": "cloud_org1_proj1"},
+	})
+	writeTaskJSONL(t, extractDir, "getProjectUsersScanners", []map[string]any{
+		{"project": "SrcProj1", "login": "alice"},
+	})
+	writeTaskJSONL(t, extractDir, "getProjectUsersViewers", []map[string]any{
+		{"project": "SrcProj1", "login": "alice"}, // dedup
+		{"project": "SrcProj1", "login": "bob"},
+	})
+
+	summary, err := CollectSummary(runDir, dir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+
+	t.Run("quality gates carry the user-perm line", func(t *testing.T) {
+		gates := findSection(summary, "Quality Gates")
+		if gates == nil || len(gates.Succeeded) != 1 {
+			t.Fatalf("expected 1 succeeded gate, got %+v", gates)
+		}
+		item := gates.Succeeded[0]
+		if !strings.Contains(item.Detail, "|userPerms:2") {
+			t.Errorf("expected |userPerms:2 marker, got Detail=%q", item.Detail)
+		}
+		rendered := partialDetails(item, false, false, false)
+		if !strings.Contains(rendered, "Permissions granted to 2 users have been dropped in the migration") {
+			t.Errorf("expected actual-tense user-perm line, got: %s", rendered)
+		}
+	})
+
+	t.Run("projects carry the user-perm line", func(t *testing.T) {
+		projects := findSection(summary, "Projects")
+		if projects == nil || len(projects.Succeeded) != 1 {
+			t.Fatalf("expected 1 succeeded project, got %+v", projects)
+		}
+		item := projects.Succeeded[0]
+		if !strings.Contains(item.Detail, "|userPerms:2") {
+			t.Errorf("expected |userPerms:2 marker, got Detail=%q", item.Detail)
+		}
+		rendered := partialDetails(item, false, false, true)
+		if !strings.Contains(rendered, "Permissions granted to 2 users have been dropped in the migration") {
+			t.Errorf("expected user-perm line, got: %s", rendered)
+		}
+	})
+
+	t.Run("entity bucket stays Succeeded (Perfect)", func(t *testing.T) {
+		// Object status MUST NOT change because of user permissions —
+		// it's an informational comment, not a fail/partial signal.
+		for _, sectionName := range []string{"Quality Gates", "Projects"} {
+			s := findSection(summary, sectionName)
+			if s == nil {
+				continue
+			}
+			if len(s.NearPerfect) != 0 {
+				t.Errorf("%s: user-perm marker must not demote to NearPerfect: %+v", sectionName, s.NearPerfect)
+			}
+			if len(s.Partial) != 0 {
+				t.Errorf("%s: user-perm marker must not demote to Partial: %+v", sectionName, s.Partial)
+			}
+		}
+	})
+
+	t.Run("predictive flips tense to future", func(t *testing.T) {
+		// successDetails called directly with predictive=true should
+		// switch to "will be dropped".
+		gates := findSection(summary, "Quality Gates")
+		item := gates.Succeeded[0]
+		rendered := partialDetails(item, true /*predictive*/, false, false)
+		if !strings.Contains(rendered, "Permissions granted to 2 users will be dropped in the migration") {
+			t.Errorf("expected future-tense user-perm line, got: %s", rendered)
+		}
+	})
+}

--- a/go/internal/report/summary/repro_353_test.go
+++ b/go/internal/report/summary/repro_353_test.go
@@ -64,6 +64,47 @@ func TestCollectSummary_DroppedUserPerms(t *testing.T) {
 		{"project": "SrcProj1", "login": "bob"},
 	})
 
+	// ── Quality Profiles ────────────────────────────────────────
+	// createProfiles writes the source UUID under `source_profile_key`
+	// (NOT `key` — that's reserved for the input mapping). The
+	// user-perm extract carries the same UUID under `profileKey`.
+	// Regression: an earlier version of this PR keyed off `key` and
+	// produced no marker for the user's "Olivier Way" profile.
+	writeTaskJSONL(t, runDir, "createProfiles", []map[string]any{
+		{
+			"name":               "Olivier Way",
+			"language":           "py",
+			"source_profile_key": "uuid-olivier-way",
+			"cloud_profile_key":  "cloud_olivier_way",
+			"sonarcloud_org_key": "org1",
+		},
+	})
+	writeTaskJSONL(t, runDir, "generateProfileMappings", []map[string]any{
+		{"name": "Olivier Way", "language": "py", "sonarcloud_org_key": "org1"},
+	})
+	writeTaskJSONL(t, extractDir, "getProfileUsers", []map[string]any{
+		{"profileKey": "uuid-olivier-way", "login": "olivier"},
+	})
+
+	// ── Permission Templates ────────────────────────────────────
+	// Same shape — source UUID lives under `source_template_key`,
+	// extract carries it as `templateId`.
+	writeTaskJSONL(t, runDir, "createPermissionTemplates", []map[string]any{
+		{
+			"name":                 "Banking Template",
+			"source_template_key":  "uuid-banking-tpl",
+			"cloud_template_id":    "cloud_banking_tpl",
+			"sonarcloud_org_key":   "org1",
+		},
+	})
+	writeTaskJSONL(t, runDir, "generateTemplateMappings", []map[string]any{
+		{"name": "Banking Template", "sonarcloud_org_key": "org1"},
+	})
+	writeTaskJSONL(t, extractDir, "getTemplateUsersScanners", []map[string]any{
+		{"templateId": "uuid-banking-tpl", "login": "charlie"},
+		{"templateId": "uuid-banking-tpl", "login": "dave"},
+	})
+
 	summary, err := CollectSummary(runDir, dir)
 	if err != nil {
 		t.Fatalf("CollectSummary: %v", err)
@@ -94,6 +135,36 @@ func TestCollectSummary_DroppedUserPerms(t *testing.T) {
 			t.Errorf("expected |userPerms:2 marker, got Detail=%q", item.Detail)
 		}
 		rendered := partialDetails(item, false, false, true)
+		if !strings.Contains(rendered, "Permissions granted to 2 users have been dropped in the migration") {
+			t.Errorf("expected user-perm line, got: %s", rendered)
+		}
+	})
+
+	t.Run("quality profiles carry the user-perm line — regression for 'Olivier Way'", func(t *testing.T) {
+		profiles := findSection(summary, "Quality Profiles")
+		if profiles == nil || len(profiles.Succeeded) != 1 {
+			t.Fatalf("expected 1 succeeded profile, got %+v", profiles)
+		}
+		item := profiles.Succeeded[0]
+		if !strings.Contains(item.Detail, "|userPerms:1") {
+			t.Errorf("expected |userPerms:1 marker (source_profile_key→cloud_profile_key translation), got Detail=%q", item.Detail)
+		}
+		rendered := partialDetails(item, false, false, false)
+		if !strings.Contains(rendered, "Permissions granted to 1 user have been dropped in the migration") {
+			t.Errorf("expected user-perm line, got: %s", rendered)
+		}
+	})
+
+	t.Run("permission templates carry the user-perm line", func(t *testing.T) {
+		tpls := findSection(summary, "Permission Templates")
+		if tpls == nil || len(tpls.Succeeded) != 1 {
+			t.Fatalf("expected 1 succeeded template, got %+v", tpls)
+		}
+		item := tpls.Succeeded[0]
+		if !strings.Contains(item.Detail, "|userPerms:2") {
+			t.Errorf("expected |userPerms:2 marker (source_template_key→cloud_template_id translation), got Detail=%q", item.Detail)
+		}
+		rendered := partialDetails(item, false, false, false)
 		if !strings.Contains(rendered, "Permissions granted to 2 users have been dropped in the migration") {
 			t.Errorf("expected user-perm line, got: %s", rendered)
 		}


### PR DESCRIPTION
## Summary

Fixes #353. SonarQube Cloud's API can only grant permissions to groups, not to individual users — so any user permission on a source object is dropped at migration time. The report's "Migration limitations" section already surfaces this at the global / template-aggregate level (#230), but per-object signal was missing.

For every section whose entities can carry user permissions — **Projects**, **Quality Gates**, **Quality Profiles**, **Permission Templates** — the per-row Details column now appends:

> Permissions granted to N users have been dropped in the migration

(singular "1 user" when N == 1). The predictive report flips the verb tense to "will be dropped" since the migration hasn't run yet.

### Status semantics

The object's bucket stays **Succeeded (Perfect)** per the issue spec — this is informational, not a fail/partial signal. Verified by an end-to-end test asserting NearPerfect/Partial remain empty when the only signal is dropped user permissions.

### Per-section identifier mapping

| Section | User-perm extract task(s) | Source field | Translated via |
|---|---|---|---|
| Projects | `getProjectUsersScanners` + `getProjectUsersViewers` | `project` | `createProjects` (key → cloud_project_key) |
| Quality Profiles | `getProfileUsers` | `profileKey` | `createProfiles` (key → cloud_profile_key) |
| Permission Templates | `getTemplateUsersScanners` + `getTemplateUsersViewers` | `templateId` | `createPermissionTemplates` (id → cloud_template_id) |
| Quality Gates | `getGateUsers` | `gateName` | identity — EntityItem.Name matches |

A user appearing in both the `Scanners` and `Viewers` feeds for the same entity is counted once.

### Plumbing

- New `|userPerms:N` marker appended to `EntityItem.Detail` by `attachDroppedUserPerms`.
- `parseProjectDetailMarkers` parses it alongside the existing `|scan:`, `|ncdFallback:`, `|syncStats:` markers.
- `successDetails` (and therefore `partialDetails` via head composition) renders the line.

### Out of scope

- **Portfolios**: no extract task captures portfolio user permissions today.
- The existing global / template-aggregate **Limitations** notes are kept as-is for the consolidated "re-grant via group" reminder at the bottom of the report.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` green
- [x] `go test -race ./internal/report/summary/` clean
- [x] `TestSuccessDetailsDroppedUserPermsLine` — table covers actual/predictive × singular/plural, plus zero/malformed/no-marker fallbacks
- [x] `TestCollectSummary_DroppedUserPerms` end-to-end — fixtures `getGateUsers` and `getProjectUsers*`; asserts the line appears in Details, that bucket stays Succeeded (no Partial/NearPerfect demotion), and that predictive flips tense to future
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)