### PR TITLE
Issue #363: consolidate sonar.auth.* settings in migration report

### DIFF
--- a/go/internal/migrate/tasks_setglobalsettings.go
+++ b/go/internal/migrate/tasks_setglobalsettings.go
@@ -210,10 +210,22 @@ const (
 	skipDetailDefaultValue = "Setting is left to default on SQS, no migration needed"
 	skipDetailNotOnSQC     = "Setting does not exist (feature does not exist or setting irrelevant) on SQC, no migration possible"
 
+	// #363: all sonar.auth.* settings collapse to a single Skipped row
+	// with this wording — authentication is not portable to SQC and has
+	// to be redefined from scratch, so listing every auth key with the
+	// generic not-on-SQC note just adds noise.
+	skipDetailSonarAuthConsolidated = "Settings not migrated. Authentication must be redefined from scratch on SonarQube Cloud"
+
+	// sonarAuthConsolidatedKey is the synthetic key used in the report
+	// row that aggregates every sonar.auth.* setting (#363).
+	sonarAuthConsolidatedKey = "sonar.auth.*"
+
 	// Exported aliases — the predict pipeline consumes these so the
 	// real and predictive reports share the exact same wording.
-	SkipDetailDefaultValue = skipDetailDefaultValue
-	SkipDetailNotOnSQC     = skipDetailNotOnSQC
+	SkipDetailDefaultValue          = skipDetailDefaultValue
+	SkipDetailNotOnSQC              = skipDetailNotOnSQC
+	SkipDetailSonarAuthConsolidated = skipDetailSonarAuthConsolidated
+	SonarAuthConsolidatedKey        = sonarAuthConsolidatedKey
 )
 
 // sqsOnlyNoteText kept for backward compatibility with existing
@@ -342,7 +354,36 @@ func partitionSQSOnlySettings(values []json.RawMessage) (remaining []json.RawMes
 		}}
 		notes = append(notes, rec)
 	}
-	return remaining, notes
+	return remaining, consolidateSonarAuthNotes(notes)
+}
+
+// consolidateSonarAuthNotes collapses every sonar.auth.* per-key note
+// emitted by partitionSQSOnlySettings into a single synthetic record
+// with key=sonar.auth.* (#363). Authentication is not portable to SQC
+// and has to be redefined from scratch, so a per-key listing just adds
+// noise. Non-auth notes pass through in their original order.
+func consolidateSonarAuthNotes(notes []globalSettingResult) []globalSettingResult {
+	out := notes[:0]
+	hasAuth := false
+	for _, n := range notes {
+		if strings.HasPrefix(n.Key, "sonar.auth.") {
+			hasAuth = true
+			continue
+		}
+		out = append(out, n)
+	}
+	if hasAuth {
+		out = append(out, globalSettingResult{
+			Key: sonarAuthConsolidatedKey,
+			Outcomes: []orgOutcome{{
+				Org:    "",
+				Status: outcomeSkipped,
+				Reason: skipReasonSQSOnlyValue,
+				Detail: skipDetailSonarAuthConsolidated,
+			}},
+		})
+	}
+	return out
 }
 
 // skipReasonSQSOnlyValue is the reason marker placed on per-section

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -1270,6 +1270,19 @@ func TestPartitionSQSOnlySettings(t *testing.T) {
 			name: "unknown setting passes through",
 			raw:  map[string]any{"key": "sonar.exclusions", "values": []string{"a"}},
 		},
+		{
+			// #363: empty auth values stay silent.
+			name:       "sonar.auth.* with empty value is silent",
+			raw:        map[string]any{"key": "sonar.auth.saml.enabled", "value": ""},
+			wantSilent: true,
+		},
+		{
+			// #363: a single sonar.auth.* with value collapses into the
+			// consolidated row (key+wording asserted in the dedicated test below).
+			name:     "sonar.auth.* with value emits the consolidated note",
+			raw:      map[string]any{"key": "sonar.auth.saml.enabled", "value": "true"},
+			wantNote: SkipDetailSonarAuthConsolidated,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1305,6 +1318,92 @@ func TestPartitionSQSOnlySettings(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// #363: every sonar.auth.* setting with a value collapses into a single
+// synthetic row keyed "sonar.auth.*" with the dedicated wording, so the
+// Global Settings section no longer lists each auth key individually.
+// Non-auth SQS-only notes must pass through unchanged.
+func TestPartitionSQSOnlySettingsConsolidatesSonarAuth(t *testing.T) {
+	mk := func(m map[string]any) json.RawMessage {
+		b, _ := json.Marshal(m)
+		return b
+	}
+	inputs := []json.RawMessage{
+		mk(map[string]any{"key": "sonar.auth.saml.enabled", "value": "true"}),
+		mk(map[string]any{"key": "sonar.auth.github.enabled", "value": "true"}),
+		mk(map[string]any{"key": "sonar.auth.gitlab.clientId", "value": "abc"}),
+		// Empty auth value — silent, must not influence the consolidated row.
+		mk(map[string]any{"key": "sonar.auth.bitbucket.enabled", "value": ""}),
+		// Non-auth SQS-only note — must pass through with its original key.
+		mk(map[string]any{"key": "sonar.technicalDebt.ratingGrid", "value": "0.03,0.07,0.2,0.5"}),
+	}
+	rem, notes := partitionSQSOnlySettings(inputs)
+	if len(rem) != 0 {
+		t.Fatalf("all inputs are SQS-only; remaining should be 0, got %d", len(rem))
+	}
+	if len(notes) != 2 {
+		t.Fatalf("expected 2 notes (1 consolidated auth + 1 ratingGrid), got %d: %+v", len(notes), notes)
+	}
+
+	var consolidated, ratingGrid *globalSettingResult
+	for i := range notes {
+		switch notes[i].Key {
+		case SonarAuthConsolidatedKey:
+			consolidated = &notes[i]
+		case "sonar.technicalDebt.ratingGrid":
+			ratingGrid = &notes[i]
+		}
+	}
+	if consolidated == nil {
+		t.Fatalf("missing consolidated sonar.auth.* row in notes: %+v", notes)
+	}
+	if ratingGrid == nil {
+		t.Fatalf("missing ratingGrid pass-through in notes: %+v", notes)
+	}
+
+	// Consolidated row carries the new wording and one section-level outcome.
+	if len(consolidated.Outcomes) != 1 {
+		t.Fatalf("consolidated row must have exactly 1 outcome, got %d", len(consolidated.Outcomes))
+	}
+	oc := consolidated.Outcomes[0]
+	if oc.Detail != SkipDetailSonarAuthConsolidated {
+		t.Errorf("consolidated Detail = %q, want %q", oc.Detail, SkipDetailSonarAuthConsolidated)
+	}
+	if oc.Status != outcomeSkipped {
+		t.Errorf("consolidated Status = %q, want %q", oc.Status, outcomeSkipped)
+	}
+	if oc.Org != "" {
+		t.Errorf("consolidated row must be section-level (Org=\"\"), got %q", oc.Org)
+	}
+	if oc.Reason != "sqs-only" {
+		t.Errorf("consolidated Reason = %q, want \"sqs-only\"", oc.Reason)
+	}
+
+	// Non-auth note passes through with its original wording (the canonical not-on-SQC text).
+	if got := ratingGrid.Outcomes[0].Detail; got != SkipDetailNotOnSQC {
+		t.Errorf("ratingGrid Detail = %q, want %q", got, SkipDetailNotOnSQC)
+	}
+}
+
+// #363: when only empty-valued sonar.auth.* keys are present, no
+// consolidated row is emitted — there's nothing to surface.
+func TestPartitionSQSOnlySettingsSonarAuthEmptyValuesStaySilent(t *testing.T) {
+	mk := func(m map[string]any) json.RawMessage {
+		b, _ := json.Marshal(m)
+		return b
+	}
+	inputs := []json.RawMessage{
+		mk(map[string]any{"key": "sonar.auth.saml.enabled", "value": ""}),
+		mk(map[string]any{"key": "sonar.auth.github.enabled", "value": ""}),
+	}
+	rem, notes := partitionSQSOnlySettings(inputs)
+	if len(rem) != 0 {
+		t.Fatalf("auth keys must be removed from customized list, got %d remaining", len(rem))
+	}
+	if len(notes) != 0 {
+		t.Fatalf("empty auth values must not produce a consolidated row, got %d notes: %+v", len(notes), notes)
 	}
 }
 

--- a/go/internal/predict/global_settings.go
+++ b/go/internal/predict/global_settings.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
@@ -79,6 +80,10 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 	seenKey[migrate.AiCodeFixHiddenSetting] = true
 	seenKey[migrate.AiCodeFixSuggestionsSetting] = true
 
+	// #363: all sonar.auth.* keys collapse to a single Skipped row,
+	// emitted once after the main loop.
+	hasConsolidatedAuth := false
+
 	for _, it := range rawItems {
 		key := jsonStringField(it.Data, "key")
 		if key == "" || seenKey[key] {
@@ -92,6 +97,18 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 			continue
 		}
 		seenKey[key] = true
+
+		// #363: defer all sonar.auth.* keys; the consolidated row is
+		// written once after both loops. Honor the empty-value
+		// silent-skip rule by consulting EvaluateSQSOnlyGlobalSetting —
+		// when it returns isSQSOnly=false the key carries no value
+		// worth surfacing, so it shouldn't trigger the consolidated row.
+		if strings.HasPrefix(key, "sonar.auth.") {
+			if _, isSQSOnly := migrate.EvaluateSQSOnlyGlobalSetting(key, it.Data); isSQSOnly {
+				hasConsolidatedAuth = true
+			}
+			continue
+		}
 
 		// #249: sonar.dbcleaner.branchesToKeepWhenInactive migrates as
 		// a regex into the SQC org-scope sonar.branch.longLivedBranches
@@ -170,6 +187,26 @@ func synthesizeSetGlobalSettings(exportDir, runDir string, extractMapping struct
 		}
 		if err := w.WriteOne(b); err != nil {
 			return err
+		}
+	}
+
+	// #363: single consolidated sonar.auth.* row, emitted once if any
+	// auth setting carried a value worth surfacing.
+	if hasConsolidatedAuth {
+		rec := map[string]any{
+			"key": migrate.SonarAuthConsolidatedKey,
+			"outcomes": []map[string]string{{
+				"org":    "",
+				"status": "skipped",
+				"reason": "sqs-only",
+				"detail": migrate.SkipDetailSonarAuthConsolidated,
+			}},
+		}
+		b, err := json.Marshal(rec)
+		if err == nil {
+			if err := w.WriteOne(b); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/go/internal/predict/predict_test.go
+++ b/go/internal/predict/predict_test.go
@@ -259,3 +259,96 @@ func TestGeneratePredictiveReport_NoCSVs(t *testing.T) {
 		t.Error("expected error on exportDir without any mapping CSVs")
 	}
 }
+
+// #363: the predictive Global Settings section must consolidate every
+// sonar.auth.* key carrying a value into a single Skipped row keyed
+// "sonar.auth.*" with the dedicated "must be redefined" wording.
+func TestGeneratePredictiveReport_ConsolidatesSonarAuth(t *testing.T) {
+	exportDir := t.TempDir()
+
+	writeFile(t, exportDir, "organizations.csv",
+		"sonarqube_org_key,sonarcloud_org_key,server_url\n"+
+			"default,target-org,"+testServerURL+"\n")
+	writeFile(t, exportDir, "projects.csv",
+		"name,key,server_url,sonarqube_org_key\n"+
+			"App,com.example:app,"+testServerURL+",default\n")
+	writeFile(t, exportDir, "gates.csv",
+		"name,server_url,source_gate_key,is_default,sonarqube_org_key\n")
+
+	extractID := "extract-0001"
+	extractDir := filepath.Join(exportDir, extractID)
+	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
+
+	// Three sonar.auth.* keys with values plus one with an empty value
+	// (must stay silent). The non-auth control should remain in Succeeded.
+	writeJSONL(t, filepath.Join(extractDir, "getServerSettings", "settings.jsonl"),
+		[]map[string]any{
+			{"key": "sonar.auth.saml.enabled", "value": "true"},
+			{"key": "sonar.auth.github.enabled", "value": "true"},
+			{"key": "sonar.auth.gitlab.clientId", "value": "abc"},
+			{"key": "sonar.auth.bitbucket.enabled", "value": ""},
+			{"key": "sonar.exclusions", "value": "**/vendor/**"},
+		})
+	writeJSONL(t, filepath.Join(extractDir, "getServerSettingsDefinitions", "defs.jsonl"),
+		[]map[string]any{
+			{"key": "sonar.auth.saml.enabled", "defaultValue": ""},
+			{"key": "sonar.auth.github.enabled", "defaultValue": ""},
+			{"key": "sonar.auth.gitlab.clientId", "defaultValue": ""},
+			{"key": "sonar.auth.bitbucket.enabled", "defaultValue": ""},
+			{"key": "sonar.exclusions", "defaultValue": ""},
+		})
+
+	if _, err := GeneratePredictiveReport(exportDir); err != nil {
+		t.Fatalf("GeneratePredictiveReport: %v", err)
+	}
+
+	entries, err := os.ReadDir(exportDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var runDir string
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "predictive-") {
+			runDir = filepath.Join(exportDir, e.Name())
+			break
+		}
+	}
+	if runDir == "" {
+		t.Fatal("no predictive run directory found")
+	}
+
+	mig, err := summary.CollectSummary(runDir, exportDir)
+	if err != nil {
+		t.Fatalf("CollectSummary: %v", err)
+	}
+	settings := findSection(mig, "Global Settings")
+	if settings == nil {
+		t.Fatal("Global Settings section missing")
+	}
+
+	// No per-key auth row may appear anywhere in the section.
+	allBuckets := append([]summary.EntityItem{}, settings.Succeeded...)
+	allBuckets = append(allBuckets, settings.NearPerfect...)
+	allBuckets = append(allBuckets, settings.Partial...)
+	allBuckets = append(allBuckets, settings.Skipped...)
+	allBuckets = append(allBuckets, settings.Failed...)
+	for _, it := range allBuckets {
+		if strings.HasPrefix(it.Name, "sonar.auth.") && it.Name != "sonar.auth.*" {
+			t.Errorf("per-key sonar.auth.* row %q must not appear; expected only the consolidated row", it.Name)
+		}
+	}
+
+	// Exactly one consolidated row in Skipped with the dedicated wording.
+	var seen int
+	for _, it := range settings.Skipped {
+		if it.Name == "sonar.auth.*" {
+			seen++
+			if it.Detail != "Settings not migrated. Authentication must be redefined from scratch on SonarQube Cloud" {
+				t.Errorf("consolidated row Detail = %q; want the #363 wording", it.Detail)
+			}
+		}
+	}
+	if seen != 1 {
+		t.Errorf("expected exactly 1 consolidated sonar.auth.* row in Skipped, got %d (skipped=%+v)", seen, settings.Skipped)
+	}
+}


### PR DESCRIPTION
## Summary
- Collapses every `sonar.auth.*` global-setting row in the migration report into a single Skipped row keyed `sonar.auth.*` with the wording "Settings not migrated. Authentication must be redefined from scratch on SonarQube Cloud".
- Applies symmetrically to the real-migrate pipeline (`partitionSQSOnlySettings`) and the predict pipeline (`synthesizeSetGlobalSettings`).
- New shared constants `SkipDetailSonarAuthConsolidated` / `SonarAuthConsolidatedKey` keep both pipelines on identical wording.

Fixes #363.

## Test plan
- [x] `go test ./...` passes (new + existing).
- [ ] Run `./migrate.sh` against an extract with multiple `sonar.auth.*` settings; confirm `setGlobalSettings.jsonl` contains exactly one record with `"key":"sonar.auth.*"` and no individual `sonar.auth.<name>` records.
- [ ] Run `./predict.sh` and repeat the JSONL check on the predictive run directory.
- [ ] Inspect rendered Global Settings section in the generated summary PDF: one `sonar.auth.*` row in Skipped, Skipped count reduced accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)