### PR TITLE
Issue #383: transfer honors the configuration file end-to-end

### DIFF
--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -54,6 +54,7 @@ func init() {
 	f.String("url", "", "URL of SonarQube Cloud")
 	f.String("run_id", "", "ID of a run to resume in case of failures")
 	f.Int("concurrency", 0, "Maximum number of concurrent requests")
+	f.Int("timeout", 0, "Per-HTTP-request timeout in seconds (default: 60). Maps to the top-level timeout config field.")
 	f.String("export_directory", "", "Root directory containing all SonarQube exports")
 	f.String("target_task", "", "Name of a specific migration task to complete")
 	f.Bool("skip_profiles", false, "Skip quality profile migration/provisioning in SonarQube Cloud")
@@ -93,6 +94,7 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	overrideString(cmd, "target_task", &cfg.TargetTask)
 	overrideString(cmd, "default_organization", &cfg.DefaultOrganization)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
+	overrideInt(cmd, "timeout", &cfg.Timeout)
 	if cmd.Flags().Changed("skip_profiles") {
 		cfg.SkipProfiles, _ = cmd.Flags().GetBool("skip_profiles")
 	}

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
@@ -35,6 +36,7 @@ const (
 	flagTargetToken        = "target_token"
 	flagEnterpriseKey      = "enterprise_key"
 	flagDefaultOrg         = "default_organization"
+	flagEdition            = "edition"
 	flagExportDir                = "export_dir"
 	flagSkipIssueSync            = "skip_issue_sync"
 	flagSkipProjectDataMigration = "skip_project_data_migration"
@@ -149,19 +151,21 @@ func init() {
 	f.StringP(flagConfig, "c", "", "Path to JSON configuration file (common shape with source / target sections)")
 	f.String(flagSourceURL, "", sqServerName+" URL (maps to source.url)")
 	f.String(flagSourceToken, "", sqServerName+" token (maps to source.token)")
-	f.String(flagProjectKey, "", "Project key to transfer (omit to transfer all projects)")
+	f.String(flagProjectKey, "", "Project key to transfer (required; transfer is project-scoped — also accepts top-level project_key in the config file)")
 	f.String(flagTargetURL, "", scCloudName+" URL (maps to target.url, default: https://sonarcloud.io/)")
 	f.String(flagTargetToken, "", scCloudName+" token (maps to target.token)")
 	f.String(flagDefaultOrg, "", scCloudName+" organization key (maps to target.default_organization)")
 	f.String(flagEnterpriseKey, "", scCloudName+" enterprise key (maps to target.enterprise_key, defaults to --"+flagDefaultOrg+")")
+	f.String(flagEdition, "", scCloudName+" license edition (maps to target.edition; defaults to enterprise)")
 	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
 	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importProjectData and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.Int(flagConcurrency, 0, "Max concurrent requests (default: 25) (maps to concurrency)")
-	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout)")
+	f.Int(flagTimeout, 0, "HTTP request timeout in seconds (maps to timeout; default: 60)")
 	f.String(flagPEMFilePath, "", "Path to client mTLS PEM file for the source server (maps to source.pem_file_path)")
 	f.String(flagKeyFilePath, "", "Path to client mTLS key file for the source server (maps to source.key_file_path)")
 	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
+	// --debug is inherited from the persistent root flag; see cmd/root.go.
 	f.StringSlice(flagExcludeBranches, nil, "Glob patterns for non-main branches to skip during project data import (e.g. feature/*,bugfix/*)")
 }
 
@@ -174,6 +178,7 @@ type transferConfig struct {
 	targetToken         string
 	defaultOrganization string
 	enterpriseKey       string
+	edition             string
 	exportDir           string
 	concurrency              int
 	timeout                  int
@@ -248,6 +253,7 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 	cfg.targetURL = migrateCfg.URL
 	cfg.targetToken = migrateCfg.Token
 	cfg.enterpriseKey = migrateCfg.EnterpriseKey
+	cfg.edition = migrateCfg.Edition
 	cfg.defaultOrganization = migrateCfg.DefaultOrganization
 
 	cfg.exportDir = extractCfg.ExportDirectory
@@ -293,6 +299,7 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 	applyFlagString(cmd, flagTargetToken, &cfg.targetToken)
 	applyFlagString(cmd, flagDefaultOrg, &cfg.defaultOrganization)
 	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
+	applyFlagString(cmd, flagEdition, &cfg.edition)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
 	applyFlagInt(cmd, flagConcurrency, &cfg.concurrency)
 	applyFlagInt(cmd, flagTimeout, &cfg.timeout)
@@ -337,6 +344,17 @@ func validateTransferConfig(cfg transferConfig) error {
 	}
 	if cfg.targetToken == "" || cfg.defaultOrganization == "" {
 		return fmt.Errorf("%s token and organization key are required (--%s / --%s or target.token / target.default_organization in config file)", scCloudName, flagTargetToken, flagDefaultOrg)
+	}
+	// #383: transfer is project-scoped by design (see the command's
+	// long help). Without an explicit project key, the extract phase
+	// would fan out across every project visible to the source token
+	// — surprising the operator and, on most non-admin tokens, ending
+	// in a "no projects found" failure after each per-project task
+	// gets a 403 / 404 in the deeper API calls. Require the key up
+	// front so the failure mode is a clear validation error instead
+	// of a downstream cascade.
+	if cfg.projectKey == "" {
+		return fmt.Errorf("project key is required (--%s or project_key in config file) — transfer is project-scoped by design", flagProjectKey)
 	}
 	return nil
 }
@@ -425,7 +443,44 @@ func runTransferExtract(ctx context.Context, cfg transferConfig) ([]string, erro
 	if err != nil {
 		return nil, fmt.Errorf("extract failed: %w", err)
 	}
+	// #383: validateTransferConfig already required a project key, but
+	// it doesn't catch misspellings — /api/projects/search?projects=<typo>
+	// returns 200 with zero components, the extract chain silently writes
+	// nothing, and downstream phases fail with a confusing "no projects
+	// found" once mappings runs. Verify post-extract that the requested
+	// project actually surfaced in getProjects; if not, abort with a
+	// clear error that names the exact value the operator typed.
+	if err := ensureTransferProjectExtracted(cfg); err != nil {
+		return nil, err
+	}
 	return skipped, nil
+}
+
+// ensureTransferProjectExtracted reads the latest extract's getProjects
+// records for the configured source URL and returns an error when the
+// configured --project_key isn't among them. Called only when
+// cfg.projectKey is non-empty (validateTransferConfig enforces that).
+func ensureTransferProjectExtracted(cfg transferConfig) error {
+	mapping, err := structure.GetUniqueExtracts(cfg.exportDir)
+	if err != nil {
+		return fmt.Errorf("scanning extract directory %s: %w", cfg.exportDir, err)
+	}
+	items, _ := structure.ReadExtractData(cfg.exportDir, mapping, "getProjects")
+	// The extract pipeline normalises URLs with a trailing slash; the
+	// config may or may not. Strip slashes on both sides before matching.
+	wantURL := strings.TrimRight(cfg.sourceURL, "/")
+	for _, item := range items {
+		if strings.TrimRight(item.ServerURL, "/") != wantURL {
+			continue
+		}
+		if common.ExtractField(item.Data, "key") == cfg.projectKey {
+			return nil
+		}
+	}
+	return fmt.Errorf(
+		"project %q does not exist on source server %s — check the --%s value "+
+			"(keys are case-sensitive; verify with GET /api/projects/search?projects=%s)",
+		cfg.projectKey, cfg.sourceURL, flagProjectKey, cfg.projectKey)
 }
 
 func runTransferStructure(cfg transferConfig) error {
@@ -454,8 +509,10 @@ func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error)
 		URL:             cfg.targetURL,
 		Token:           cfg.targetToken,
 		EnterpriseKey:   cfg.enterpriseKey,
+		Edition:         cfg.edition,
 		ExportDirectory: cfg.exportDir,
 		Concurrency:     cfg.concurrency,
+		Timeout:         cfg.timeout,
 		// Project-scoped migration: run only the leaf tasks for the project,
 		// its quality gate/profiles, permissions, and issue/hotspot history.
 		// Their dependencies are resolved automatically.

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -28,6 +28,7 @@ func newTransferTestCmd() *cobra.Command {
 	f.String(flagTargetToken, "", "")
 	f.String(flagDefaultOrg, "", "")
 	f.String(flagEnterpriseKey, "", "")
+	f.String(flagEdition, "", "")
 	f.String(flagExportDir, "./migration-files/", "")
 	f.Int(flagConcurrency, 0, "")
 	f.Int(flagTimeout, 0, "")
@@ -66,6 +67,7 @@ func TestResolveTransferConfig_UnifiedConfigShape(t *testing.T) {
 			"url": "https://sonarcloud.io/",
 			"token": "sc-token",
 			"enterprise_key": "ent-key",
+			"edition": "developer",
 			"default_organization": "my-org"
 		}
 	}`)
@@ -87,6 +89,7 @@ func TestResolveTransferConfig_UnifiedConfigShape(t *testing.T) {
 		targetToken:         "sc-token",
 		defaultOrganization: "my-org",
 		enterpriseKey:       "ent-key",
+		edition:             "developer",
 		exportDir:           "/tmp/from-cfg",
 		concurrency:         7,
 		timeout:             42,
@@ -107,6 +110,7 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 		"concurrency": 7,
 		"timeout": 42,
 		"export_directory": "/tmp/from-cfg",
+		"debug": false,
 		"source": {
 			"url": "https://from-cfg",
 			"token": "cfg-source",
@@ -118,6 +122,7 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 			"url": "https://from-cfg",
 			"token": "cfg-target",
 			"enterprise_key": "cfg-ent",
+			"edition": "developer",
 			"default_organization": "cfg-org"
 		}
 	}`)
@@ -131,12 +136,14 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 		"--target_token", "cli-target-tok",
 		"--default_organization", "cli-org",
 		"--enterprise_key", "cli-ent",
+		"--edition", "community",
 		"--export_dir", "/tmp/cli",
 		"--concurrency", "11",
 		"--timeout", "99",
 		"--pem_file_path", "/cli/pem",
 		"--key_file_path", "/cli/key",
 		"--cert_password", "cli-pass",
+		"--debug",
 	}
 	if err := cmd.ParseFlags(args); err != nil {
 		t.Fatal(err)
@@ -158,12 +165,14 @@ func TestResolveTransferConfig_CLIOverridesConfig(t *testing.T) {
 		{"targetToken", cfg.targetToken, "cli-target-tok"},
 		{"defaultOrganization", cfg.defaultOrganization, "cli-org"},
 		{"enterpriseKey", cfg.enterpriseKey, "cli-ent"},
+		{"edition", cfg.edition, "community"},
 		{"exportDir", cfg.exportDir, "/tmp/cli"},
 		{"concurrency", cfg.concurrency, 11},
 		{"timeout", cfg.timeout, 99},
 		{"pemFilePath", cfg.pemFilePath, "/cli/pem"},
 		{"keyFilePath", cfg.keyFilePath, "/cli/key"},
 		{"certPassword", cfg.certPassword, "cli-pass"},
+		{"debug", cfg.debug, true},
 	}
 	for _, c := range checks {
 		if c.got != c.want {
@@ -193,10 +202,11 @@ func TestResolveTransferConfig_EnterpriseKeyDefaultsToOrg(t *testing.T) {
 	}
 }
 
-// Validation must error if either side is missing credentials, with a
-// message that names the new --source_* / --target_* flags so users
-// aren't pointed at the retired --sq-* / --sc-* names.
-func TestValidateTransferConfig_MissingCredentials(t *testing.T) {
+// Validation must error if either side is missing credentials or the
+// project key is missing (#383), with messages that name the relevant
+// CLI flag so users aren't pointed at the retired --sq-* / --sc-*
+// names.
+func TestValidateTransferConfig_MissingFields(t *testing.T) {
 	cases := []struct {
 		name   string
 		cfg    transferConfig
@@ -204,13 +214,21 @@ func TestValidateTransferConfig_MissingCredentials(t *testing.T) {
 	}{
 		{
 			name:   "missing source",
-			cfg:    transferConfig{targetToken: "t", defaultOrganization: "o"},
+			cfg:    transferConfig{targetToken: "t", defaultOrganization: "o", projectKey: "p"},
 			errSub: "--" + flagSourceURL,
 		},
 		{
 			name:   "missing target",
-			cfg:    transferConfig{sourceURL: "u", sourceToken: "t"},
+			cfg:    transferConfig{sourceURL: "u", sourceToken: "t", projectKey: "p"},
 			errSub: "--" + flagTargetToken,
+		},
+		{
+			name: "missing project key (#383)",
+			cfg: transferConfig{
+				sourceURL: "u", sourceToken: "t",
+				targetToken: "tt", defaultOrganization: "o",
+			},
+			errSub: "--" + flagProjectKey,
 		},
 	}
 	for _, c := range cases {
@@ -223,6 +241,98 @@ func TestValidateTransferConfig_MissingCredentials(t *testing.T) {
 				t.Errorf("error %q does not mention %q", err.Error(), c.errSub)
 			}
 		})
+	}
+}
+
+// #383: with all required fields present (including project_key),
+// validation must pass.
+func TestValidateTransferConfig_HappyPath(t *testing.T) {
+	cfg := transferConfig{
+		sourceURL:           "https://sq.example.com",
+		sourceToken:         "sq-tok",
+		projectKey:          "my-project",
+		targetToken:         "sc-tok",
+		defaultOrganization: "my-org",
+	}
+	if err := validateTransferConfig(cfg); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+// #383: a misspelled --project_key passes validation but silently
+// returns zero projects from /api/projects/search?projects=<typo>.
+// ensureTransferProjectExtracted closes that gap by checking the
+// post-extract getProjects records and erroring with a clear message
+// that names the exact value the operator typed.
+func TestEnsureTransferProjectExtracted_MissingProject(t *testing.T) {
+	dir := t.TempDir()
+	srvURL := "http://localhost:10000"
+
+	// Synthesise an extract dir with extract.json + getProjects/ containing
+	// real project keys, but NOT the one the operator typed.
+	extractDir := filepath.Join(dir, "2026-06-12-01")
+	if err := os.MkdirAll(filepath.Join(extractDir, "getProjects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, extractDir, "extract.json", `{"url":"`+srvURL+`/"}`)
+	writeFile(t, filepath.Join(extractDir, "getProjects"), "results.1.jsonl",
+		`{"key":"real-project-1","serverUrl":"`+srvURL+`/"}`+"\n"+
+			`{"key":"real-project-2","serverUrl":"`+srvURL+`/"}`+"\n")
+
+	cfg := transferConfig{
+		sourceURL:  srvURL,
+		projectKey: "missspelled-key",
+		exportDir:  dir,
+	}
+	err := ensureTransferProjectExtracted(cfg)
+	if err == nil {
+		t.Fatal("expected error for misspelled project key, got nil")
+	}
+	for _, want := range []string{"missspelled-key", srvURL, "--" + flagProjectKey} {
+		if !contains(err.Error(), want) {
+			t.Errorf("error %q does not mention %q", err.Error(), want)
+		}
+	}
+}
+
+// #383: when the configured project key matches a record in
+// getProjects (trailing-slash variations on the source URL accepted),
+// no error is returned.
+func TestEnsureTransferProjectExtracted_PresentProject(t *testing.T) {
+	cases := []struct {
+		name      string
+		cfgURL    string
+		recordURL string
+	}{
+		{name: "both with trailing slash", cfgURL: "http://localhost:10000/", recordURL: "http://localhost:10000/"},
+		{name: "cfg without slash, record with", cfgURL: "http://localhost:10000", recordURL: "http://localhost:10000/"},
+		{name: "cfg with slash, record without", cfgURL: "http://localhost:10000/", recordURL: "http://localhost:10000"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			extractDir := filepath.Join(dir, "2026-06-12-01")
+			if err := os.MkdirAll(filepath.Join(extractDir, "getProjects"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			writeFile(t, extractDir, "extract.json", `{"url":"`+c.recordURL+`"}`)
+			writeFile(t, filepath.Join(extractDir, "getProjects"), "results.1.jsonl",
+				`{"key":"my-project","serverUrl":"`+c.recordURL+`"}`+"\n")
+
+			cfg := transferConfig{sourceURL: c.cfgURL, projectKey: "my-project", exportDir: dir}
+			if err := ensureTransferProjectExtracted(cfg); err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// writeFile is a tiny helper that writes contents to dir/name.
+func writeFile(t *testing.T, dir, name, contents string) {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -126,6 +126,7 @@ type OrgConfigEntry struct {
 type settingsBlock struct {
 	ExportDirectory string `json:"export_directory"`
 	Concurrency     int    `json:"concurrency"`
+	Timeout         int    `json:"timeout"`
 }
 
 func parseConfigFile(path string) (configFileShape, error) {
@@ -159,11 +160,15 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			cfg.RunID = s.Target.RunID
 			cfg.TargetTask = s.Target.TargetTask
 			cfg.Concurrency = s.Target.Concurrency
+			cfg.Timeout = s.Target.Timeout
 			cfg.DefaultOrganization = s.Target.DefaultOrganization
 			cfg.ExcludeBranches = s.Target.ExcludeBranches
 		}
 		if cfg.Concurrency == 0 {
 			cfg.Concurrency = s.Concurrency
+		}
+		if cfg.Timeout == 0 {
+			cfg.Timeout = s.Timeout
 		}
 		cfg.ExportDirectory = s.ExportDirectory
 		// Top-level skip_issue_sync applies to every shape (#299).
@@ -204,6 +209,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			Edition:            s.Edition,
 			ExportDirectory:    s.ExportDirectory,
 			Concurrency:        s.Concurrency,
+			Timeout:            s.Timeout,
 			RunID:              s.RunID,
 			TargetTask:         s.TargetTask,
 			SkipProfiles:       s.SkipProfiles,
@@ -245,6 +251,7 @@ func (sc sonarCloudBlock) toMigrateConfig(settings *settingsBlock) MigrateConfig
 	if settings != nil {
 		cfg.ExportDirectory = settings.ExportDirectory
 		cfg.Concurrency = settings.Concurrency
+		cfg.Timeout = settings.Timeout
 	}
 	return cfg
 }

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -51,6 +51,8 @@ func TestLoadMigrateConfigFileShapes(t *testing.T) {
 				URL:             "https://sonarcloud.io/",
 				ExportDirectory: "./files",
 				Concurrency:     10,
+				// #383: settings.timeout now propagates to MigrateConfig.
+				Timeout: 60,
 			},
 		},
 	}
@@ -286,6 +288,89 @@ func TestLoadMigrateConfigFileUnifiedShape_TargetOverridesGlobals(t *testing.T) 
 	cfg, _ := LoadMigrateConfigFile(path)
 	if cfg.Concurrency != 25 {
 		t.Errorf("override: concurrency=%d", cfg.Concurrency)
+	}
+}
+
+// #383: Timeout must flow into MigrateConfig from every documented
+// config-file shape so the migrate phase honors the operator's value
+// instead of falling back to the SDK default (60s). The unified
+// shape's top-level timeout supplies a default; an explicit
+// target.timeout overrides it (same precedence as concurrency).
+func TestLoadMigrateConfigFile_TimeoutAllShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			name: "flat",
+			body: `{"url":"u","token":"t","timeout":15}`,
+			want: 15,
+		},
+		{
+			name: "command-sectioned (migrate block)",
+			body: `{"migrate":{"url":"u","token":"t","timeout":20}}`,
+			want: 20,
+		},
+		{
+			name: "side-sectioned (sonarcloud + settings)",
+			body: `{"sonarcloud":{"url":"u","token":"t"},"settings":{"timeout":30}}`,
+			want: 30,
+		},
+		{
+			name: "unified — top-level only",
+			body: `{"timeout":45,"target":{"url":"u","token":"t"}}`,
+			want: 45,
+		},
+		{
+			name: "unified — target overrides top-level",
+			body: `{"timeout":10,"target":{"url":"u","token":"t","timeout":99}}`,
+			want: 99,
+		},
+		{
+			name: "unified — target only",
+			body: `{"target":{"url":"u","token":"t","timeout":55}}`,
+			want: 55,
+		},
+		{
+			name: "unified — missing leaves Timeout at zero (applyDefaults will fill 60)",
+			body: `{"target":{"url":"u","token":"t"}}`,
+			want: 0,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := dir + "/cfg.json"
+			if err := os.WriteFile(path, []byte(c.body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := LoadMigrateConfigFile(path)
+			if err != nil {
+				t.Fatalf("load: %v", err)
+			}
+			if cfg.Timeout != c.want {
+				t.Errorf("Timeout: got %d, want %d (body=%s)", cfg.Timeout, c.want, c.body)
+			}
+		})
+	}
+}
+
+// #383: applyDefaults must fill Timeout with the SDK default (60s)
+// when the config left it at zero, so callers that previously relied
+// on the SDK fallback keep working.
+func TestMigrateConfig_ApplyDefaultsFillsTimeout(t *testing.T) {
+	cfg := MigrateConfig{}
+	cfg.applyDefaults()
+	if cfg.Timeout != 60 {
+		t.Errorf("Timeout default: got %d, want 60", cfg.Timeout)
+	}
+
+	// Explicit value is preserved.
+	cfg = MigrateConfig{Timeout: 5}
+	cfg.applyDefaults()
+	if cfg.Timeout != 5 {
+		t.Errorf("Timeout preservation: got %d, want 5", cfg.Timeout)
 	}
 }
 

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -31,6 +31,11 @@ type MigrateConfig struct {
 	URL             string // Cloud URL (default: https://sonarcloud.io/)
 	RunID           string // Resume a prior run
 	Concurrency     int
+	// Timeout is the per-HTTP-request timeout in seconds applied to
+	// every SonarQube Cloud call the migrate phase makes (#383). When
+	// <= 0, applyDefaults sets it to 60 — matching the SDK default
+	// and what the extract pipeline uses (extract.go).
+	Timeout         int
 	ExportDirectory string
 	TargetTask      string
 
@@ -119,6 +124,7 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 		}
 	}
 	clientOpts := []sqapi.Option{
+		sqapi.WithTimeout(cfg.Timeout),
 		sqapi.WithRetryLogger(retryLog),
 		sqapi.WithRateLimitObserver(rateLimitObs),
 	}
@@ -308,6 +314,9 @@ func runPhase(ctx context.Context, e *Executor, taskNames []string, registry map
 func (cfg *MigrateConfig) applyDefaults() {
 	if cfg.Concurrency <= 0 {
 		cfg.Concurrency = 25
+	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = 60
 	}
 	if cfg.ExportDirectory == "" {
 		cfg.ExportDirectory = "/app/files/"


### PR DESCRIPTION
## Summary
Several config-file knobs that `transfer --config <file>` is documented to honor were silently dropped:

- `target.edition` was parsed by `LoadMigrateConfigFile` but never written into `transferConfig`, so `MigrateConfig.Edition` always defaulted to `enterprise`.
- top-level `timeout` reached the extract phase but `MigrateConfig` had no `Timeout` field at all — the migrate-phase HTTP client always used the SDK's 60s default.
- `--edition` wasn't a registered CLI flag on `transfer`.

This PR:
1. Adds `Timeout` to `MigrateConfig` (default 60), wires `sqapi.WithTimeout(cfg.Timeout)` into `RunMigrate`'s client options, parses it from every config-file shape (flat / command-sectioned / side-sectioned `settings` block / unified `target.timeout` with top-level fallback), and registers `--timeout` on the `migrate` command.
2. Adds `Edition` to `transferConfig` end-to-end: read from `migrateCfg.Edition`, register `--edition` flag, apply CLI override, pass to `RunMigrate` alongside `Timeout`.
3. Hardens transfer's project-scoping contract — the help text says transfer is project-scoped, but it used to accept an omitted `--project_key` and fan out across every project visible to the source token. `validateTransferConfig` now requires `--project_key` (or top-level `project_key` in the config). After the extract phase, `ensureTransferProjectExtracted` reads `getProjects` and fails fast with a clear error when the typed key isn't found — naming the exact value and the source URL — instead of running the whole pipeline only to fail at mappings with a confusing "no projects found".

Fixes #383.

## Test plan
- [x] `go test ./...` — all packages green, with new unit coverage for `Timeout` plumbing across all 4 config shapes + `applyDefaults`, `--edition` / `--debug` / `--timeout` CLI overrides on transfer, `--project_key` required validation, and `ensureTransferProjectExtracted` (missing-key error wording + URL trailing-slash tolerance).
- [ ] Manual: `transfer -c config-ee.json --default_organization X --project_key <real-key>` runs end-to-end with the config's `timeout` + `edition` actually applied.
- [ ] Manual: `transfer ... --project_key <typo>` errors immediately after extract with `project "<typo>" does not exist on source server …` — no structure/mappings noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
