### PR TITLE
Issue #372: skip getAiCodeFixConfig on SQS < 2025.3

### DIFF
--- a/go/internal/extract/extract_test.go
+++ b/go/internal/extract/extract_test.go
@@ -17,7 +17,12 @@ import (
 )
 
 const (
-	testServerVersion = "10.7.0.12345"
+	// Default to a 2025.x version so version-gated tasks (e.g.
+	// getAiCodeFixConfig, which requires the v2 fix-suggestions
+	// endpoint introduced in 2025.3 — issue #372) exercise their
+	// happy path. Tests covering older-server behaviour spin up
+	// their own mock with an explicit version.
+	testServerVersion = "2025.4.0.12345"
 	testToken         = "test-token"
 	testResultsFile   = "results.1.jsonl"
 )
@@ -525,6 +530,55 @@ func TestRunExtractEditionFiltering(t *testing.T) {
 	_, err := RunExtract(context.Background(), cfg)
 	if err == nil {
 		t.Error("expected error for enterprise-only task on community edition")
+	}
+}
+
+// TestRunExtractAiCodeFixSkippedOnOldSQS verifies issue #372: SQS 2025.1
+// returns HTTP 405 for GET api/v2/fix-suggestions/feature-enablements
+// because the endpoint was only introduced in 2025.3. The task should
+// skip itself before issuing the GET, so the extract does NOT fail and
+// no getAiCodeFixConfig output directory is created.
+func TestRunExtractAiCodeFixSkippedOnOldSQS(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/server/version", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "2025.1.0.12345")
+	})
+	mux.HandleFunc("GET /api/system/info", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"edition": "developer", "version": "2025.1.0.12345",
+		})
+	})
+	// If the task fails to gate itself, the mock answers with 405 just
+	// like the real SQS 2025.1 server in the issue report.
+	v2Hit := false
+	mux.HandleFunc("GET /api/v2/fix-suggestions/feature-enablements", func(w http.ResponseWriter, r *http.Request) {
+		v2Hit = true
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		_, _ = w.Write([]byte(`{"message":"Method not supported."}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	cfg := ExtractConfig{
+		URL: srv.URL, Token: testToken, ExportDirectory: dir,
+		TargetTask: "getAiCodeFixConfig", Concurrency: 1,
+	}
+
+	if _, err := RunExtract(context.Background(), cfg); err != nil {
+		t.Fatalf("RunExtract failed: %v", err)
+	}
+	if v2Hit {
+		t.Error("api/v2/fix-suggestions/feature-enablements was called; task should skip on SQS < 2025.3")
+	}
+
+	entries, _ := os.ReadDir(dir)
+	if len(entries) == 0 {
+		t.Fatal("expected extract run directory")
+	}
+	extractDir := filepath.Join(dir, entries[0].Name())
+	if _, err := os.Stat(filepath.Join(extractDir, "getAiCodeFixConfig")); !os.IsNotExist(err) {
+		t.Errorf("getAiCodeFixConfig directory should not exist on SQS < 2025.3, got err=%v", err)
 	}
 }
 

--- a/go/internal/extract/tasks_system.go
+++ b/go/internal/extract/tasks_system.go
@@ -7,7 +7,15 @@ package extract
 import (
 	"context"
 	"net/url"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
+
+// aiCodeFixV2Available marks the SQS release where
+// api/v2/fix-suggestions/feature-enablements first answered GET
+// requests. 2025.1 / 2025.2 return HTTP 405 for the GET, so the task
+// is skipped entirely on those servers (issue #372).
+var aiCodeFixV2Available = common.MustParseVersion("2025.3")
 
 func systemTasks() []TaskDef {
 	return []TaskDef{
@@ -65,11 +73,17 @@ func systemTasks() []TaskDef {
 			// (each carrying type, selected/selfHosted flags, and the
 			// chosen model). The migrate + predict pipelines combine
 			// this with sonar.ai.codefix.hidden to drive the per-key
-			// migration strategy. The endpoint was added in SQS
-			// 2025.x; older servers may return 404 — non-fatal.
+			// migration strategy. The endpoint was added in SQS 2025.3;
+			// 2025.1 / 2025.2 return 405 for the GET and pre-2025
+			// servers return 404 — both are skipped (issue #372).
 			Name:     "getAiCodeFixConfig",
 			Editions: AllEditions,
 			Run: func(ctx context.Context, e *Executor) error {
+				if e.Version.Less(aiCodeFixV2Available) {
+					e.Logger.Debug("getAiCodeFixConfig skipped: SQS version predates api/v2/fix-suggestions/feature-enablements",
+						"version", e.Version.String())
+					return nil
+				}
 				err := fetchAndWriteSingle(ctx, e, "getAiCodeFixConfig",
 					"api/v2/fix-suggestions/feature-enablements", nil, "",
 					map[string]any{"serverUrl": e.ServerURL})


### PR DESCRIPTION
## Summary
- Gate `getAiCodeFixConfig` on `Version >= 2025.3`. The `api/v2/fix-suggestions/feature-enablements` endpoint was only introduced in 2025.3; on 2025.1 / 2025.2 the GET returns HTTP 405 and breaks the whole `extract` run (issue #372).
- Older servers now fall back to the same graceful no-op already used for pre-2025 versions that returned 404, leaving the migrate + predict pipelines in their existing `HasConfig: false` skip branch.
- Bumped the shared `testServerVersion` constant from `10.7.0.12345` to `2025.4.0.12345` so the existing full-extract test still exercises the v2 endpoint happy path.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] New `TestRunExtractAiCodeFixSkippedOnOldSQS` drives a mock server reporting `2025.1.0.12345` that answers the v2 endpoint with 405, and asserts the extract succeeds without calling the endpoint and without creating the `getAiCodeFixConfig` output directory.
- [x] Manual extract against a real SQS 2025.1 server (the reproduction scenario from the issue)

Fixes #372

Generated with [Claude Code](https://claude.com/claude-code)
