### PR TITLE
Issue #381: interactive confirmation gates the reset command

### DIFF
--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -5,11 +5,19 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 	"github.com/spf13/cobra"
 )
+
+const flagResetYes = "yes"
 
 var resetCmd = &cobra.Command{
 	Use:   "reset [token] [enterprise_key]",
@@ -25,7 +33,20 @@ var resetCmd = &cobra.Command{
 			return fmt.Errorf("TOKEN and ENTERPRISE_KEY are required (either as arguments or in config file)")
 		}
 
-		fmt.Println("WARNING: This will delete everything in every organization within the enterprise.")
+		autoYes, _ := cmd.Flags().GetBool(flagResetYes)
+		fmt.Fprintln(os.Stdout, "WARNING: This will delete migrated entities from the listed SonarCloud organizations.")
+		confirmed, err := confirmResetOrgs(cfg.ExportDirectory, autoYes, os.Stdin, os.Stdout)
+		if err != nil {
+			return err
+		}
+		if confirmed == nil {
+			// confirmResetOrgs already printed "Reset aborted."; exit
+			// cleanly so a misclick / Ctrl-D in the prompt doesn't
+			// look like a failure to the operator's shell.
+			return nil
+		}
+		cfg.ConfirmedOrgs = confirmed
+
 		if err := migrate.RunReset(cmd.Context(), cfg); err != nil {
 			return err
 		}
@@ -41,6 +62,7 @@ func init() {
 	f.String("url", "https://sonarcloud.io/", "URL of SonarQube Cloud")
 	f.Int("concurrency", 25, "Maximum number of concurrent requests")
 	f.String("export_directory", DefaultExportDirectory, "Directory to place all interim files")
+	f.Bool(flagResetYes, false, "Skip the interactive confirmation prompt and reset every listed organization (intended for non-interactive / scripted use). #381.")
 }
 
 func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, error) {
@@ -79,4 +101,115 @@ func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, e
 	}
 
 	return cfg, nil
+}
+
+// confirmResetOrgs gates the destructive reset behind an interactive
+// confirmation prompt (#381). It lists every mapped SonarCloud org
+// with its project count and asks the operator to type the subset
+// to reset (whitespace-separated). Returns:
+//
+//   - (confirmed-orgs, nil) on a valid non-empty selection.
+//   - (nil, nil) when the operator aborts (empty line or EOF) —
+//     callers exit cleanly without doing any destructive work.
+//   - (nil, err) on a malformed selection (unknown org key, etc.)
+//     or an underlying read / CSV failure.
+//
+// When autoYes is true, the helper prints the same list but skips
+// the prompt and returns every org — for non-interactive callers
+// (CI, scripts) that have already taken responsibility for the wipe.
+func confirmResetOrgs(exportDir string, autoYes bool, in io.Reader, out io.Writer) ([]string, error) {
+	orgs, err := loadResetTargetOrgs(exportDir)
+	if err != nil {
+		return nil, err
+	}
+	if len(orgs) == 0 {
+		return nil, fmt.Errorf("no SonarCloud organizations found in %s/organizations.csv — nothing to reset", exportDir)
+	}
+	projCounts := loadProjectsPerOrg(exportDir)
+
+	fmt.Fprintln(out, "The following SonarCloud organizations are targeted by this reset:")
+	for _, o := range orgs {
+		fmt.Fprintf(out, "  - %s (%d projects)\n", o, projCounts[o])
+	}
+
+	if autoYes {
+		return orgs, nil
+	}
+
+	fmt.Fprint(out, "\nType the org keys to reset (whitespace-separated), or press [Enter] to abort: ")
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return nil, fmt.Errorf("reading confirmation: %w", err)
+	}
+	typed := strings.Fields(strings.TrimSpace(line))
+	if len(typed) == 0 {
+		fmt.Fprintln(out, "Reset aborted.")
+		return nil, nil
+	}
+
+	known := make(map[string]bool, len(orgs))
+	for _, o := range orgs {
+		known[o] = true
+	}
+
+	var confirmed, unknown []string
+	seen := make(map[string]bool, len(typed))
+	for _, t := range typed {
+		if seen[t] {
+			continue
+		}
+		seen[t] = true
+		if known[t] {
+			confirmed = append(confirmed, t)
+		} else {
+			unknown = append(unknown, t)
+		}
+	}
+	if len(unknown) > 0 {
+		return nil, fmt.Errorf("unknown org key(s): %q — must be one of the listed orgs", strings.Join(unknown, ", "))
+	}
+	return confirmed, nil
+}
+
+// loadResetTargetOrgs reads organizations.csv and returns every unique
+// non-empty, non-SKIPPED sonarcloud_org_key, sorted for deterministic
+// display.
+func loadResetTargetOrgs(exportDir string) ([]string, error) {
+	rows, err := structure.LoadCSV(exportDir, "organizations.csv")
+	if err != nil {
+		return nil, fmt.Errorf("loading organizations.csv from %s: %w", exportDir, err)
+	}
+	seen := make(map[string]bool, len(rows))
+	for _, r := range rows {
+		k, _ := r["sonarcloud_org_key"].(string)
+		k = strings.TrimSpace(k)
+		if k == "" || k == "SKIPPED" {
+			continue
+		}
+		seen[k] = true
+	}
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// loadProjectsPerOrg returns the per-cloud-org count of projects the
+// migrate tool created — i.e., exactly what reset will delete (#381
+// follow-up). It mirrors runGetCreatedProjects: a union over every
+// prior migrate run's createProjects JSONL, deduped by
+// cloud_project_key, grouped by sonarcloud_org_key.
+//
+// Returns an empty map when no migrate run has happened yet so
+// callers can render "(0 projects)" without erroring out — running
+// reset against a fresh export_dir is a legitimate state.
+func loadProjectsPerOrg(exportDir string) map[string]int {
+	counts, err := migrate.MigrateCreatedProjectCounts(exportDir)
+	if err != nil || counts == nil {
+		return map[string]int{}
+	}
+	return counts
 }

--- a/go/cmd/reset_test.go
+++ b/go/cmd/reset_test.go
@@ -5,8 +5,13 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -182,5 +187,203 @@ func TestBuildResetConfigShape3FromExampleFile(t *testing.T) {
 	}
 	if cfg.Concurrency != 10 {
 		t.Errorf("Concurrency: got %d", cfg.Concurrency)
+	}
+}
+
+// #381: confirmResetOrgs gates the destructive reset behind an
+// interactive prompt. The helper must:
+//   - list every mapped cloud org with its project count;
+//   - accept whitespace-separated org keys (collapsing multiple spaces);
+//   - return (nil, nil) on empty input / EOF, signalling a clean abort;
+//   - error clearly when a typed key isn't in the displayed set;
+//   - dedup typed keys; and
+//   - skip the prompt entirely when autoYes is true.
+
+func writeResetFixture(t *testing.T, orgsCSV, projectsCSV string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if orgsCSV != "" {
+		if err := os.WriteFile(filepath.Join(dir, "organizations.csv"), []byte(orgsCSV), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if projectsCSV != "" {
+		if err := os.WriteFile(filepath.Join(dir, "projects.csv"), []byte(projectsCSV), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestConfirmResetOrgs_HappyPathSubset(t *testing.T) {
+	// #381 follow-up: project counts in the prompt are sourced from
+	// prior migrate runs' createProjects JSONL (not the structure
+	// phase's organizations.csv count) so the displayed number
+	// matches exactly what reset will delete.
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\norg3,cloud-c\n", "")
+	seedResetMigrateRun(t, dir, "run-01", []map[string]any{
+		{"cloud_project_key": "p1", "sonarcloud_org_key": "cloud-a"},
+		{"cloud_project_key": "p2", "sonarcloud_org_key": "cloud-a"},
+		{"cloud_project_key": "p3", "sonarcloud_org_key": "cloud-b"},
+		// cloud-c has no migrate-created projects → 0.
+	})
+
+	var out bytes.Buffer
+	in := strings.NewReader("cloud-a cloud-b\n")
+	got, err := confirmResetOrgs(dir, false, in, &out)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a", "cloud-b"}) {
+		t.Errorf("got %+v, want [cloud-a cloud-b]", got)
+	}
+	for _, want := range []string{"cloud-a (2 projects)", "cloud-b (1 projects)", "cloud-c (0 projects)"} {
+		if !strings.Contains(out.String(), want) {
+			t.Errorf("expected prompt to contain %q, got:\n%s", want, out.String())
+		}
+	}
+}
+
+// seedResetMigrateRun creates a fake migrate run directory under
+// exportDir for the reset tests. Mirrors what real migrate runs look
+// like: a run_meta.json marker plus a createProjects/ JSONL output.
+func seedResetMigrateRun(t *testing.T, exportDir, runID string, records []map[string]any) {
+	t.Helper()
+	runDir := filepath.Join(exportDir, runID)
+	if err := os.MkdirAll(filepath.Join(runDir, "createProjects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "run_meta.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(runDir, "createProjects", "results.1.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	for _, r := range records {
+		_ = enc.Encode(r)
+	}
+}
+
+func TestConfirmResetOrgs_CollapsesWhitespace(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
+
+	got, err := confirmResetOrgs(dir, false, strings.NewReader("   cloud-a    cloud-b   \n"), io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a", "cloud-b"}) {
+		t.Errorf("got %+v, want [cloud-a cloud-b]", got)
+	}
+}
+
+func TestConfirmResetOrgs_EmptyEnterAborts(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
+
+	var out bytes.Buffer
+	got, err := confirmResetOrgs(dir, false, strings.NewReader("\n"), &out)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil (abort), got %+v", got)
+	}
+	if !strings.Contains(out.String(), "Reset aborted.") {
+		t.Errorf("expected abort message, got:\n%s", out.String())
+	}
+}
+
+func TestConfirmResetOrgs_EOFAborts(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
+
+	// Empty reader → immediate EOF; treated the same as Enter alone.
+	got, err := confirmResetOrgs(dir, false, strings.NewReader(""), io.Discard)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil (abort) on EOF, got %+v", got)
+	}
+}
+
+func TestConfirmResetOrgs_UnknownKeyError(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\n", "")
+
+	_, err := confirmResetOrgs(dir, false, strings.NewReader("cloud-a typo-org\n"), io.Discard)
+	if err == nil {
+		t.Fatal("expected error for unknown key, got nil")
+	}
+	if !strings.Contains(err.Error(), "typo-org") || !strings.Contains(err.Error(), "unknown") {
+		t.Errorf("error %q does not mention the typo'd key", err.Error())
+	}
+}
+
+func TestConfirmResetOrgs_DedupsInput(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\n", "")
+
+	got, err := confirmResetOrgs(dir, false, strings.NewReader("cloud-a cloud-a cloud-b cloud-a\n"), io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a", "cloud-b"}) {
+		t.Errorf("got %+v, want [cloud-a cloud-b]", got)
+	}
+}
+
+func TestConfirmResetOrgs_AutoYesSkipsPrompt(t *testing.T) {
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-b\norg2,cloud-a\n", "")
+
+	// Reader returns content that would normally be parsed; autoYes
+	// must take precedence and never read from it.
+	in := strings.NewReader("this-should-not-be-read\n")
+	got, err := confirmResetOrgs(dir, true, in, io.Discard)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	// Sorted for deterministic display + return.
+	if !reflect.DeepEqual(got, []string{"cloud-a", "cloud-b"}) {
+		t.Errorf("got %+v, want sorted [cloud-a cloud-b]", got)
+	}
+	// Confirm reader untouched (still holds its original payload).
+	b, _ := io.ReadAll(in)
+	if string(b) == "" {
+		t.Error("autoYes must NOT consume the input reader")
+	}
+}
+
+func TestConfirmResetOrgs_SkipsSkippedSentinel(t *testing.T) {
+	// "SKIPPED" cloud org keys (and empties) must NOT be listed as
+	// targets — they were already opted out during mapping.
+	dir := writeResetFixture(t,
+		"sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,SKIPPED\norg3,\n", "")
+
+	var out bytes.Buffer
+	got, err := confirmResetOrgs(dir, true, strings.NewReader(""), &out)
+	if err != nil {
+		t.Fatalf("confirmResetOrgs: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"cloud-a"}) {
+		t.Errorf("got %+v, want [cloud-a]", got)
+	}
+	if strings.Contains(out.String(), "SKIPPED") {
+		t.Errorf("SKIPPED placeholder must not appear in the prompt output, got:\n%s", out.String())
+	}
+}
+
+func TestConfirmResetOrgs_EmptyOrgsCSVErrors(t *testing.T) {
+	// No organizations.csv → cannot continue.
+	dir := t.TempDir()
+	_, err := confirmResetOrgs(dir, false, strings.NewReader(""), io.Discard)
+	if err == nil {
+		t.Fatal("expected error when organizations.csv is missing")
 	}
 }

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -118,7 +118,7 @@ func TestLoadResetConfigFileShapes(t *testing.T) {
 			if err != nil {
 				t.Fatalf("LoadResetConfigFile(%s): %v", tc.file, err)
 			}
-			if got != tc.want {
+			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("ResetConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)
 			}
 		})

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -266,6 +266,17 @@ func loadCSVToJSONL(e *Executor, taskName, csvFilename string) error {
 				row["sonarcloud_org_key"] = scKey
 			}
 		}
+		// #381: in reset mode, rows whose cloud org wasn't confirmed
+		// by the operator get their sonarcloud_org_key rewritten to
+		// the SKIPPED sentinel so the existing shouldSkipOrg check at
+		// every per-org reset/delete task site naturally excludes
+		// them. A nil map = not in reset mode = no rewrite.
+		if e.ResetConfirmedOrgs != nil {
+			scKey, _ := row["sonarcloud_org_key"].(string)
+			if !e.ResetConfirmedOrgs[scKey] {
+				row["sonarcloud_org_key"] = skippedOrgSentinel
+			}
+		}
 		b, err := json.Marshal(row)
 		if err != nil {
 			continue

--- a/go/internal/migrate/helpers_test.go
+++ b/go/internal/migrate/helpers_test.go
@@ -61,6 +61,78 @@ func TestLoadCSVToJSONL(t *testing.T) {
 	}
 }
 
+// #381: when Executor.ResetConfirmedOrgs is set, loadCSVToJSONL must
+// rewrite the sonarcloud_org_key of every un-confirmed row to the
+// SKIPPED sentinel so the existing shouldSkipOrg path naturally
+// excludes those orgs from every per-org reset task. Rows whose
+// cloud org IS in the confirmed set must pass through untouched.
+// A nil map (the migrate-time default) leaves every row alone.
+func TestLoadCSVToJSONLResetConfirmedOrgsFilter(t *testing.T) {
+	cases := []struct {
+		name      string
+		confirmed map[string]bool
+		wantOrgs  []string
+	}{
+		{
+			name:      "nil map — no rewrite (migrate-time default)",
+			confirmed: nil,
+			wantOrgs:  []string{"cloud-a", "cloud-b", "cloud-c"},
+		},
+		{
+			name:      "subset confirmed — others rewritten to SKIPPED",
+			confirmed: map[string]bool{"cloud-a": true, "cloud-c": true},
+			wantOrgs:  []string{"cloud-a", "SKIPPED", "cloud-c"},
+		},
+		{
+			name:      "none confirmed — every row goes to SKIPPED",
+			confirmed: map[string]bool{},
+			wantOrgs:  []string{"SKIPPED", "SKIPPED", "SKIPPED"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			csvContent := "sonarqube_org_key,sonarcloud_org_key\norg1,cloud-a\norg2,cloud-b\norg3,cloud-c\n"
+			if err := os.WriteFile(filepath.Join(dir, "test.csv"), []byte(csvContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			// loadCSVToJSONL also reads organizations.csv for the
+			// enrichment join — write a self-referential one that
+			// matches the test rows.
+			if err := os.WriteFile(filepath.Join(dir, "organizations.csv"), []byte(csvContent), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			runDir := filepath.Join(dir, "run-01")
+			os.MkdirAll(runDir, 0o755)
+			store := common.NewDataStore(runDir)
+
+			e := &Executor{
+				Store:              store,
+				ExportDir:          dir,
+				ResetConfirmedOrgs: c.confirmed,
+			}
+			if err := loadCSVToJSONL(e, "testTask", "test.csv"); err != nil {
+				t.Fatalf("loadCSVToJSONL: %v", err)
+			}
+			items, err := store.ReadAll("testTask")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(items) != len(c.wantOrgs) {
+				t.Fatalf("expected %d items, got %d", len(c.wantOrgs), len(items))
+			}
+			for i, raw := range items {
+				var row map[string]any
+				_ = json.Unmarshal(raw, &row)
+				got, _ := row["sonarcloud_org_key"].(string)
+				if got != c.wantOrgs[i] {
+					t.Errorf("row %d: sonarcloud_org_key = %q, want %q", i, got, c.wantOrgs[i])
+				}
+			}
+		})
+	}
+}
+
 func TestLoadCSVToJSONLMissingFile(t *testing.T) {
 	dir := t.TempDir()
 	runDir := filepath.Join(dir, "run-01")

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -78,6 +78,15 @@ type Executor struct {
 	Sem             chan struct{}
 	Logger          *slog.Logger
 	ExcludeBranches []string
+
+	// ResetConfirmedOrgs is populated only by RunReset after the
+	// operator has interactively confirmed which SonarCloud orgs to
+	// wipe (#381). When set (non-nil), loadCSVToJSONL rewrites the
+	// sonarcloud_org_key of every row whose org is NOT in this set to
+	// the SKIPPED sentinel — the existing shouldSkipOrg path then
+	// naturally excludes those orgs from every per-org delete/reset
+	// task without per-task plumbing. Nil for migrate runs (no filter).
+	ResetConfirmedOrgs map[string]bool
 }
 
 // RunMigrate is the main entry point for the migrate command.

--- a/go/internal/migrate/reset.go
+++ b/go/internal/migrate/reset.go
@@ -30,6 +30,14 @@ type ResetConfig struct {
 	Concurrency     int
 	ExportDirectory string
 	Debug           bool
+
+	// ConfirmedOrgs is the operator-confirmed subset of mapped
+	// SonarCloud organizations to actually wipe (#381). Populated by
+	// the reset command's interactive confirmation prompt or by the
+	// --yes flag for non-interactive runs. When empty / nil, no
+	// filter is applied (all mapped orgs get reset — the legacy
+	// behaviour for callers that don't go through cmd/reset.go).
+	ConfirmedOrgs []string
 }
 
 // RunReset deletes all migrated entities from SonarQube Cloud.
@@ -128,6 +136,12 @@ func RunReset(ctx context.Context, cfg ResetConfig) error {
 		ExportDir: cfg.ExportDirectory,
 		Sem:       make(chan struct{}, cfg.Concurrency),
 		Logger:    logger,
+	}
+	if len(cfg.ConfirmedOrgs) > 0 {
+		executor.ResetConfirmedOrgs = make(map[string]bool, len(cfg.ConfirmedOrgs))
+		for _, o := range cfg.ConfirmedOrgs {
+			executor.ResetConfirmedOrgs[o] = true
+		}
 	}
 
 	for i, phase := range plan {

--- a/go/internal/migrate/tasks_read.go
+++ b/go/internal/migrate/tasks_read.go
@@ -7,7 +7,11 @@ package migrate
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
@@ -187,34 +191,172 @@ func runGetMigrationUser(ctx context.Context, e *Executor) error {
 	return w.WriteOne(raw)
 }
 
-// runGetCreatedProjects lists every project in every mapped SonarCloud
-// organization. It iterates generateOrganizationMappings (one record per
-// org) rather than createProjects (one record per project) so that the
-// /api/projects/search call fires exactly once per org. Reset feeds the
-// output to deleteProjects; iterating per-project caused N×N duplicates
-// where reset would try to delete the same key once per createProjects
-// record in that org.
+// runGetCreatedProjects unions every prior migrate run's createProjects
+// JSONL output and writes the deduplicated, org-filtered list to the
+// reset run's getCreatedProjects task — the input deleteProjects reads
+// to know which SonarCloud project keys to delete.
+//
+// Previously this task queried /api/projects/search?organization=<org>,
+// which lists EVERY project in the SonarCloud org — including projects
+// the migrate tool never created (pre-existing, manually provisioned,
+// or imported via another tool). Running reset would then wipe those
+// too — a serious safety problem (#381 follow-up). Scoping deletion to
+// projects the migrate tool actually created closes that gap.
+//
+// The migrate task createProjects writes one record per provisioned
+// SonarCloud project, with `cloud_project_key` + `sonarcloud_org_key`
+// populated. We scan every migrate run directory under exportDir
+// (identified by run_meta.json — reset runs use clear.json instead),
+// union their createProjects records, dedup by cloud_project_key, and
+// emit a {key, sonarcloud_org_key} record that matches the shape
+// deleteProjects expects (`key` carries the cloud project key).
+//
+// Reset's interactive confirmation (#381) populates
+// Executor.ResetConfirmedOrgs; when set, records whose cloud org isn't
+// confirmed are filtered out here so deleteProjects never sees them.
 func runGetCreatedProjects(ctx context.Context, e *Executor) error {
-	return forEachMigrateItem(ctx, e, "getCreatedProjects", "generateOrganizationMappings",
-		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+	w, err := e.Store.Writer("getCreatedProjects")
+	if err != nil {
+		return err
+	}
+
+	migrateRuns, err := listMigrateRunDirs(e.ExportDir)
+	if err != nil {
+		return fmt.Errorf("scanning migrate run directories: %w", err)
+	}
+	if len(migrateRuns) == 0 {
+		e.Logger.Warn("getCreatedProjects: no prior migrate runs found under export directory — nothing to delete",
+			"export_dir", e.ExportDir)
+		return nil
+	}
+
+	seen := make(map[string]bool)
+	var out []json.RawMessage
+	for _, runDir := range migrateRuns {
+		items, err := readJSONLDir(filepath.Join(runDir, "createProjects"))
+		if err != nil {
+			e.Logger.Debug("getCreatedProjects: skipping migrate run with no createProjects output",
+				"run_dir", runDir, "err", err)
+			continue
+		}
+		for _, item := range items {
+			cloudKey := extractField(item, "cloud_project_key")
+			if cloudKey == "" || seen[cloudKey] {
+				continue
+			}
 			orgKey := extractField(item, "sonarcloud_org_key")
 			if shouldSkipOrg(orgKey) {
-				return nil
+				continue
 			}
-			e.Logger.Debug("project api call: GET /api/projects/search (list org projects)",
-				"org", orgKey)
-			raw, err := e.Raw.GetPaginated(ctx, common.PaginatedOpts{
-				Path: "api/projects/search", ResultKey: "components",
-				Params: url.Values{"organization": {orgKey}},
-			})
-			if err != nil {
-				return err
+			// Honor the operator's interactive confirmation (#381).
+			if e.ResetConfirmedOrgs != nil && !e.ResetConfirmedOrgs[orgKey] {
+				continue
 			}
-			enriched := common.EnrichAll(raw, map[string]any{
+			seen[cloudKey] = true
+
+			// Emit a record shaped for deleteProjects: it extracts
+			// `key` (cloud project key) and uses sonarcloud_org_key
+			// for the org context. The original createProjects record
+			// carries `key` as the SOURCE key, so we transform here.
+			rec, _ := json.Marshal(map[string]any{
+				"key":                cloudKey,
 				"sonarcloud_org_key": orgKey,
+				"source_key":         extractField(item, "key"),
+				"server_url":         extractField(item, "server_url"),
 			})
-			return w.WriteChunk(enriched)
-		})
+			out = append(out, rec)
+		}
+	}
+	e.Logger.Info("getCreatedProjects: collected migrate-created projects",
+		"count", len(out), "migrate_runs_scanned", len(migrateRuns))
+	return w.WriteChunk(out)
+}
+
+// MigrateCreatedProjectCounts returns the count of distinct
+// migrate-created projects per SonarCloud organization key across
+// every prior migrate run found under exportDir. It mirrors exactly
+// what runGetCreatedProjects feeds deleteProjects, so the reset
+// command's interactive confirmation prompt (#381) can display the
+// real number of projects each org will lose.
+//
+// Returns (nil, nil) when exportDir doesn't exist or contains no
+// migrate runs — callers render "(0 projects)" for every org in that
+// case.
+func MigrateCreatedProjectCounts(exportDir string) (map[string]int, error) {
+	runDirs, err := listMigrateRunDirs(exportDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	seen := make(map[string]bool)
+	counts := make(map[string]int)
+	for _, runDir := range runDirs {
+		items, err := readJSONLDir(filepath.Join(runDir, "createProjects"))
+		if err != nil {
+			continue
+		}
+		for _, item := range items {
+			cloudKey := extractField(item, "cloud_project_key")
+			if cloudKey == "" || seen[cloudKey] {
+				continue
+			}
+			orgKey := extractField(item, "sonarcloud_org_key")
+			if shouldSkipOrg(orgKey) {
+				continue
+			}
+			seen[cloudKey] = true
+			counts[orgKey]++
+		}
+	}
+	return counts, nil
+}
+
+// listMigrateRunDirs returns the absolute paths of every subdirectory
+// under exportDir that holds a migrate run (signalled by a
+// run_meta.json file). Reset run directories are skipped — they hold
+// clear.json instead.
+func listMigrateRunDirs(exportDir string) ([]string, error) {
+	entries, err := os.ReadDir(exportDir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		runDir := filepath.Join(exportDir, e.Name())
+		if _, err := os.Stat(filepath.Join(runDir, "run_meta.json")); err != nil {
+			continue
+		}
+		out = append(out, runDir)
+	}
+	return out, nil
+}
+
+// readJSONLDir reads every results.*.jsonl file under dir and returns
+// the concatenated records. Mirrors common.DataStore.ReadAll without
+// requiring an Executor / DataStore (used by listMigrateRunDirs to
+// look at directories that aren't the reset's own run dir).
+func readJSONLDir(dir string) ([]json.RawMessage, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var all []json.RawMessage
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		items, err := common.ReadJSONLFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		all = append(all, items...)
+	}
+	return all, nil
 }
 
 func runGetEnterprises(ctx context.Context, e *Executor) error {

--- a/go/internal/migrate/tasks_read_test.go
+++ b/go/internal/migrate/tasks_read_test.go
@@ -7,7 +7,8 @@ package migrate
 import (
 	"context"
 	"encoding/json"
-	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -55,58 +56,73 @@ func TestGetProfileBackups(t *testing.T) {
 	}
 }
 
-func TestGetCreatedProjects(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["getCreatedProjects"].Run(context.Background(), e)
+// seedMigrateRunDir writes a fake migrate run under exportDir: a
+// run_meta.json marker (distinguishes it from a reset run, which uses
+// clear.json) and a createProjects/results.1.jsonl JSONL with the
+// supplied records. Returns the run path.
+func seedMigrateRunDir(t *testing.T, exportDir, runID string, records []map[string]any) string {
+	t.Helper()
+	runDir := filepath.Join(exportDir, runID)
+	if err := os.MkdirAll(filepath.Join(runDir, "createProjects"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "run_meta.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(filepath.Join(runDir, "createProjects", "results.1.jsonl"))
 	if err != nil {
-		t.Fatalf("getCreatedProjects: %v", err)
+		t.Fatal(err)
 	}
-
-	items, _ := e.Store.ReadAll("getCreatedProjects")
-	if len(items) == 0 {
-		t.Error("expected getCreatedProjects output")
+	defer f.Close()
+	for _, r := range records {
+		b, _ := json.Marshal(r)
+		f.Write(b)
+		f.Write([]byte("\n"))
 	}
+	return runDir
 }
 
-// Regression: getCreatedProjects must iterate per-org (one
-// /api/projects/search call per organization), not per createProjects
-// record. Reset fed deleteProjects through this task, and the old
-// per-record iteration produced one chunk per createProjects entry —
-// for a tenant with N projects in M orgs, deleteProjects would attempt
-// N deletions per record, returning 404 for every duplicate. Pin the
-// per-org iteration shape so we never regress.
-func TestGetCreatedProjectsDeduplicatesByOrg(t *testing.T) {
+// #381 follow-up: getCreatedProjects now scopes deletion to projects
+// the migrate tool ACTUALLY created (read from prior migrate run
+// dirs' createProjects JSONL) instead of listing every project in the
+// SonarCloud org via /api/projects/search. The new behaviour:
+//
+//   - Reads every subdir of exportDir that has run_meta.json (= a
+//     migrate run) and unions their createProjects records.
+//   - Dedupes by cloud_project_key so re-runs that re-touch the same
+//     project don't produce duplicate delete attempts.
+//   - Skips records whose sonarcloud_org_key is empty / SKIPPED.
+//   - When Executor.ResetConfirmedOrgs is set (the operator confirmed
+//     a subset via the interactive prompt), records whose cloud org
+//     isn't confirmed are filtered out so deleteProjects never sees
+//     them.
+//   - Emits {key, sonarcloud_org_key, source_key, server_url} per
+//     project, with `key` carrying the CLOUD key (the shape
+//     deleteProjects extracts).
+func TestGetCreatedProjects_UnionsMigrateRuns(t *testing.T) {
 	cloudSrv := newMockCloudServer()
 	defer cloudSrv.Close()
 	apiSrv := newMockAPIServer()
 	defer apiSrv.Close()
 	dir := t.TempDir()
-	setupExtractData(dir)
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
 
-	// Write extra createProjects records for the same org. If the
-	// iteration source regressed back to createProjects, getCreatedProjects
-	// would call /api/projects/search once per record and write one
-	// chunk per record. Iterating generateOrganizationMappings (one
-	// record per org) caps it at one chunk per org.
-	w, _ := e.Store.Writer("createProjects")
-	for i := 0; i < 9; i++ {
-		extra, _ := json.Marshal(map[string]any{
-			"sonarcloud_org_key": testCloudOrg,
-			"cloud_project_key":  fmt.Sprintf("cloud-org1_proj%d", i+2),
-		})
-		w.WriteOne(extra)
-	}
+	// Two migrate runs with overlapping cloud_project_key (dedup
+	// must keep exactly one record).
+	seedMigrateRunDir(t, dir, "2026-06-12-01", []map[string]any{
+		{"key": "src-a", "cloud_project_key": "cloud-a", "sonarcloud_org_key": "org1"},
+		{"key": "src-b", "cloud_project_key": "cloud-b", "sonarcloud_org_key": "org1"},
+	})
+	seedMigrateRunDir(t, dir, "2026-06-12-02", []map[string]any{
+		{"key": "src-b", "cloud_project_key": "cloud-b", "sonarcloud_org_key": "org1"},
+		{"key": "src-c", "cloud_project_key": "cloud-c", "sonarcloud_org_key": "org2"},
+	})
+	// Reset run (clear.json instead of run_meta.json) must be ignored.
+	resetDir := filepath.Join(dir, "2026-06-12-03")
+	os.MkdirAll(filepath.Join(resetDir, "createProjects"), 0o755)
+	os.WriteFile(filepath.Join(resetDir, "clear.json"), []byte(`{}`), 0o644)
+	os.WriteFile(filepath.Join(resetDir, "createProjects", "results.1.jsonl"),
+		[]byte(`{"cloud_project_key":"cloud-LEAK","sonarcloud_org_key":"org1"}`+"\n"), 0o644)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	if err := reg["getCreatedProjects"].Run(context.Background(), e); err != nil {
@@ -114,11 +130,92 @@ func TestGetCreatedProjectsDeduplicatesByOrg(t *testing.T) {
 	}
 
 	items, _ := e.Store.ReadAll("getCreatedProjects")
-	// Mock returns 1 component per /api/projects/search call. With one
-	// org we expect exactly 1 component. Old behaviour: 10 (1 per
-	// createProjects record).
-	if len(items) != 1 {
-		t.Errorf("expected 1 item (one chunk per org), got %d — iteration likely regressed to per-record", len(items))
+	gotKeys := map[string]string{}
+	for _, raw := range items {
+		var rec map[string]any
+		_ = json.Unmarshal(raw, &rec)
+		k, _ := rec["key"].(string)
+		org, _ := rec["sonarcloud_org_key"].(string)
+		gotKeys[k] = org
+	}
+	want := map[string]string{
+		"cloud-a": "org1",
+		"cloud-b": "org1",
+		"cloud-c": "org2",
+	}
+	if len(gotKeys) != len(want) {
+		t.Errorf("got %d records, want %d: %+v", len(gotKeys), len(want), gotKeys)
+	}
+	for k, org := range want {
+		if got, ok := gotKeys[k]; !ok || got != org {
+			t.Errorf("missing or wrong org for %s: got %q, want %q", k, got, org)
+		}
+	}
+	if _, leaked := gotKeys["cloud-LEAK"]; leaked {
+		t.Error("reset run's createProjects must NOT contribute records (clear.json, not run_meta.json)")
+	}
+}
+
+// #381: Executor.ResetConfirmedOrgs filters per-org. Records whose
+// sonarcloud_org_key isn't in the confirmed set are excluded.
+func TestGetCreatedProjects_HonorsResetConfirmedOrgs(t *testing.T) {
+	cloudSrv := newMockCloudServer()
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e.ResetConfirmedOrgs = map[string]bool{"org1": true}
+
+	seedMigrateRunDir(t, dir, "2026-06-12-01", []map[string]any{
+		{"cloud_project_key": "cloud-a", "sonarcloud_org_key": "org1"},
+		{"cloud_project_key": "cloud-b", "sonarcloud_org_key": "org2"},
+		{"cloud_project_key": "cloud-c", "sonarcloud_org_key": "org1"},
+		{"cloud_project_key": "cloud-d", "sonarcloud_org_key": "SKIPPED"},
+	})
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["getCreatedProjects"].Run(context.Background(), e); err != nil {
+		t.Fatalf("getCreatedProjects: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("getCreatedProjects")
+	keys := map[string]bool{}
+	for _, raw := range items {
+		var rec map[string]any
+		_ = json.Unmarshal(raw, &rec)
+		k, _ := rec["key"].(string)
+		keys[k] = true
+	}
+	if !keys["cloud-a"] || !keys["cloud-c"] {
+		t.Errorf("expected cloud-a and cloud-c (org1) to pass through, got %+v", keys)
+	}
+	if keys["cloud-b"] {
+		t.Error("cloud-b (org2 — not confirmed) must be filtered out")
+	}
+	if keys["cloud-d"] {
+		t.Error("cloud-d (SKIPPED org) must be filtered out")
+	}
+}
+
+// #381: when no prior migrate run exists, getCreatedProjects writes no
+// records (reset has nothing safe to delete). It must not error so the
+// rest of the reset plan can still run (resetGlobalSettings etc.).
+func TestGetCreatedProjects_NoMigrateRunIsNoOp(t *testing.T) {
+	cloudSrv := newMockCloudServer()
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["getCreatedProjects"].Run(context.Background(), e); err != nil {
+		t.Fatalf("getCreatedProjects: %v", err)
+	}
+	items, _ := e.Store.ReadAll("getCreatedProjects")
+	if len(items) != 0 {
+		t.Errorf("expected no records when there are no migrate runs, got %d", len(items))
 	}
 }
 


### PR DESCRIPTION
## Summary
Reset used to fire on `Enter` after a single warning line — and worse, it then enumerated **every** project in every cloud org via `/api/projects/search`, wiping pre-existing / manually-provisioned / externally-imported projects the migrate tool had never touched. This PR adds two safety layers:

### 1. Interactive confirmation prompt
After the credential check, reset prints each mapped SonarCloud org with its migrate-created project count and asks the operator to type the org keys they want to reset:

```
The following SonarCloud organizations are targeted by this reset:
  - latest-gh (6 projects)
  - latest-gl (3 projects)
  - latest-others (3 projects)
  - latest-unbound (65 projects)

Type the org keys to reset (whitespace-separated), or press [Enter] to abort:
```

- Whitespace-separated input, multi-space collapsing, dedup of typed keys.
- Unknown / misspelled keys → loud error naming the value.
- Enter alone or EOF → clean abort, no destructive work done.
- New `--yes` flag bypasses the prompt for non-interactive callers.

The confirmed subset is plumbed via `ResetConfig.ConfirmedOrgs` → `Executor.ResetConfirmedOrgs`. `loadCSVToJSONL` (the shared loader behind every `generate*Mappings` task) rewrites the `sonarcloud_org_key` of un-confirmed rows to the existing `SKIPPED` sentinel, so the existing `shouldSkipOrg` check at every per-org reset/delete task site naturally excludes them — no per-task plumbing required.

### 2. Scope project deletion to migrate-created projects
`runGetCreatedProjects` used to call `/api/projects/search?organization=<org>` and feed every cloud project to `deleteProjects`. It now:
- Unions every prior migrate run's `createProjects` JSONL output (run dirs identified by `run_meta.json`; reset runs use `clear.json` so they're ignored).
- Dedups by `cloud_project_key`.
- Filters by `Executor.ResetConfirmedOrgs`.
- Emits `{key:<cloud_project_key>, sonarcloud_org_key, source_key, server_url}` per project — `key` carrying the cloud key matches what `deleteProjects` extracts.

A new exported helper `migrate.MigrateCreatedProjectCounts(exportDir)` powers the prompt count so **what reset displays ≡ what reset deletes**.

Fixes #381.

## Test plan
- [x] `go test ./...` — full suite green, including 9 new cases for `confirmResetOrgs` (happy path, multi-space, empty/EOF abort, unknown key, dedup, `--yes`, SKIPPED filter, missing CSV), a 3-case loader-filter table for `loadCSVToJSONL`, and 3 new `getCreatedProjects` tests (union across migrate runs, `ResetConfirmedOrgs` filter, no-migrate-run no-op).
- [x] Manual against a real `migration-files-ee/` with 4 SQC orgs (latest-gh / latest-gl / latest-others / latest-unbound):
  - Counts displayed match what migrate actually created (e.g., latest-gl: 3, latest-unbound: 65 — not 2 / 66 from the structure phase).
  - Typing only a subset wipes only those orgs; the other orgs' projects survive.
  - Pre-existing (non-migrate-created) projects in a confirmed org are no longer wiped.
  - Empty Enter aborts cleanly.
  - Misspelled key errors out before any destructive work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
