### PR TITLE
Fix issue status mapping for ACCEPTED and FIXED resolutions in migration logic (#322)

### DIFF
--- a/docs/MIGRATION-FACETS-AUDIT.md
+++ b/docs/MIGRATION-FACETS-AUDIT.md
@@ -43,7 +43,7 @@ Adversarial verification of every claim in [MIGRATION-FACETS.md](MIGRATION-FACET
 ---
 
 ## ⚠️ PARTIALLY_CONFIRMED — core true, details overstated/wrong (22)
-<!-- updated: 2026-06-05_21:03:00 -->
+<!-- updated: 2026-06-08_23:04:10 -->
 
 | Claim | Accurate part | Inaccurate / overstated part |
 |---|---|---|
@@ -59,7 +59,7 @@ Adversarial verification of every claim in [MIGRATION-FACETS.md](MIGRATION-FACET
 | **Active Rules** | repo, key, severity, q-profile key migrate (+ key remapped) | **impacts, params, timestamps NOT migrated** — params always empty map, timestamps fall back to migration run-time |
 | **External Issues** | all 6 fields migrate via protobuf — accurate | Filename wrong: code writes **`external-issues-{ref}.pb`** (hyphen), not `externalissues-{ref}.pb` |
 | **Ad-Hoc Rules** | 6 fields encoded correctly | **name** = rule key (not display name); **description** = generated literal `"Rule from {engine} plugin"`, not source description |
-| **Issue Status** | mechanism + 5 states map correctly | **FIXED excluded** entirely from sync (`tasks_issuesync.go:536`); **ACCEPTED maps to `wontfix`** → lands as WONTFIX on Cloud, not ACCEPTED |
+| **Issue Status** | mechanism + states map correctly; **ACCEPTED now maps to the `accept` transition** → lands as ACCEPTED on Cloud (fixed in #322) | **FIXED is intentionally excluded** from sync (`tasks_issuesync.go` `loadMatchableIssues`) — a fixed issue's code no longer exists, so the freshly-built scanner report's CE re-analysis won't reproduce it and there is no Cloud counterpart to transition. This is correct/by-design, not a bug. |
 | **Issue Comments** | text, author, timestamp, `add_comment` mechanism | Prefix is **`[Migrated from {login} on {date}]`**, not `[Migrated from SonarQube Server - @author]`; dedup is **substring match, not hash-deduped** |
 | **Hotspot Review Status** | SAFE/FIXED sync correctly | **ACKNOWLEDGED silently downgraded to SAFE** (`tasks_hotspotsync.go:135`) |
 | **Branches** | main + non-main **LONG** migrate (main-first), issues/source/SCM/ref-branch/analysis handshake | **SHORT skipped, PULL_REQUEST never submitted** (all forced to LONG); **measures empty**; per-branch **NCD skipped**; SCM author/revision stubbed |
@@ -101,11 +101,11 @@ Adversarial verification of every claim in [MIGRATION-FACETS.md](MIGRATION-FACET
 4. **Stub SCM identity.** Only issue *dates* are real; per-line *revision* and *author* are synthetic stubs.
 
 ## Recommended doc fixes (priority order)
-<!-- updated: 2026-06-05_21:03:00 -->
+<!-- updated: 2026-06-08_23:04:10 -->
 
 1. **Move to NOT-MIGRATED / GAP:** Measures, Duplications, Issue Assignments, User Mapping, Groups *membership*.
 2. **Move to IS-MIGRATED:** Webhooks (auto-recreated; note secret caveat); Per-issue severity overrides (via `overriddenSeverity`).
 3. **Correct mechanisms:** New Code Periods → `/api/settings/set` (not `new_code_periods/set`); External Issues filename → `external-issues-{ref}.pb`; Source language/lines → `component-{ref}.pb`.
 4. **Add field-level caveats:** Issues (native field coverage), Active Rules (no params/impacts/timestamps), Branches (LONG-only, no measures), Permissions/Templates (group-only), Portfolios (flattened), Projects (visibility forced private, key prefixed).
-5. **Fix status fidelity notes:** FIXED not synced, ACCEPTED→WONTFIX, hotspot ACKNOWLEDGED→SAFE.
+5. **Status fidelity notes:** FIXED intentionally not synced (no Cloud counterpart — by design); ACCEPTED→accept (lands as ACCEPTED, fixed in #322); hotspot ACKNOWLEDGED→SAFE (still a real gap, tracked separately).
 6. **Fix the two self-contradictions** (Assignments, severity overrides).

--- a/docs/MIGRATION-FACETS.md
+++ b/docs/MIGRATION-FACETS.md
@@ -4,6 +4,7 @@
 > **Reconciled against the actual Go code on 2026-06-05.** Every row below reflects what the running binary does (`go/`, `lib/sq-api-go/`), not spec/design intent. Claims that previously described unbuilt specs or dead code have been corrected or moved. Full claim-by-claim evidence (file:line) is in [MIGRATION-FACETS-AUDIT.md](MIGRATION-FACETS-AUDIT.md).
 
 ## ✅ What IS Migrated
+<!-- updated: 2026-06-08_23:03:54 -->
 
 The **Caveats / NOT carried** column is load-bearing — read it before relying on a row.
 
@@ -25,7 +26,7 @@ The **Caveats / NOT carried** column is load-bearing — read it before relying 
 | **Analysis Data** | Active Rules | repo, key, severity, q-profile key (remapped SQ→Cloud) | **params, impacts, and timestamps are NOT migrated** on this path — params default to empty, timestamps fall back to the migration run-time | Protobuf `activerules.pb` | 001 |
 | **Analysis Data** | External Issues (3rd-party analyzers) | engineId, ruleId, message, severity, type, textRange | filename is **`external-issues-{ref}.pb`** (hyphenated) | Protobuf `external-issues-{ref}.pb` | 013 |
 | **Analysis Data** | Ad-Hoc Rules | engineId, ruleId, severity, type, cleanCodeAttribute | **`name` = rule key** (not a display name); **`description` = generic placeholder** `"Rule from {engine} plugin"`, not the source rule description | Protobuf `adhocrules.pb` | 013 |
-| **Metadata Sync** | Issue Status | OPEN, CONFIRMED, REOPENED, RESOLVED, FALSE_POSITIVE, WONTFIX | **`FIXED` is excluded** from sync entirely; **`ACCEPTED` is mapped to the `wontfix` transition** → lands as WONTFIX on Cloud, not ACCEPTED | `/api/issues/do_transition` | 008/024 |
+| **Metadata Sync** | Issue Status | OPEN, CONFIRMED, REOPENED, RESOLVED, FALSE_POSITIVE, WONTFIX, **ACCEPTED** | **`ACCEPTED` maps to the `accept` transition** → lands as ACCEPTED on Cloud (fixed in #322); modern MQR `ACCEPTED` (surfaced over the Server API as status=RESOLVED, resolution=WONTFIX) is detected via the `issueStatus` enum and routed to `accept`, while genuine legacy `WONTFIX` still maps to `wontfix`. **`FIXED`-resolution issues are intentionally excluded** — the fixed code no longer exists, so CE re-analysis of the migrated scanner report won't reproduce them (no Cloud counterpart to transition) | `/api/issues/do_transition` | 008/024 |
 | **Metadata Sync** | Issue Comments | text (Markdown, HTML fallback) + original author + timestamp | prefix is **`[Migrated from {login} on {date}]`** (no literal "SonarQube Server", no `@`); dedup is **plain substring match, not hashing** | `/api/issues/add_comment` | 008/024 |
 | **Metadata Sync** | Issue Tags | all custom tags | — (fully accurate) | `/api/issues/set_tags` | 008/024 |
 | **Metadata Sync** | Hotspot Review Status | TO_REVIEW / REVIEWED + resolution SAFE / FIXED | **`ACKNOWLEDGED` is silently downgraded to `SAFE`**; TO_REVIEW makes no API call (Cloud default) | `/api/hotspots/change_status` | 009/024 |
@@ -36,6 +37,7 @@ The **Caveats / NOT carried** column is load-bearing — read it before relying 
 | **Config** | Webhooks | project + global/server webhooks auto-recreated on Cloud (global fanned out to every migrated org); list-then-create idempotency | **webhook secret is NOT carried** (source API doesn't expose it) — migrated webhooks land unsecured; global fan-out runs on the `migrate` path only (`transfer` recreates project webhooks only) | `/api/webhooks/create` | — |
 
 ## ❌ What is NOT Migrated
+<!-- updated: 2026-06-08_23:03:54 -->
 
 | Entity / Data | Reason | Notes |
 |---|---|---|
@@ -56,9 +58,11 @@ The **Caveats / NOT carried** column is load-bearing — read it before relying 
 | CI/CD pipeline configuration | Tool can't modify external systems | `SONAR_HOST_URL` / `SONAR_TOKEN` must be updated manually |
 | `IN_SANDBOX` issue status (SQ 2025.1+) | No SonarCloud equivalent | **Omitted from the extraction query** on the live path (no warning emitted; the warn-and-skip code is in the unused `pipeline` package) |
 | Closed issues (sync phase) | May not exist in Cloud after re-analysis | Skipped at the source-load stage, before status sync |
+| FIXED-resolution issues (sync phase) | The fixed code no longer exists, so the migrated scanner report's CE re-analysis does not reproduce them — no Cloud counterpart | Intentionally skipped at the source-load stage (`loadMatchableIssues`), before status sync; by design, not a bug |
 | Symbols / syntax-highlighting reference data | Lower-priority, optional (SPEC-004 FR-12/FR-13) | Endpoints never called; proto types unused |
 
 ## ⚠️ Known Gaps (real bugs / partial fidelity, verified in code)
+<!-- updated: 2026-06-08_23:03:54 -->
 
 | Item | Status | Spec |
 |---|---|---|
@@ -66,7 +70,6 @@ The **Caveats / NOT carried** column is load-bearing — read it before relying 
 | **BUG-05** — issue **assignee** extracted but the assign call is never invoked (no Cloud assign API) | Real | 010 |
 | **BUG-06** — no source-link / back-reference comment to the original Server issue/hotspot is added | Real | 008/009 |
 | Hotspot resolution **ACKNOWLEDGED** is downgraded to SAFE on Cloud | Real | 009 |
-| Issue status **FIXED** excluded from sync; **ACCEPTED** lands as WONTFIX | Real | 008 |
 | External rule **descriptions** use a generic placeholder rather than rule-specific text | Real | 013 |
 | SCM **author/revision** are stub values (only dates are real) | Real | 004 |
 | Symbols / syntax-highlighting reference data | Optional, not implemented | 004 |

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -57,6 +57,20 @@ func issueMetadataSyncTasks() []TaskDef {
 // getProjectIssuesFull extract's branch enrichment) and left empty for
 // Cloud-side candidates. Used at sync time to log a per-project
 // branch count so operators can see the project's shape.
+//
+// IssueStatus mirrors the modern unified `issueStatus` enum
+// (SonarQube 10.4+ / MQR model: OPEN, CONFIRMED, FALSE_POSITIVE,
+// ACCEPTED, FIXED). It is the authoritative triage signal and the only
+// field that distinguishes an ACCEPTED issue from a legacy Won't Fix —
+// an accepted issue reports status=RESOLVED, resolution=WONTFIX,
+// issueStatus=ACCEPTED. Populated for source-side issues; left empty
+// for Cloud candidates (the search response is consulted via
+// Transitions instead). See #322.
+//
+// Transitions is the Cloud issue's available-transition list (from
+// /api/issues/search?additionalFields=transitions). Populated only for
+// Cloud-side candidates; used to verify the "accept" transition is
+// offered before applying it (#322). Empty for source-side issues.
 type matchableIssue struct {
 	Key            string
 	Rule           string
@@ -64,11 +78,13 @@ type matchableIssue struct {
 	Line           int
 	Status         string
 	Resolution     string
+	IssueStatus    string
 	Tags           []string
 	Comments       []issueComment
 	Assignee       string
 	ManualSeverity bool
 	Branch         string
+	Transitions    []string
 }
 
 // issueComment is a normalised comment attached to a matchableIssue.
@@ -105,16 +121,57 @@ func stripProjectKeyPrefix(component string) string {
 // Transition logic
 // ---------------------------------------------------------------------------
 
-// getFallbackTransition maps an SQS issue's resolution and status to the
-// Cloud transition name required to move the Cloud issue into an equivalent
-// state.
+// acceptTransition is the MQR-model transition that moves a Cloud issue
+// into the ACCEPTED state. It supersedes the deprecated "wontfix"
+// transition: applying "wontfix" lands the issue as Won't Fix, which the
+// modern issue lifecycle surfaces differently from Accepted. SonarCloud
+// is always the migration target and exposes "accept" (per SPEC-008), so
+// accepted / won't-fix source issues map here. See issue #322.
+const acceptTransition = "accept"
+
+// getFallbackTransition maps an SQS issue to the Cloud transition name
+// required to move the Cloud issue into the equivalent state.
 //
-// Resolution takes priority (it is the most specific signal). When the
-// resolution is empty or unrecognised, we fall back to the status field.
+// Precedence — most authoritative first:
+//  1. issueStatus: the modern unified enum (SonarQube 10.4+ / MQR
+//     model). It is the ONLY field that distinguishes ACCEPTED from a
+//     legacy Won't Fix — an accepted issue reports status=RESOLVED,
+//     resolution=WONTFIX, issueStatus=ACCEPTED. The previous code
+//     checked resolution first and so mapped every ACCEPTED issue to
+//     "wontfix", landing it as Won't Fix on Cloud (issue #322). Reading
+//     issueStatus first fixes that.
+//  2. resolution: legacy signal for pre-10.4 servers that emit no
+//     issueStatus.
+//  3. status: final legacy fallback.
+//
+// Accepted / won't-fix issues resolve to acceptTransition; availability
+// of that transition on the specific Cloud issue is verified separately
+// by resolveTransition, which leaves the issue OPEN (rather than
+// mislabeling it) when "accept" is not offered.
 //
 // Returns "" when no transition is needed (e.g. OPEN issues).
-func getFallbackTransition(resolution, status string) string {
-	// Resolution-based priority — most specific.
+func getFallbackTransition(issueStatus, resolution, status string) string {
+	// 1. Modern unified issueStatus enum — most authoritative.
+	switch strings.ToUpper(issueStatus) {
+	case "ACCEPTED":
+		return acceptTransition
+	case "FALSE_POSITIVE":
+		return "falsepositive"
+	case "CONFIRMED":
+		return "confirm"
+	case "OPEN", "FIXED":
+		// OPEN needs no transition; FIXED issues are excluded at load
+		// time (no Cloud counterpart) and should not reach here.
+		return ""
+	}
+
+	// 2. Legacy resolution-based priority (pre-10.4 servers that emit no
+	// issueStatus). A genuine legacy WONTFIX keeps mapping to the
+	// deprecated-but-still-accepted "wontfix" transition, per SPEC-008,
+	// to avoid regressing pre-10.4 migrations. Only the MODERN
+	// issueStatus=ACCEPTED case (handled above) routes to "accept";
+	// modern accepted issues never reach here because issueStatus is
+	// checked first.
 	switch strings.ToUpper(resolution) {
 	case "FALSE-POSITIVE":
 		return "falsepositive"
@@ -122,7 +179,7 @@ func getFallbackTransition(resolution, status string) string {
 		return "wontfix"
 	}
 
-	// Status-based fallback.
+	// 3. Legacy status-based fallback.
 	switch strings.ToUpper(status) {
 	case "CONFIRMED":
 		return "confirm"
@@ -133,7 +190,7 @@ func getFallbackTransition(resolution, status string) string {
 	case "RESOLVED", "CLOSED":
 		return "resolve"
 	case "ACCEPTED":
-		return "wontfix"
+		return acceptTransition
 	case "FALSE_POSITIVE":
 		return "falsepositive"
 	case "IN_SANDBOX":
@@ -141,6 +198,27 @@ func getFallbackTransition(resolution, status string) string {
 	default:
 		return ""
 	}
+}
+
+// resolveTransition decides the Cloud transition to apply for a source
+// issue, gating the MQR "accept" transition on its availability on the
+// matched Cloud issue.
+//
+// cloudTransitions is the matched Cloud issue's available-transition
+// list (from /api/issues/search?additionalFields=transitions). A
+// non-empty list that does NOT contain "accept" means the Cloud issue
+// cannot be accepted from its current state. Rather than downgrade to
+// "wontfix" — which would mislabel the issue as Won't Fix — we leave it
+// OPEN (return "") and report downgraded=true so the caller can log the
+// fidelity loss (issue #322). An empty/unknown list is treated
+// optimistically: we still attempt "accept" and let do_transition +
+// isExpectedTransitionError absorb a rejection.
+func resolveTransition(src matchableIssue, cloudTransitions []string) (transition string, downgraded bool) {
+	desired := getFallbackTransition(src.IssueStatus, src.Resolution, src.Status)
+	if desired == acceptTransition && len(cloudTransitions) > 0 && !slices.Contains(cloudTransitions, acceptTransition) {
+		return "", true
+	}
+	return desired, false
 }
 
 // ---------------------------------------------------------------------------
@@ -172,6 +250,14 @@ const metadataSyncTag = "metadata-synchronized"
 func hasManualChanges(iss matchableIssue) bool {
 	status := strings.ToUpper(iss.Status)
 	resolution := strings.ToUpper(iss.Resolution)
+	issueStatus := strings.ToUpper(iss.IssueStatus)
+	// Modern unified issueStatus enum (10.4+) is the authoritative
+	// triage signal: an accepted issue can report status=RESOLVED (or
+	// OPEN) with the triage state living only in issueStatus, so check
+	// it directly rather than relying on the legacy fields (#322).
+	if issueStatus == "ACCEPTED" || issueStatus == "FALSE_POSITIVE" {
+		return true
+	}
 	if status == "ACCEPTED" || status == "FALSE_POSITIVE" {
 		return true
 	}
@@ -208,7 +294,9 @@ func classifyActionableReasons(actionable []matchableIssue) actionableReasonBrea
 	for _, iss := range actionable {
 		status := strings.ToUpper(iss.Status)
 		resolution := strings.ToUpper(iss.Resolution)
-		if status == "ACCEPTED" || status == "FALSE_POSITIVE" ||
+		issueStatus := strings.ToUpper(iss.IssueStatus)
+		if issueStatus == "ACCEPTED" || issueStatus == "FALSE_POSITIVE" ||
+			status == "ACCEPTED" || status == "FALSE_POSITIVE" ||
 			resolution == "FALSE-POSITIVE" || resolution == "WONTFIX" {
 			b.acceptedOrFP++
 		}
@@ -531,6 +619,9 @@ func findCloudIssueCandidates(ctx context.Context, e *Executor, cloudKey, orgKey
 	// run (the cloud counterpart may be in ACCEPTED / FALSE_POSITIVE
 	// state already).
 	params.Set("issueStatuses", "OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED")
+	// Ask for the per-issue available-transition list so we can verify
+	// the "accept" transition is offered before applying it (#322).
+	params.Set("additionalFields", "transitions")
 	apiIssues, err := e.Cloud.Issues.SearchAll(ctx, params)
 	if err != nil {
 		return nil, err
@@ -558,7 +649,7 @@ func syncOnePair(ctx context.Context, e *Executor, pair issuePair, counter *Task
 	}
 
 	cloudKey := pair.cloud.Key
-	transFailed := syncIssueTransition(ctx, e, cloudKey, pair.source)
+	transFailed := syncIssueTransition(ctx, e, cloudKey, pair.source, pair.cloud.Transitions)
 	commentFailed := syncIssueComments(ctx, e, cloudKey, pair.source.Comments, pair.cloud.Comments)
 	tagsFailed := syncIssueTags(ctx, e, cloudKey, pair.source.Tags)
 
@@ -569,10 +660,22 @@ func syncOnePair(ctx context.Context, e *Executor, pair issuePair, counter *Task
 	}
 }
 
-// syncIssueTransition applies the fallback status transition on the Cloud issue.
+// syncIssueTransition applies the status transition on the Cloud issue.
+// cloudTransitions is the matched Cloud issue's available-transition list,
+// used to gate the "accept" transition (see resolveTransition).
 // Returns true if the transition failed with an unexpected error.
-func syncIssueTransition(ctx context.Context, e *Executor, cloudKey string, src matchableIssue) bool {
-	transition := getFallbackTransition(src.Resolution, src.Status)
+func syncIssueTransition(ctx context.Context, e *Executor, cloudKey string, src matchableIssue, cloudTransitions []string) bool {
+	transition, downgraded := resolveTransition(src, cloudTransitions)
+	if downgraded {
+		// Fidelity loss surfaced explicitly per #322: the source issue
+		// is ACCEPTED but the Cloud issue cannot take "accept", so we
+		// leave it OPEN rather than mislabeling it as Won't Fix.
+		e.Logger.Warn("syncIssueMetadata: 'accept' transition unavailable on Cloud issue; leaving it OPEN rather than mislabeling it Won't Fix",
+			"issue", cloudKey,
+			"source_issue_status", src.IssueStatus,
+			"source_resolution", src.Resolution,
+			"available_transitions", cloudTransitions)
+	}
 	if transition == "" {
 		return false
 	}
@@ -728,9 +831,16 @@ func (r *ruleTagDefaults) UserTagsOnly(serverURL, ruleKey string, allTags []stri
 }
 
 // loadMatchableIssues reads the extracted SQS issues for a project and
-// converts them to matchableIssue values. Issues with CLOSED status or
-// FIXED resolution are excluded because they have no Cloud counterpart
-// (the scan report does not reproduce them).
+// converts them to matchableIssue values.
+//
+// Issues with no Cloud counterpart are excluded — intentionally and,
+// per #322, explicitly (the FIXED count is logged rather than silently
+// dropped):
+//   - CLOSED status: the issue was removed by analysis.
+//   - FIXED (legacy resolution=FIXED or modern issueStatus=FIXED): the
+//     underlying code was fixed, so a fresh Cloud scan does not re-raise
+//     the issue. There is nothing to sync onto — this is a documented
+//     exclusion, not a bug.
 //
 // ruleDefaults is used to strip rule-default tags from each issue's
 // tag list so that matchableIssue.Tags holds only the user-added tags
@@ -742,6 +852,7 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 	}
 
 	var issues []matchableIssue
+	var excludedFixed int
 	for _, item := range items {
 		if item.ServerURL != serverURL {
 			continue
@@ -752,12 +863,14 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 
 		status := strings.ToUpper(extractField(item.Data, "status"))
 		resolution := strings.ToUpper(extractField(item.Data, "resolution"))
+		issueStatus := strings.ToUpper(extractField(item.Data, "issueStatus"))
 
-		// Exclude CLOSED and FIXED — these won't exist in Cloud.
+		// Exclude CLOSED and FIXED — these have no Cloud counterpart.
 		if status == "CLOSED" {
 			continue
 		}
-		if resolution == "FIXED" {
+		if resolution == "FIXED" || issueStatus == "FIXED" {
+			excludedFixed++
 			continue
 		}
 
@@ -774,12 +887,22 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 			Line:           line,
 			Status:         extractField(item.Data, "status"),
 			Resolution:     extractField(item.Data, "resolution"),
+			IssueStatus:    extractField(item.Data, "issueStatus"),
 			Tags:           userTags,
 			Comments:       comments,
 			Assignee:       extractField(item.Data, "assignee"),
 			ManualSeverity: extractBool(item.Data, "manualSeverity"),
 			Branch:         extractField(item.Data, "branch"),
 		})
+	}
+
+	// Surface the FIXED exclusion explicitly (#322) rather than dropping
+	// silently: FIXED issues are resolved because the code was fixed, so
+	// a fresh Cloud scan does not re-raise them and there is nothing to
+	// sync onto. Operators should still see how many were skipped.
+	if excludedFixed > 0 {
+		e.Logger.Info("syncIssueMetadata: excluding FIXED source issues from status sync (code was fixed; no Cloud counterpart is re-raised by analysis)",
+			"project", serverKey, "excluded_fixed", excludedFixed)
 	}
 	return issues
 }
@@ -797,15 +920,16 @@ func apiIssueToMatchable(ai sqtypes.Issue) matchableIssue {
 		})
 	}
 	return matchableIssue{
-		Key:        ai.Key,
-		Rule:       ai.Rule,
-		Component:  ai.Component,
-		Line:       ai.Line,
-		Status:     ai.Status,
-		Resolution: ai.Resolution,
-		Tags:       ai.Tags,
-		Comments:   comments,
-		Assignee:   ai.Assignee,
+		Key:         ai.Key,
+		Rule:        ai.Rule,
+		Component:   ai.Component,
+		Line:        ai.Line,
+		Status:      ai.Status,
+		Resolution:  ai.Resolution,
+		Tags:        ai.Tags,
+		Comments:    comments,
+		Assignee:    ai.Assignee,
+		Transitions: ai.Transitions,
 	}
 }
 

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -368,3 +368,131 @@ func TestClassifyIssueCandidatesByLine(t *testing.T) {
 		})
 	}
 }
+
+// #322: getFallbackTransition must read the modern issueStatus enum
+// FIRST. A real ACCEPTED issue from a 10.4+ server arrives as
+// status=RESOLVED, resolution=WONTFIX, issueStatus=ACCEPTED — the old
+// resolution-first logic caught the WONTFIX resolution and mapped it to
+// the "wontfix" transition, landing the issue as Won't Fix on Cloud
+// instead of Accepted. It must now map to the "accept" transition, while
+// a GENUINE legacy WONTFIX (no issueStatus, pre-10.4) still maps to
+// "wontfix" so those migrations are not regressed.
+func TestGetFallbackTransition(t *testing.T) {
+	tests := []struct {
+		name        string
+		issueStatus string
+		resolution  string
+		status      string
+		want        string
+	}{
+		// --- Modern issueStatus enum (10.4+) takes priority ---
+		{name: "#322 regression: ACCEPTED arrives as RESOLVED+WONTFIX -> accept", issueStatus: "ACCEPTED", resolution: "WONTFIX", status: "RESOLVED", want: "accept"},
+		{name: "modern FALSE_POSITIVE -> falsepositive", issueStatus: "FALSE_POSITIVE", resolution: "FALSE-POSITIVE", status: "RESOLVED", want: "falsepositive"},
+		{name: "modern CONFIRMED -> confirm", issueStatus: "CONFIRMED", status: "CONFIRMED", want: "confirm"},
+		{name: "modern OPEN -> no transition", issueStatus: "OPEN", status: "OPEN", want: ""},
+		{name: "modern FIXED -> no transition (excluded at load)", issueStatus: "FIXED", resolution: "FIXED", status: "RESOLVED", want: ""},
+		{name: "issueStatus is case-insensitive", issueStatus: "accepted", resolution: "WONTFIX", status: "RESOLVED", want: "accept"},
+
+		// --- Legacy resolution path (pre-10.4, no issueStatus) ---
+		{name: "legacy WONTFIX (no issueStatus) -> wontfix, NOT regressed", issueStatus: "", resolution: "WONTFIX", status: "RESOLVED", want: "wontfix"},
+		{name: "legacy FALSE-POSITIVE (no issueStatus) -> falsepositive", issueStatus: "", resolution: "FALSE-POSITIVE", status: "RESOLVED", want: "falsepositive"},
+
+		// --- Legacy status fallback (no issueStatus, no resolution) ---
+		{name: "legacy CONFIRMED status -> confirm", status: "CONFIRMED", want: "confirm"},
+		{name: "legacy REOPENED status -> reopen", status: "REOPENED", want: "reopen"},
+		{name: "legacy OPEN status -> no transition", status: "OPEN", want: ""},
+		{name: "legacy RESOLVED status (no resolution) -> resolve", status: "RESOLVED", want: "resolve"},
+		{name: "legacy ACCEPTED status (no issueStatus) -> accept", status: "ACCEPTED", want: "accept"},
+		{name: "legacy FALSE_POSITIVE status -> falsepositive", status: "FALSE_POSITIVE", want: "falsepositive"},
+		{name: "IN_SANDBOX -> no transition", status: "IN_SANDBOX", want: ""},
+		{name: "all empty -> no transition", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getFallbackTransition(tc.issueStatus, tc.resolution, tc.status)
+			if got != tc.want {
+				t.Errorf("getFallbackTransition(%q, %q, %q) = %q, want %q", tc.issueStatus, tc.resolution, tc.status, got, tc.want)
+			}
+		})
+	}
+}
+
+// #322: resolveTransition gates the "accept" transition on the matched
+// Cloud issue's available-transition list. When "accept" is not offered
+// it must leave the issue OPEN (return "") and report downgraded=true —
+// it must NEVER silently downgrade to "wontfix" (that would mislabel the
+// issue as Won't Fix). An empty/unknown list is treated optimistically.
+// Transitions other than "accept" are not gated.
+func TestResolveTransition(t *testing.T) {
+	accepted := matchableIssue{IssueStatus: "ACCEPTED", Resolution: "WONTFIX", Status: "RESOLVED"}
+	falsePos := matchableIssue{IssueStatus: "FALSE_POSITIVE", Resolution: "FALSE-POSITIVE", Status: "RESOLVED"}
+	legacyWontfix := matchableIssue{Resolution: "WONTFIX", Status: "RESOLVED"}
+	open := matchableIssue{IssueStatus: "OPEN", Status: "OPEN"}
+
+	tests := []struct {
+		name           string
+		src            matchableIssue
+		cloudTrans     []string
+		wantTransition string
+		wantDowngraded bool
+	}{
+		{name: "accept available -> accept", src: accepted, cloudTrans: []string{"confirm", "accept", "falsepositive"}, wantTransition: "accept", wantDowngraded: false},
+		{name: "accept unavailable -> OPEN + downgraded (never wontfix)", src: accepted, cloudTrans: []string{"reopen", "unconfirm"}, wantTransition: "", wantDowngraded: true},
+		{name: "unknown transitions (nil) -> optimistic accept", src: accepted, cloudTrans: nil, wantTransition: "accept", wantDowngraded: false},
+		{name: "unknown transitions (empty slice) -> optimistic accept", src: accepted, cloudTrans: []string{}, wantTransition: "accept", wantDowngraded: false},
+		{name: "false positive is not gated", src: falsePos, cloudTrans: []string{"confirm"}, wantTransition: "falsepositive", wantDowngraded: false},
+		{name: "legacy wontfix is not gated", src: legacyWontfix, cloudTrans: []string{"reopen"}, wantTransition: "wontfix", wantDowngraded: false},
+		{name: "open needs no transition", src: open, cloudTrans: []string{"accept"}, wantTransition: "", wantDowngraded: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotT, gotD := resolveTransition(tc.src, tc.cloudTrans)
+			if gotT != tc.wantTransition || gotD != tc.wantDowngraded {
+				t.Errorf("resolveTransition(%+v, %v) = (%q, %v), want (%q, %v)", tc.src, tc.cloudTrans, gotT, gotD, tc.wantTransition, tc.wantDowngraded)
+			}
+		})
+	}
+}
+
+// #322: hasManualChanges must recognise the modern issueStatus enum so
+// accepted / false-positive issues on 10.4+ servers (whose legacy status
+// may be OPEN/RESOLVED with the triage state living only in issueStatus)
+// are still flagged actionable — otherwise the transition fix never
+// fires for them.
+func TestHasManualChangesIssueStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		iss  matchableIssue
+		want bool
+	}{
+		{name: "issueStatus ACCEPTED, legacy status OPEN -> actionable", iss: matchableIssue{IssueStatus: "ACCEPTED", Status: "OPEN"}, want: true},
+		{name: "issueStatus FALSE_POSITIVE, legacy status OPEN -> actionable", iss: matchableIssue{IssueStatus: "FALSE_POSITIVE", Status: "OPEN"}, want: true},
+		{name: "real-data shape: RESOLVED+WONTFIX+issueStatus ACCEPTED -> actionable", iss: matchableIssue{IssueStatus: "ACCEPTED", Resolution: "WONTFIX", Status: "RESOLVED"}, want: true},
+		{name: "issueStatus OPEN, no other signal -> skip", iss: matchableIssue{IssueStatus: "OPEN", Status: "OPEN"}, want: false},
+		{name: "issueStatus lowercase accepted -> actionable", iss: matchableIssue{IssueStatus: "accepted", Status: "OPEN"}, want: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasManualChanges(tc.iss); got != tc.want {
+				t.Errorf("hasManualChanges(%+v) = %v, want %v", tc.iss, got, tc.want)
+			}
+		})
+	}
+}
+
+// #322: classifyActionableReasons counts issueStatus-driven accepted/FP
+// even when the legacy status/resolution fields don't carry the state.
+func TestClassifyActionableReasonsIssueStatus(t *testing.T) {
+	issues := []matchableIssue{
+		{IssueStatus: "ACCEPTED", Status: "OPEN"},                  // accepted via issueStatus only
+		{IssueStatus: "FALSE_POSITIVE", Status: "OPEN"},            // fp via issueStatus only
+		{IssueStatus: "OPEN", Status: "OPEN", Tags: []string{"x"}}, // tags only, not acceptedOrFP
+	}
+	b := classifyActionableReasons(issues)
+	if b.acceptedOrFP != 2 {
+		t.Errorf("acceptedOrFP via issueStatus: want 2, got %d", b.acceptedOrFP)
+	}
+	if b.customTags != 1 {
+		t.Errorf("customTags: want 1, got %d", b.customTags)
+	}
+}


### PR DESCRIPTION
Code has been fixed.

Regression Tested in your version of `sonar-tools` @okorach-sonar :

<img width="1214" height="194" alt="image" src="https://github.com/user-attachments/assets/a456fe44-f98c-4229-8ec1-297cf6972872" />

and 

<img width="1260" height="157" alt="image" src="https://github.com/user-attachments/assets/ebefe35a-9521-486c-a77a-16aac36b6845" />

----
## Summary by Gitar

- **Issue status mapping:**
  - Introduced `IssueStatus` tracking to handle modern MQR-model issues correctly.
  - Refactored `getFallbackTransition` to prioritize `issueStatus` over legacy fields, ensuring `ACCEPTED` issues map to the `accept` transition.
- **Transition safety:**
  - Added `resolveTransition` to gate the `accept` transition based on availability, ensuring issues remain `OPEN` rather than mislabeled as `WONTFIX`.
- **Exclusion handling:**
  - Explicitly log the count of `FIXED` issues excluded during `loadMatchableIssues` to improve operator visibility.
- **Documentation:**
  - Updated `MIGRATION-FACETS.md` and `MIGRATION-FACETS-AUDIT.md` to reflect the corrected `ACCEPTED` status mapping and clarify the design rationale for excluding `FIXED` issues.

<sub>This will update automatically on new commits.</sub>