### PR TITLE
Bump version to v2026.06.12-BETA

### DIFF
--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -4,6 +4,6 @@
 
 package version
 
-const Version = "v2026.06.10-BETA"
+const Version = "v2026.06.12-BETA"
 
 const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary
- Bumps `Version` from `v2026.06.10-BETA` to `v2026.06.12-BETA` in `go/internal/version/version.go`.

## Test plan
- [ ] `go build ./...` succeeds
- [ ] `sonar-migration-tool --version` reports `v2026.06.12-BETA`

🤖 Generated with [Claude Code](https://claude.com/claude-code)