### PR TITLE
Issue #388: gui command honors --config

### DIFF
--- a/go/cmd/gui.go
+++ b/go/cmd/gui.go
@@ -13,7 +13,9 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/sonar-solutions/sonar-migration-tool/internal/extract"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/gui"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/wizard"
 	"github.com/spf13/cobra"
 )
@@ -29,10 +31,14 @@ func init() {
 	guiCmd.Flags().String("export_directory", DefaultExportDirectory, "Root directory to output the export")
 	guiCmd.Flags().String("addr", "localhost:0", "Address to bind the HTTP server (default: random port)")
 	guiCmd.Flags().Bool("no-browser", false, "Do not open the browser automatically")
+	guiCmd.Flags().StringP("config", "c", "", "Path to JSON configuration file (same shape as extract / migrate / transfer). Pre-fills the wizard form with the URLs, enterprise key, and tokens it carries.")
 }
 
 func runGUI(cmd *cobra.Command, args []string) error {
-	exportDir, _ := cmd.Flags().GetString("export_directory")
+	exportDir, seed, err := resolveGUIDefaults(cmd)
+	if err != nil {
+		return err
+	}
 	addr, _ := cmd.Flags().GetString("addr")
 	noBrowser, _ := cmd.Flags().GetBool("no-browser")
 
@@ -72,7 +78,7 @@ func runGUI(cmd *cobra.Command, args []string) error {
 		hub.SetPrompter(prompter)
 		hub.Send(gui.ServerMessage{Type: gui.TypeWizardStarted})
 
-		go runWizardAsync(wizCtx, prompter, hub, exportDir, &wizMu, &wizActive)
+		go runWizardAsync(wizCtx, prompter, hub, exportDir, seed, &wizMu, &wizActive)
 	}
 
 	hub.OnCancelWizard = func() {
@@ -95,8 +101,8 @@ func runGUI(cmd *cobra.Command, args []string) error {
 	return <-errCh
 }
 
-func runWizardAsync(ctx context.Context, prompter *gui.WebPrompter, hub *gui.Hub, exportDir string, mu *sync.Mutex, active *bool) {
-	err := wizard.Run(ctx, prompter, exportDir)
+func runWizardAsync(ctx context.Context, prompter *gui.WebPrompter, hub *gui.Hub, exportDir string, seed *wizard.WizardState, mu *sync.Mutex, active *bool) {
+	err := wizard.RunWithSeed(ctx, prompter, exportDir, seed)
 
 	mu.Lock()
 	*active = false
@@ -112,6 +118,67 @@ func runWizardAsync(ctx context.Context, prompter *gui.WebPrompter, hub *gui.Hub
 		}
 	}
 	hub.Send(msg)
+}
+
+// resolveGUIDefaults reads --config (if any) plus --export_directory
+// and returns the export dir to use plus a wizard seed for the URLs
+// + tokens + enterprise key the config carries. Returns (exportDir,
+// nil, nil) when --config is absent — the wizard then starts with a
+// blank form, preserving the pre-#388 behaviour.
+//
+// Precedence:
+//   - --export_directory wins over config's export_directory when
+//     explicitly set on the CLI (matches the transfer command).
+//   - The seed is never persisted to disk in full — tokens travel
+//     in-memory only; URL fields end up on disk only when the wizard
+//     itself records them during a phase.
+func resolveGUIDefaults(cmd *cobra.Command) (string, *wizard.WizardState, error) {
+	exportDir, _ := cmd.Flags().GetString("export_directory")
+	configFile, _ := cmd.Flags().GetString("config")
+	if configFile == "" {
+		return exportDir, nil, nil
+	}
+
+	extractCfg, err := extract.LoadExtractConfigFile(configFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("loading --config: %w", err)
+	}
+	migrateCfg, err := migrate.LoadMigrateConfigFile(configFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("loading --config: %w", err)
+	}
+
+	if !cmd.Flags().Changed("export_directory") {
+		switch {
+		case extractCfg.ExportDirectory != "":
+			exportDir = extractCfg.ExportDirectory
+		case migrateCfg.ExportDirectory != "":
+			exportDir = migrateCfg.ExportDirectory
+		}
+	}
+
+	seed := &wizard.WizardState{}
+	if extractCfg.URL != "" {
+		v := extractCfg.URL
+		seed.SourceURL = &v
+	}
+	if extractCfg.Token != "" {
+		v := extractCfg.Token
+		seed.SourceToken = &v
+	}
+	if migrateCfg.URL != "" {
+		v := migrateCfg.URL
+		seed.TargetURL = &v
+	}
+	if migrateCfg.Token != "" {
+		v := migrateCfg.Token
+		seed.TargetToken = &v
+	}
+	if migrateCfg.EnterpriseKey != "" {
+		v := migrateCfg.EnterpriseKey
+		seed.EnterpriseKey = &v
+	}
+	return exportDir, seed, nil
 }
 
 func openBrowserWhenReady(ctx context.Context, srv *gui.Server) {

--- a/go/cmd/gui_test.go
+++ b/go/cmd/gui_test.go
@@ -1,0 +1,169 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+// newGUITestCmd mirrors guiCmd's flag set so resolveGUIDefaults can be
+// exercised in isolation, without bringing up the HTTP server.
+func newGUITestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "gui"}
+	f := cmd.Flags()
+	f.String("export_directory", DefaultExportDirectory, "")
+	f.String("addr", "localhost:0", "")
+	f.Bool("no-browser", false, "")
+	f.StringP("config", "c", "", "")
+	return cmd
+}
+
+func writeGUIConfig(t *testing.T, contents string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "cfg.json")
+	if err := os.WriteFile(p, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// #388: with no --config, resolveGUIDefaults must return the configured
+// export directory and a nil seed so the wizard behaves exactly as it
+// did before the flag was added — a fresh blank form.
+func TestResolveGUIDefaults_NoConfig(t *testing.T) {
+	cmd := newGUITestCmd()
+	exportDir, seed, err := resolveGUIDefaults(cmd)
+	if err != nil {
+		t.Fatalf("resolveGUIDefaults: %v", err)
+	}
+	if seed != nil {
+		t.Errorf("expected nil seed when --config absent, got %+v", seed)
+	}
+	if exportDir != DefaultExportDirectory {
+		t.Errorf("exportDir: got %q, want %q", exportDir, DefaultExportDirectory)
+	}
+}
+
+// #388: with --config pointing at a unified-shape config, the seed
+// carries every URL, token, and enterprise key the file declares.
+func TestResolveGUIDefaults_UnifiedShapeFillsSeed(t *testing.T) {
+	path := writeGUIConfig(t, `{
+		"export_directory": "/tmp/from-cfg",
+		"source": {
+			"url": "https://sq.example.com",
+			"token": "sq-token"
+		},
+		"target": {
+			"url": "https://sonarcloud.io/",
+			"token": "sc-token",
+			"enterprise_key": "ent-key"
+		}
+	}`)
+
+	cmd := newGUITestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+	exportDir, seed, err := resolveGUIDefaults(cmd)
+	if err != nil {
+		t.Fatalf("resolveGUIDefaults: %v", err)
+	}
+	if exportDir != "/tmp/from-cfg" {
+		t.Errorf("exportDir: got %q, want /tmp/from-cfg (from config)", exportDir)
+	}
+	if seed == nil {
+		t.Fatal("expected seed populated from config, got nil")
+	}
+	assertSeedStringField(t, "SourceURL", seed.SourceURL, "https://sq.example.com")
+	assertSeedStringField(t, "SourceToken", seed.SourceToken, "sq-token")
+	assertSeedStringField(t, "TargetURL", seed.TargetURL, "https://sonarcloud.io/")
+	assertSeedStringField(t, "TargetToken", seed.TargetToken, "sc-token")
+	assertSeedStringField(t, "EnterpriseKey", seed.EnterpriseKey, "ent-key")
+}
+
+// #388: --export_directory on the CLI must win over the config-file
+// value, mirroring the precedence the transfer command uses.
+func TestResolveGUIDefaults_CLIExportDirWinsOverConfig(t *testing.T) {
+	path := writeGUIConfig(t, `{
+		"export_directory": "/tmp/from-cfg",
+		"source": {"url": "https://sq", "token": "t"},
+		"target": {"url": "https://sc", "token": "t"}
+	}`)
+	cmd := newGUITestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path, "--export_directory", "/tmp/from-cli"}); err != nil {
+		t.Fatal(err)
+	}
+	exportDir, _, err := resolveGUIDefaults(cmd)
+	if err != nil {
+		t.Fatalf("resolveGUIDefaults: %v", err)
+	}
+	if exportDir != "/tmp/from-cli" {
+		t.Errorf("exportDir: got %q, want /tmp/from-cli (CLI wins)", exportDir)
+	}
+}
+
+// #388: a config with no export_directory leaves the default in place,
+// and seed fields the config didn't carry stay nil.
+func TestResolveGUIDefaults_MissingFieldsLeaveSeedFieldNil(t *testing.T) {
+	path := writeGUIConfig(t, `{
+		"source": {"url": "https://sq"}
+	}`)
+	cmd := newGUITestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+	exportDir, seed, err := resolveGUIDefaults(cmd)
+	if err != nil {
+		t.Fatalf("resolveGUIDefaults: %v", err)
+	}
+	if exportDir != DefaultExportDirectory {
+		t.Errorf("exportDir: got %q, want default %q", exportDir, DefaultExportDirectory)
+	}
+	if seed == nil {
+		t.Fatal("expected non-nil seed when --config is set")
+	}
+	assertSeedStringField(t, "SourceURL", seed.SourceURL, "https://sq")
+	if seed.SourceToken != nil {
+		t.Errorf("SourceToken: got %v, want nil (config didn't carry it)", seed.SourceToken)
+	}
+	if seed.TargetURL != nil {
+		t.Errorf("TargetURL: got %v, want nil", seed.TargetURL)
+	}
+	if seed.TargetToken != nil {
+		t.Errorf("TargetToken: got %v, want nil", seed.TargetToken)
+	}
+	if seed.EnterpriseKey != nil {
+		t.Errorf("EnterpriseKey: got %v, want nil", seed.EnterpriseKey)
+	}
+}
+
+// #388: a malformed --config returns an error (better than silently
+// running with a blank form when the operator clearly intended to
+// pre-fill it).
+func TestResolveGUIDefaults_MalformedConfigErrors(t *testing.T) {
+	path := writeGUIConfig(t, `{ not valid json `)
+	cmd := newGUITestCmd()
+	if err := cmd.ParseFlags([]string{"-c", path}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resolveGUIDefaults(cmd); err == nil {
+		t.Fatal("expected error on malformed --config, got nil")
+	}
+}
+
+func assertSeedStringField(t *testing.T, field string, got *string, want string) {
+	t.Helper()
+	if got == nil {
+		t.Errorf("%s: got nil, want %q", field, want)
+		return
+	}
+	if *got != want {
+		t.Errorf("%s: got %q, want %q", field, *got, want)
+	}
+}

--- a/go/internal/wizard/phases.go
+++ b/go/internal/wizard/phases.go
@@ -70,9 +70,15 @@ func promptExtractCredentials(p Prompter, state *WizardState) (string, string, e
 			}
 		}
 
-		token, err := p.PromptPassword("Admin token:")
-		if err != nil {
-			return "", "", err
+		// #388: --config can pre-fill the token; only prompt when it
+		// hasn't been seeded.
+		token := ptrStr(state.SourceToken)
+		if token == "" {
+			var err error
+			token, err = p.PromptPassword("Admin token:")
+			if err != nil {
+				return "", "", err
+			}
 		}
 
 		ok, err := p.ConfirmReview("Source Server Credentials", []KV{
@@ -86,6 +92,9 @@ func promptExtractCredentials(p Prompter, state *WizardState) (string, string, e
 			return sourceURL, token, nil
 		}
 		state.SourceURL = nil
+		// Reject + re-prompt for the token too — operator may have
+		// confirmed because the typed value was wrong.
+		state.SourceToken = nil
 	}
 }
 
@@ -409,9 +418,15 @@ func phaseMigrate(ctx context.Context, p Prompter, state *WizardState, exportDir
 		return fmt.Errorf("migration declined by user")
 	}
 
-	token, err := p.PromptPassword("Cloud admin token:")
-	if err != nil {
-		return err
+	// #388: --config can pre-fill the cloud token; only prompt when
+	// the wizard wasn't seeded with one.
+	token := ptrStr(state.TargetToken)
+	if token == "" {
+		var err error
+		token, err = p.PromptPassword("Cloud admin token:")
+		if err != nil {
+			return err
+		}
 	}
 
 	return runMigrateWithRetry(ctx, p, state, exportDir, token)

--- a/go/internal/wizard/state.go
+++ b/go/internal/wizard/state.go
@@ -29,16 +29,27 @@ const (
 
 // WizardState holds the persistent state of a migration wizard session.
 // JSON serialization persists to .wizard_state.json for resume support.
+//
+// SourceToken / TargetToken are deliberately tagged json:"-" so they
+// never reach disk. They exist only so `gui --config <file>` (#388)
+// can pre-fill the corresponding password prompts in memory via
+// RunWithSeed — the wizard reads them when present and prompts
+// otherwise. Resume reloads the state from disk, where these fields
+// will be empty, and the user is asked to retype the tokens.
 type WizardState struct {
-	Phase              WizardPhase `json:"phase"`
-	ExtractID          *string     `json:"extract_id"`
-	SourceURL          *string     `json:"source_url"`
-	TargetURL          *string     `json:"target_url"`
-	EnterpriseKey      *string     `json:"enterprise_key"`
-	OrganizationsMapped bool       `json:"organizations_mapped"`
-	ValidationPassed   bool        `json:"validation_passed"`
-	MigrationRunID     *string     `json:"migration_run_id"`
-	SkippedProjects    []string    `json:"skipped_projects,omitempty"`
+	Phase               WizardPhase `json:"phase"`
+	ExtractID           *string     `json:"extract_id"`
+	SourceURL           *string     `json:"source_url"`
+	TargetURL           *string     `json:"target_url"`
+	EnterpriseKey       *string     `json:"enterprise_key"`
+	OrganizationsMapped bool        `json:"organizations_mapped"`
+	ValidationPassed    bool        `json:"validation_passed"`
+	MigrationRunID      *string     `json:"migration_run_id"`
+	SkippedProjects     []string    `json:"skipped_projects,omitempty"`
+
+	// Tokens — in-memory only. See type-level comment for rationale.
+	SourceToken *string `json:"-"`
+	TargetToken *string `json:"-"`
 }
 
 // NewWizardState returns a WizardState initialized to the INIT phase.

--- a/go/internal/wizard/wizard.go
+++ b/go/internal/wizard/wizard.go
@@ -13,6 +13,18 @@ import (
 // Run is the main entry point for the wizard. It loads state, handles
 // resume, and runs phases sequentially until complete or interrupted.
 func Run(ctx context.Context, p Prompter, exportDir string) error {
+	return RunWithSeed(ctx, p, exportDir, nil)
+}
+
+// RunWithSeed is the same as Run but pre-fills the in-memory state
+// with values from `seed` before prompting. Disk state wins over the
+// seed — re-running `gui --config <file>` against a partially
+// completed wizard never silently rewrites progress. Tokens carried
+// in the seed (SourceToken / TargetToken) are merged into the
+// in-memory state only; they are NEVER persisted to
+// .wizard_state.json. The cmd/gui.go config-load path uses this to
+// honour `--config` per issue #388.
+func RunWithSeed(ctx context.Context, p Prompter, exportDir string, seed *WizardState) error {
 	if err := os.MkdirAll(exportDir, 0o755); err != nil {
 		return fmt.Errorf("creating export directory: %w", err)
 	}
@@ -22,6 +34,9 @@ func Run(ctx context.Context, p Prompter, exportDir string) error {
 	state, err := Load(exportDir)
 	if err != nil {
 		return fmt.Errorf("loading wizard state: %w", err)
+	}
+	if seed != nil {
+		mergeSeed(state, seed)
 	}
 
 	state, shouldContinue := handleResume(p, state, exportDir)
@@ -35,6 +50,31 @@ func Run(ctx context.Context, p Prompter, exportDir string) error {
 	}
 
 	return runPhaseLoop(ctx, p, state, exportDir, startPhase)
+}
+
+// mergeSeed copies any field from seed into state when state's
+// corresponding field is unset. The disk-wins rule preserves resume
+// semantics: a previously-completed phase keeps the values it
+// recorded even if a new --config supplies different ones.
+func mergeSeed(state, seed *WizardState) {
+	if state.SourceURL == nil && seed.SourceURL != nil && *seed.SourceURL != "" {
+		state.SourceURL = seed.SourceURL
+	}
+	if state.TargetURL == nil && seed.TargetURL != nil && *seed.TargetURL != "" {
+		state.TargetURL = seed.TargetURL
+	}
+	if state.EnterpriseKey == nil && seed.EnterpriseKey != nil && *seed.EnterpriseKey != "" {
+		state.EnterpriseKey = seed.EnterpriseKey
+	}
+	// Tokens are always seeded when supplied — disk never has them
+	// (json:"-"), so the "disk wins" rule degenerates to "seed wins
+	// when present" for these two fields.
+	if seed.SourceToken != nil && *seed.SourceToken != "" {
+		state.SourceToken = seed.SourceToken
+	}
+	if seed.TargetToken != nil && *seed.TargetToken != "" {
+		state.TargetToken = seed.TargetToken
+	}
 }
 
 // handleResume prompts the user when a previous session exists.

--- a/go/internal/wizard/wizard_test.go
+++ b/go/internal/wizard/wizard_test.go
@@ -514,3 +514,142 @@ func writeExtractMeta(t *testing.T, dir string) {
 	data, _ := json.Marshal(meta)
 	os.WriteFile(filepath.Join(extractDir, "extract.json"), data, 0o644)
 }
+
+// #388: mergeSeed pre-fills wizard state fields from a config-driven
+// seed without clobbering values the wizard has already recorded
+// (disk-wins semantics for the URL / enterprise-key triple). Tokens
+// always come from the seed because the on-disk state never carries
+// them (json:"-").
+func TestMergeSeed(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+
+	cases := []struct {
+		name  string
+		state WizardState
+		seed  WizardState
+		want  WizardState
+	}{
+		{
+			name:  "empty state — every seed field applied",
+			state: WizardState{},
+			seed: WizardState{
+				SourceURL:     strPtr("https://sq"),
+				TargetURL:     strPtr("https://sc"),
+				EnterpriseKey: strPtr("ent"),
+				SourceToken:   strPtr("sq-tok"),
+				TargetToken:   strPtr("sc-tok"),
+			},
+			want: WizardState{
+				SourceURL:     strPtr("https://sq"),
+				TargetURL:     strPtr("https://sc"),
+				EnterpriseKey: strPtr("ent"),
+				SourceToken:   strPtr("sq-tok"),
+				TargetToken:   strPtr("sc-tok"),
+			},
+		},
+		{
+			name: "existing URL wins, seed token still applied",
+			state: WizardState{
+				SourceURL:     strPtr("disk-sq"),
+				TargetURL:     strPtr("disk-sc"),
+				EnterpriseKey: strPtr("disk-ent"),
+			},
+			seed: WizardState{
+				SourceURL:     strPtr("seed-sq"),
+				TargetURL:     strPtr("seed-sc"),
+				EnterpriseKey: strPtr("seed-ent"),
+				SourceToken:   strPtr("sq-tok"),
+				TargetToken:   strPtr("sc-tok"),
+			},
+			want: WizardState{
+				SourceURL:     strPtr("disk-sq"),
+				TargetURL:     strPtr("disk-sc"),
+				EnterpriseKey: strPtr("disk-ent"),
+				SourceToken:   strPtr("sq-tok"),
+				TargetToken:   strPtr("sc-tok"),
+			},
+		},
+		{
+			name: "partial fill — only nil fields touched",
+			state: WizardState{
+				SourceURL: strPtr("disk-sq"),
+			},
+			seed: WizardState{
+				SourceURL:     strPtr("seed-sq"),
+				TargetURL:     strPtr("seed-sc"),
+				EnterpriseKey: strPtr("seed-ent"),
+			},
+			want: WizardState{
+				SourceURL:     strPtr("disk-sq"),
+				TargetURL:     strPtr("seed-sc"),
+				EnterpriseKey: strPtr("seed-ent"),
+			},
+		},
+		{
+			name:  "empty-string seed values are no-ops",
+			state: WizardState{},
+			seed: WizardState{
+				SourceURL:     strPtr(""),
+				TargetURL:     strPtr(""),
+				EnterpriseKey: strPtr(""),
+				SourceToken:   strPtr(""),
+				TargetToken:   strPtr(""),
+			},
+			want: WizardState{},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			state := c.state
+			mergeSeed(&state, &c.seed)
+			assertPtrEqual(t, "SourceURL", state.SourceURL, c.want.SourceURL)
+			assertPtrEqual(t, "TargetURL", state.TargetURL, c.want.TargetURL)
+			assertPtrEqual(t, "EnterpriseKey", state.EnterpriseKey, c.want.EnterpriseKey)
+			assertPtrEqual(t, "SourceToken", state.SourceToken, c.want.SourceToken)
+			assertPtrEqual(t, "TargetToken", state.TargetToken, c.want.TargetToken)
+		})
+	}
+}
+
+// #388: tokens carried in the wizard state must never reach
+// .wizard_state.json — they're json:"-" so Save() drops them. Resume
+// reloads the file and gets nil tokens.
+func TestWizardState_TokensNotPersisted(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	dir := t.TempDir()
+	state := &WizardState{
+		SourceURL:   strPtr("https://sq"),
+		SourceToken: strPtr("secret-sq"),
+		TargetToken: strPtr("secret-sc"),
+	}
+	if err := state.Save(dir); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	reloaded, err := Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if reloaded.SourceToken != nil {
+		t.Errorf("SourceToken must not persist; got %q on disk", *reloaded.SourceToken)
+	}
+	if reloaded.TargetToken != nil {
+		t.Errorf("TargetToken must not persist; got %q on disk", *reloaded.TargetToken)
+	}
+	if reloaded.SourceURL == nil || *reloaded.SourceURL != "https://sq" {
+		t.Errorf("SourceURL did not round-trip; got %v", reloaded.SourceURL)
+	}
+}
+
+func assertPtrEqual(t *testing.T, field string, got, want *string) {
+	t.Helper()
+	switch {
+	case got == nil && want == nil:
+		return
+	case got == nil:
+		t.Errorf("%s: got nil, want %q", field, *want)
+	case want == nil:
+		t.Errorf("%s: got %q, want nil", field, *got)
+	case *got != *want:
+		t.Errorf("%s: got %q, want %q", field, *got, *want)
+	}
+}


### PR DESCRIPTION
## Summary
Every other top-level command (`extract`, `migrate`, `reset`, `transfer`) accepts `--config <file>` and reads its starting values from the same JSON shapes — but `gui` made you retype the source URL, target URL, enterprise key, and tokens into the wizard even when a working `config-*.json` was already on disk.

This PR adds `-c / --config` to the `gui` command. When supplied:

- `extract.LoadExtractConfigFile` + `migrate.LoadMigrateConfigFile` parse the same flat / command-sectioned / side-sectioned / unified shapes the rest of the CLI accepts (no new schema).
- A `wizard.WizardState` **seed** is built and threaded into a new `wizard.RunWithSeed` entry point. `mergeSeed` applies:
  - **Disk wins** for URL / enterprise-key fields → resume after a partial run still keeps whatever the operator typed.
  - **Seed wins** for tokens → the on-disk state never carries them (`json:"-"`), so the seed is the only source.
- `promptExtractCredentials` and the migrate-phase cloud-token prompt now consult `state.SourceToken` / `state.TargetToken` and skip the `PromptPassword` call when the wizard was seeded — addressing the "token should not be prompted if present in the config file" follow-up from the issue thread.
- `--export_directory` on the CLI wins over `export_directory` in the config, mirroring `transfer`.

Tokens stay in memory only; `.wizard_state.json` on disk continues to carry the non-secret fields. Resume reloads that file and re-prompts for the tokens when the seed isn't supplied again.

Fixes #388.

## Test plan
- [x] `go test ./...` — all packages green, with new coverage:
  - `TestMergeSeed` (4 cases: empty state / disk-wins / partial / empty-string no-op).
  - `TestWizardState_TokensNotPersisted` — Save+Load round-trip drops tokens.
  - `TestResolveGUIDefaults` (5 cases: no `--config`, unified shape, CLI override, missing fields, malformed config).
- [ ] Manual: `./sonar-migration-tool gui --config config-ee.json` → wizard's URL / enterprise-key / token prompts auto-fill from the config.
- [ ] Manual: `./sonar-migration-tool gui` (no config) → unchanged behaviour, blank form.
- [ ] Manual: re-run `gui --config config-ee.json` against an export dir holding a stale `.wizard_state.json` → resume prompt fires; existing state's URL survives even though the config has a different one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
