### PR TITLE
Bump version to v2026.06.09-ALPHA

### DIFF
--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -4,6 +4,6 @@
 
 package version
 
-const Version = "0.2.0"
+const Version = "v2026.06.09-ALPHA"
 
 const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary
- Bump `Version` constant from `0.2.0` to `v2026.06.09-ALPHA` in `go/internal/version/version.go`.

## Test plan
- [ ] `sonar-migration-tool --version` reports `v2026.06.09-ALPHA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)