### PR TITLE
Issue #368: reset leaves a single Default Template as default for all qualifiers

### DIFF
--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -79,8 +79,9 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 	// whose dependency chains do not pull migrate-only create*/set*
 	// work back into the plan. The other reset* tasks
 	// (resetDefaultProfiles, resetDefaultGates, resetPermissionTemplates)
-	// remain no-ops triggered as side-effects of deletes and are
-	// intentionally NOT in this list.
+	// are pulled into the plan as dependencies of the corresponding
+	// delete* tasks (so they run first to clear the current default
+	// before the destroy call) and are intentionally NOT named here.
 	resetPrefixTargets := map[string]bool{
 		"resetGlobalSettings": true,
 	}

--- a/go/internal/migrate/tasks_delete.go
+++ b/go/internal/migrate/tasks_delete.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
@@ -48,6 +49,26 @@ func isBuiltInProfile(p types.QualityProfile) bool {
 func matchesSonarWayName(name string) bool {
 	n := strings.ToLower(strings.TrimSpace(name))
 	return n == "sonar way" || n == "sonar way (built-in)"
+}
+
+// defaultPermissionTemplateName is the canonical name of the
+// permission template every new SonarCloud org ships with. Reset
+// uses it to identify the built-in (case-insensitively) so it can
+// promote it as default for every qualifier and skip it during the
+// delete sweep.
+const defaultPermissionTemplateName = "Default Template"
+
+// resetPermissionTemplateQualifiers lists the object qualifiers reset
+// promotes the built-in "Default Template" as default for. Mirrors
+// the per-qualifier semantics of /api/permissions/set_default_template.
+var resetPermissionTemplateQualifiers = []string{"TRK", "VW", "APP"}
+
+// isBuiltInPermissionTemplate matches the built-in "Default Template"
+// by name (case-insensitive, trimmed). The SQC search_templates
+// response carries no isBuiltIn flag for permission templates, so the
+// name is the only signal available.
+func isBuiltInPermissionTemplate(name string) bool {
+	return strings.EqualFold(strings.TrimSpace(name), defaultPermissionTemplateName)
 }
 
 // deleteTasks returns tasks for deleting/resetting entities in Cloud.
@@ -96,8 +117,18 @@ func deleteTasks() []TaskDef {
 			Run:          runDeleteGroups,
 		},
 		{
-			Name:         "deleteTemplates",
-			Dependencies: []string{"createPermissionTemplates"},
+			Name: "deleteTemplates",
+			// deleteTemplates enumerates the org's permission templates
+			// via the SonarCloud API rather than reading
+			// createPermissionTemplates' output — issue #368 requires
+			// deleting EVERY non-built-in template, not just the ones
+			// the migration created (otherwise an org reset can leave
+			// templates the migration set as default behind, since
+			// SQC refuses to delete the current default). The
+			// resetPermissionTemplates dependency runs first so the
+			// built-in "Default Template" is the current default for
+			// every qualifier before any delete call.
+			Dependencies: []string{"generateOrganizationMappings", "resetPermissionTemplates"},
 			Run:          runDeleteTemplates,
 		},
 		{
@@ -129,8 +160,15 @@ func deleteTasks() []TaskDef {
 			Run:          runResetDefaultGates,
 		},
 		{
+			// Promotes the built-in "Default Template" as the org's
+			// default permission template for every qualifier (TRK,
+			// VW, APP) before deleteTemplates runs. SonarCloud rejects
+			// /api/permissions/delete_template on whichever template
+			// is the current default for any qualifier, so without
+			// this step the migration-promoted custom default
+			// template survives reset. Issue #368.
 			Name:         "resetPermissionTemplates",
-			Dependencies: []string{"setDefaultTemplates"},
+			Dependencies: []string{"generateOrganizationMappings"},
 			Run:          runResetPermissionTemplates,
 		},
 		{
@@ -303,20 +341,43 @@ func runDeleteGroups(ctx context.Context, e *Executor) error {
 	return err
 }
 
+// runDeleteTemplates enumerates every permission template in each
+// mapped org via /api/permissions/search_templates and deletes the
+// non-built-in ones. Issue #368 requires reset to delete every
+// non-built-in template, not just those the migration created.
+// resetPermissionTemplates is a dependency, so by the time this runs
+// the built-in "Default Template" is the current default for every
+// qualifier and any previously-default custom template is deletable.
 func runDeleteTemplates(ctx context.Context, e *Executor) error {
 	counter := TaskCounterFromContext(ctx)
-	err := forEachMigrateItem(ctx, e, "deleteTemplates", "createPermissionTemplates",
+	err := forEachMigrateItem(ctx, e, "deleteTemplates", "generateOrganizationMappings",
 		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
-			templateID := extractField(item, "cloud_template_id")
-			if templateID == "" {
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
 				return nil
 			}
-			orgKey := extractField(item, "sonarcloud_org_key")
-			err := e.Cloud.Permissions.DeleteTemplate(ctx, templateID, orgKey)
+			templates, _, err := searchPermissionTemplates(ctx, e, orgKey)
 			if err != nil {
 				counter.Fail()
-				logAPIWarn(e.Logger, "deleteTemplates failed", err, "template", templateID)
-			} else {
+				logAPIWarn(e.Logger, "deleteTemplates: listing templates failed", err, "org", orgKey)
+				return nil
+			}
+			e.Logger.Debug("deleteTemplates: listed templates",
+				"org", orgKey, "count", len(templates), "summary", summarisePermissionTemplates(templates))
+			for _, tpl := range templates {
+				if isBuiltInPermissionTemplate(tpl.Name) {
+					e.Logger.Debug("deleteTemplates: keeping built-in template",
+						"org", orgKey, "template", tpl.Name)
+					continue
+				}
+				e.Logger.Info("deleteTemplates: deleting template",
+					"org", orgKey, "template", tpl.Name, "template_id", tpl.ID)
+				if err := e.Cloud.Permissions.DeleteTemplate(ctx, tpl.ID, orgKey); err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "deleteTemplates failed", err,
+						"template", tpl.Name, "template_id", tpl.ID, "org", orgKey)
+					continue
+				}
 				counter.Success()
 			}
 			return nil
@@ -547,8 +608,113 @@ func summariseGates(gates []types.QualityGate) string {
 	return strings.Join(parts, ", ")
 }
 
-func runResetPermissionTemplates(_ context.Context, e *Executor) error {
-	// No-op: Cloud resets defaults when templates are deleted.
-	w, _ := e.Store.Writer("resetPermissionTemplates")
-	return w.WriteChunk(nil)
+// runResetPermissionTemplates promotes the built-in "Default Template"
+// as each mapped org's default permission template for every
+// qualifier (TRK, VW, APP), so deleteTemplates can subsequently
+// destroy whichever custom template the migration (or the user) had
+// promoted to default. SonarCloud's /api/permissions/delete_template
+// rejects whichever template is the current default for any
+// qualifier; without this step the custom default survives reset.
+// Issue #368.
+func runResetPermissionTemplates(ctx context.Context, e *Executor) error {
+	counter := TaskCounterFromContext(ctx)
+	err := forEachMigrateItem(ctx, e, "resetPermissionTemplates", "generateOrganizationMappings",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
+				return nil
+			}
+			templates, defaults, err := searchPermissionTemplates(ctx, e, orgKey)
+			if err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "resetPermissionTemplates: listing templates failed", err, "org", orgKey)
+				return nil
+			}
+			e.Logger.Debug("resetPermissionTemplates: listed templates",
+				"org", orgKey, "count", len(templates), "summary", summarisePermissionTemplates(templates))
+
+			var builtIn *permissionTemplateInfo
+			for i := range templates {
+				if isBuiltInPermissionTemplate(templates[i].Name) {
+					builtIn = &templates[i]
+					break
+				}
+			}
+			if builtIn == nil {
+				e.Logger.Warn("resetPermissionTemplates: no built-in \"Default Template\" found; deleteTemplates may fail to delete the current default",
+					"org", orgKey, "templates_returned", summarisePermissionTemplates(templates))
+				counter.Fail()
+				return nil
+			}
+
+			for _, q := range resetPermissionTemplateQualifiers {
+				if defaults[q] == builtIn.ID {
+					e.Logger.Info("resetPermissionTemplates: built-in is already default",
+						"org", orgKey, "qualifier", q, "template", builtIn.Name, "template_id", builtIn.ID)
+					counter.Success()
+					continue
+				}
+				e.Logger.Info("resetPermissionTemplates: promoting built-in to default",
+					"org", orgKey, "qualifier", q, "template", builtIn.Name, "template_id", builtIn.ID)
+				if err := e.Cloud.Permissions.SetDefaultTemplate(ctx, builtIn.ID, q, orgKey); err != nil {
+					counter.Fail()
+					logAPIWarn(e.Logger, "resetPermissionTemplates: set_default_template failed", err,
+						"org", orgKey, "qualifier", q, "template_id", builtIn.ID)
+					continue
+				}
+				counter.Success()
+			}
+			return nil
+		})
+	return err
+}
+
+// permissionTemplateInfo is the slim subset of /api/permissions/
+// search_templates each reset/delete task needs.
+type permissionTemplateInfo struct {
+	ID   string
+	Name string
+}
+
+// searchPermissionTemplates fetches and parses both the
+// permissionTemplates[] list and the defaultTemplates[] map (keyed
+// by qualifier -> templateId) for one org via
+// /api/permissions/search_templates.
+func searchPermissionTemplates(ctx context.Context, e *Executor, orgKey string) ([]permissionTemplateInfo, map[string]string, error) {
+	body, err := e.Raw.Get(ctx, "api/permissions/search_templates", url.Values{"organization": {orgKey}})
+	if err != nil {
+		return nil, nil, fmt.Errorf("search_templates org=%s: %w", orgKey, err)
+	}
+	var parsed struct {
+		PermissionTemplates []struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"permissionTemplates"`
+		DefaultTemplates []struct {
+			TemplateID string `json:"templateId"`
+			Qualifier  string `json:"qualifier"`
+		} `json:"defaultTemplates"`
+	}
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return nil, nil, fmt.Errorf("decoding search_templates response for org=%s: %w", orgKey, err)
+	}
+	templates := make([]permissionTemplateInfo, 0, len(parsed.PermissionTemplates))
+	for _, t := range parsed.PermissionTemplates {
+		templates = append(templates, permissionTemplateInfo{ID: t.ID, Name: t.Name})
+	}
+	defaults := make(map[string]string, len(parsed.DefaultTemplates))
+	for _, d := range parsed.DefaultTemplates {
+		defaults[d.Qualifier] = d.TemplateID
+	}
+	return templates, defaults, nil
+}
+
+// summarisePermissionTemplates renders a compact, log-friendly summary
+// of an org's permission templates: "<name> (id=X)" joined by ", ".
+func summarisePermissionTemplates(templates []permissionTemplateInfo) string {
+	parts := make([]string, 0, len(templates))
+	for _, t := range templates {
+		parts = append(parts, fmt.Sprintf("%q (id=%s)", t.Name, t.ID))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -588,3 +588,198 @@ func TestRunResetGlobalSettingsAllInherited(t *testing.T) {
 		t.Errorf("Reset should not be called when no customized settings; got %d calls", resetCalls)
 	}
 }
+
+// TestRunResetPermissionTemplatesPromotesBuiltInForEveryQualifier
+// pins the #368 behavior: when the built-in "Default Template" is not
+// the current default for some qualifier(s), the task must call
+// /api/permissions/set_default_template once per missing qualifier,
+// targeting the built-in's templateId.
+func TestRunResetPermissionTemplatesPromotesBuiltInForEveryQualifier(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		setCalls []map[string]string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				{"id": "tpl-default", "name": "Default Template"},
+				{"id": "tpl-custom-proj", "name": "Custom Project Template"},
+				{"id": "tpl-custom-app", "name": "Mobile Apps"},
+			},
+			"defaultTemplates": []map[string]any{
+				// Built-in is currently default ONLY for portfolios.
+				{"templateId": "tpl-custom-proj", "qualifier": "TRK"},
+				{"templateId": "tpl-default", "qualifier": "VW"},
+				{"templateId": "tpl-custom-app", "qualifier": "APP"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/permissions/set_default_template", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		setCalls = append(setCalls, map[string]string{
+			"templateId":   r.FormValue("templateId"),
+			"qualifier":    r.FormValue("qualifier"),
+			"organization": r.FormValue("organization"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runResetPermissionTemplates: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Expect exactly two set_default_template calls (TRK + APP); VW is
+	// already default and must be skipped to avoid a redundant API call.
+	if len(setCalls) != 2 {
+		t.Fatalf("expected 2 set_default_template calls (TRK + APP), got %d: %v", len(setCalls), setCalls)
+	}
+	gotQualifiers := map[string]bool{}
+	for _, c := range setCalls {
+		if c["templateId"] != "tpl-default" {
+			t.Errorf("templateId: got %q, want \"tpl-default\" (the built-in)", c["templateId"])
+		}
+		if c["organization"] != testCloudOrg {
+			t.Errorf("organization: got %q, want %q", c["organization"], testCloudOrg)
+		}
+		gotQualifiers[c["qualifier"]] = true
+	}
+	if !gotQualifiers["TRK"] || !gotQualifiers["APP"] {
+		t.Errorf("expected qualifiers {TRK, APP}, got %v", gotQualifiers)
+	}
+	if gotQualifiers["VW"] {
+		t.Error("VW must NOT be re-promoted: built-in was already default for it")
+	}
+}
+
+// TestRunResetPermissionTemplatesSkipsWhenAlreadyDefault confirms the
+// task makes ZERO set_default_template calls when the built-in is
+// already the current default for every qualifier — guards against
+// redundant API noise.
+func TestRunResetPermissionTemplatesSkipsWhenAlreadyDefault(t *testing.T) {
+	setCalls := 0
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				{"id": "tpl-default", "name": "Default Template"},
+			},
+			"defaultTemplates": []map[string]any{
+				{"templateId": "tpl-default", "qualifier": "TRK"},
+				{"templateId": "tpl-default", "qualifier": "VW"},
+				{"templateId": "tpl-default", "qualifier": "APP"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/permissions/set_default_template", func(w http.ResponseWriter, r *http.Request) {
+		setCalls++
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runResetPermissionTemplates: %v", err)
+	}
+	if setCalls != 0 {
+		t.Errorf("set_default_template must not be called when built-in already default for all qualifiers; got %d", setCalls)
+	}
+}
+
+// TestRunDeleteTemplatesEnumeratesAndDeletes confirms the rewritten
+// deleteTemplates enumerates via search_templates and deletes every
+// non-built-in template, regardless of whether the migration created
+// it. Issue #368.
+func TestRunDeleteTemplatesEnumeratesAndDeletes(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		deleted []string
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/permissions/search_templates", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"permissionTemplates": []map[string]any{
+				{"id": "tpl-default", "name": "Default Template"},
+				{"id": "tpl-1", "name": "DEFAULT"},
+				{"id": "tpl-2", "name": "Mobile Apps"},
+				// Trimmed + alternate case must still match the built-in.
+				{"id": "tpl-default-alt", "name": "  default template  "},
+			},
+			"defaultTemplates": []map[string]any{
+				{"templateId": "tpl-default", "qualifier": "TRK"},
+				{"templateId": "tpl-default", "qualifier": "VW"},
+				{"templateId": "tpl-default", "qualifier": "APP"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/permissions/delete_template", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		deleted = append(deleted, r.FormValue("templateId"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	w, _ := e.Store.Writer("generateOrganizationMappings")
+	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
+	w.WriteOne(b)
+
+	if err := runDeleteTemplates(context.Background(), e); err != nil {
+		t.Fatalf("runDeleteTemplates: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deleted) != 2 {
+		t.Fatalf("expected 2 deletes (\"DEFAULT\" + \"Mobile Apps\"), got %d: %v", len(deleted), deleted)
+	}
+	deletedSet := map[string]bool{}
+	for _, id := range deleted {
+		deletedSet[id] = true
+	}
+	if !deletedSet["tpl-1"] || !deletedSet["tpl-2"] {
+		t.Errorf("expected both \"DEFAULT\" (tpl-1) and \"Mobile Apps\" (tpl-2) deleted, got %v", deletedSet)
+	}
+	if deletedSet["tpl-default"] || deletedSet["tpl-default-alt"] {
+		t.Error("built-in \"Default Template\" must never be deleted (case-insensitive name match)")
+	}
+}


### PR DESCRIPTION
## Summary
- `resetPermissionTemplates` was a no-op that assumed SQC would auto-reset defaults when templates were deleted. SQC actually refuses to delete the current default for any qualifier, so a migration-promoted custom template survived reset.
- Now promotes the built-in "Default Template" as default for `TRK`, `VW`, and `APP` (skipping qualifiers where it's already default) before any delete call.
- `deleteTemplates` now enumerates every template via `/api/permissions/search_templates` and deletes every non-built-in one (case-insensitive name match against "Default Template"), mirroring `runDeleteGates` / `runDeleteProfiles`.
- Rewired dependencies so the new ordering is encoded in the task graph: `resetPermissionTemplates` → `[generateOrganizationMappings]`, `deleteTemplates` → `[generateOrganizationMappings, resetPermissionTemplates]`.

Fixes #368.

## Test plan
- [x] `go test ./...` passes (3 new tests cover the promote-per-qualifier path, the skip-when-already-default shortcut, and the enumerate-and-delete sweep).
- [ ] Manual: migrate from an SQS instance whose default template isn't named "Default Template" and isn't default for all object types, then run `./reset.sh`. Confirm in `Administration > Permission Templates` that only "Default Template" remains and is checked for Projects, Applications, and Portfolios.
- [ ] Spot-check the reset run log: one info line per `set_default_template` call (and one "already default" skip line per skipped qualifier), and a debug summary of templates listed by `deleteTemplates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
