### PR TITLE
Issue #392: hotspot status sync uses (rule, line, offset) matching

### DIFF
--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -36,11 +36,22 @@ func hotspotMetadataSyncTasks() []TaskDef {
 
 // matchableHotspot is a normalised hotspot representation used for FIFO
 // matching between source (SonarQube Server) and target (SonarQube Cloud).
+//
+// Offset is the textRange.startOffset (column) and disambiguates
+// co-located hotspots on the same line (#392 follow-up). Two
+// hotspots of the same rule firing on different columns of the same
+// line — e.g., `sys.argv[1]` and `sys.argv[2]` on a single line —
+// must NOT be collapsed to a single representative; without an
+// offset key they would race and one cloud counterpart would
+// silently stay TO_REVIEW. Offset is 0 when the source data
+// predates `textRange` or the cloud endpoint omits it; callers
+// fall back to coarser matching in that case.
 type matchableHotspot struct {
 	Key        string
 	RuleKey    string
 	Component  string
 	Line       int
+	Offset     int
 	Status     string
 	Resolution string
 	Comments   []hotspotComment
@@ -122,12 +133,20 @@ func hotspotResolutionPriority(h matchableHotspot) int {
 }
 
 // dedupeActionableHotspots collapses cross-branch duplicate source
-// hotspots — same (component, ruleKey, line) but different SQS keys —
-// into a single representative whose Comments are the union of all
-// duplicates' comments. The representative carries the highest-
-// priority (most cautious) status/resolution per hotspotResolutionPriority
-// so an ACKNOWLEDGED branch always wins over a SAFE sibling. Iteration
-// order is stable (sorted by source key) so the result is deterministic.
+// hotspots — same (component, ruleKey, line, offset) but different
+// SQS keys — into a single representative whose Comments are the
+// union of all duplicates' comments. The representative carries the
+// highest-priority (most cautious) status/resolution per
+// hotspotResolutionPriority so an ACKNOWLEDGED branch always wins
+// over a SAFE sibling. Iteration order is stable (sorted by source
+// key) so the result is deterministic.
+//
+// Offset is part of the key (#392 follow-up) so two hotspots of the
+// same rule firing on different columns of the same line — e.g.
+// `sys.argv[1]` and `sys.argv[2]` on a single line — stay as two
+// distinct source reps. Collapsing them caused half the cloud
+// counterparts to silently stay TO_REVIEW (live evidence:
+// 6 of 31 SAFE hotspots stuck on python:S4823).
 func dedupeActionableHotspots(in []matchableHotspot) []matchableHotspot {
 	if len(in) < 2 {
 		return in
@@ -136,6 +155,7 @@ func dedupeActionableHotspots(in []matchableHotspot) []matchableHotspot {
 		Component string
 		RuleKey   string
 		Line      int
+		Offset    int
 	}
 	sorted := make([]matchableHotspot, len(in))
 	copy(sorted, in)
@@ -145,7 +165,7 @@ func dedupeActionableHotspots(in []matchableHotspot) []matchableHotspot {
 	order := make([]groupKey, 0, len(sorted))
 	for i := range sorted {
 		h := sorted[i]
-		k := groupKey{Component: h.Component, RuleKey: h.RuleKey, Line: h.Line}
+		k := groupKey{Component: h.Component, RuleKey: h.RuleKey, Line: h.Line, Offset: h.Offset}
 		rep, ok := groups[k]
 		if !ok {
 			cp := h
@@ -358,7 +378,7 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, s
 			"project", cloudKey, "source_key", src.Key, "file", filePath)
 		return syncOutcomeLookupError
 	}
-	target, outcome := classifyHotspotCandidatesByLine(candidates, src.RuleKey, src.Line)
+	target, outcome := classifyHotspotCandidatesByLine(candidates, src.RuleKey, src.Line, src.Offset)
 	switch outcome {
 	case syncOutcomeSynced:
 		pair := hotspotPair{source: src, cloud: target}
@@ -382,7 +402,7 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, s
 	case syncOutcomeLineMismatch:
 		keys := make([]string, 0)
 		for _, c := range candidates {
-			if c.RuleKey == src.RuleKey && c.Line == src.Line {
+			if c.Line == src.Line && (c.RuleKey == "" || c.RuleKey == src.RuleKey) {
 				keys = append(keys, c.Key)
 			}
 		}
@@ -391,14 +411,82 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, s
 	return outcome
 }
 
-// classifyHotspotCandidatesByLine is the hotspot counterpart of
-// classifyIssueCandidatesByLine. The hotspot search isn't scoped by
-// rule on the cloud side, so we filter on (ruleKey, line) here.
-func classifyHotspotCandidatesByLine(candidates []matchableHotspot, sourceRule string, sourceLine int) (matchableHotspot, syncOutcome) {
+// classifyHotspotCandidatesByLine resolves a cloud counterpart for one
+// source hotspot from the per-file candidate set returned by
+// /api/hotspots/search?files=<filePath>.
+//
+// Three-phase match (#392 + follow-up):
+//
+//  1. PRECISE — (ruleKey, line, offset) match. textRange.startOffset
+//     disambiguates two hotspots of the same rule firing on different
+//     columns of the same line (e.g. `sys.argv[1]` and `sys.argv[2]`).
+//     Without it, those collapse to syncOutcomeLineMismatch and stay
+//     TO_REVIEW. Skipped when either side has Offset == 0 (older API
+//     shapes that omit textRange).
+//
+//  2. RULE+LINE — (ruleKey, line) match. The common case: rule
+//     populated on both sides, no column ambiguity needed. Restores
+//     the pre-offset behaviour that already covered 25 of the 31
+//     SAFE hotspots in the live run.
+//
+//  3. EMPTY-RULE FALLBACK — line-only against cloud candidates whose
+//     ruleKey is empty. The 2026-06-09 audit recorded a case where
+//     every cloud hotspot parsed with RuleKey == "" (per-version /
+//     per-endpoint omission); without this fallback the entire
+//     project's REVIEWED hotspots stay TO_REVIEW. Candidates with a
+//     non-empty ruleKey that doesn't match the source are deliberately
+//     NOT considered here — they're a different rule firing on the
+//     same line.
+//
+// Returns syncOutcomeSynced when exactly one candidate qualifies,
+// syncOutcomeLineMismatch when several do (caller skips rather than
+// guess), and syncOutcomeNotFound when none do.
+func classifyHotspotCandidatesByLine(candidates []matchableHotspot, sourceRule string, sourceLine, sourceOffset int) (matchableHotspot, syncOutcome) {
+	// Phase 1: precise (ruleKey, line, offset). Both sides must carry
+	// a non-zero offset for this phase to be considered.
+	if sourceOffset > 0 {
+		var pick matchableHotspot
+		matches := 0
+		for _, c := range candidates {
+			if c.RuleKey == sourceRule && c.Line == sourceLine && c.Offset > 0 && c.Offset == sourceOffset {
+				matches++
+				if matches == 1 {
+					pick = c
+				}
+			}
+		}
+		if matches == 1 {
+			return pick, syncOutcomeSynced
+		}
+		// matches == 0 (offset not present or no exact column hit) →
+		// fall through to phase 2. matches > 1 means duplicate offsets
+		// on the cloud (extremely unusual) — also fall through and let
+		// phase 2's rule+line check resolve to line_mismatch.
+	}
+
+	// Phase 2: (ruleKey, line) match.
 	var pick matchableHotspot
 	matches := 0
 	for _, c := range candidates {
 		if c.RuleKey == sourceRule && c.Line == sourceLine {
+			matches++
+			if matches == 1 {
+				pick = c
+			}
+		}
+	}
+	if matches > 0 {
+		if matches == 1 {
+			return pick, syncOutcomeSynced
+		}
+		return matchableHotspot{}, syncOutcomeLineMismatch
+	}
+
+	// Phase 3: cloud candidates with no ruleKey are eligible for a
+	// line-only fallback.
+	matches = 0
+	for _, c := range candidates {
+		if c.RuleKey == "" && c.Line == sourceLine {
 			matches++
 			if matches == 1 {
 				pick = c
@@ -650,6 +738,7 @@ func parseMatchableHotspot(data json.RawMessage) matchableHotspot {
 	status := extractField(data, "status")
 	resolution := extractField(data, "resolution")
 	line := extractHotspotLine(data)
+	offset := extractHotspotStartOffset(data)
 
 	// ruleKey may be at top level or nested inside a "rule" object.
 	ruleKey := extractField(data, "ruleKey")
@@ -664,6 +753,7 @@ func parseMatchableHotspot(data json.RawMessage) matchableHotspot {
 		RuleKey:    ruleKey,
 		Component:  component,
 		Line:       line,
+		Offset:     offset,
 		Status:     status,
 		Resolution: resolution,
 		Comments:   comments,
@@ -689,6 +779,35 @@ func extractHotspotLine(data json.RawMessage) int {
 	if json.Unmarshal(raw, &s) == nil {
 		n, _ := strconv.Atoi(s)
 		return n
+	}
+	return 0
+}
+
+// extractHotspotStartOffset reads the textRange.startOffset column
+// from a hotspot JSON object. Returns 0 when the field is absent —
+// callers MUST treat 0 as "unknown" rather than "column 0" so the
+// matcher's offset-based disambiguation falls back gracefully on
+// older API shapes.
+func extractHotspotStartOffset(data json.RawMessage) int {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return 0
+	}
+	tr, ok := obj["textRange"]
+	if !ok {
+		return 0
+	}
+	var inner map[string]json.RawMessage
+	if err := json.Unmarshal(tr, &inner); err != nil {
+		return 0
+	}
+	raw, ok := inner["startOffset"]
+	if !ok {
+		return 0
+	}
+	var v int
+	if json.Unmarshal(raw, &v) == nil {
+		return v
 	}
 	return 0
 }

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -47,63 +47,176 @@ func TestHotspotHasManualChanges(t *testing.T) {
 	}
 }
 
-// #356: hotspot classifier uses (ruleKey, line) because /api/hotspots/search
-// doesn't accept a rules filter — we fetch by file and resolve in
-// memory. 1 → synced, 0 → not_found, n>1 → line_mismatch; mismatched
-// rules / lines are skipped.
+// #392: the hotspot classifier is three-phase:
+//
+//  1. Precise (ruleKey, line, offset) — disambiguates co-located
+//     hotspots of the same rule on different columns (sys.argv[1] and
+//     sys.argv[2] on a single line). Only considered when both sides
+//     carry a non-zero offset.
+//  2. (ruleKey, line) — covers the common case where rule is enough.
+//  3. Empty-ruleKey line-only — fallback for the 2026-06-09 audit
+//     case where the cloud response omits ruleKey.
 func TestClassifyHotspotCandidatesByLine(t *testing.T) {
-	cand := func(key, rule string, line int) matchableHotspot {
-		return matchableHotspot{Key: key, RuleKey: rule, Line: line}
+	cand := func(key, rule string, line, offset int) matchableHotspot {
+		return matchableHotspot{Key: key, RuleKey: rule, Line: line, Offset: offset}
 	}
 	tests := []struct {
-		name        string
-		candidates  []matchableHotspot
-		sourceRule  string
-		sourceLine  int
-		wantKey     string
-		wantOutcome syncOutcome
+		name         string
+		candidates   []matchableHotspot
+		sourceRule   string
+		sourceLine   int
+		sourceOffset int
+		wantKey      string
+		wantOutcome  syncOutcome
 	}{
+		// --- Phase 1: precise (rule, line, offset) ---
 		{
-			name:        "exactly one rule+line match — synced (a)",
-			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 42)},
-			sourceRule:  "javasecurity:S1",
-			sourceLine:  42,
-			wantKey:     "h-1",
-			wantOutcome: syncOutcomeSynced,
+			// Live scenario from #392 follow-up: two cloud hotspots of
+			// the same rule on the same line, different startOffsets.
+			// Without offset they collapse to line_mismatch; with it,
+			// each source resolves cleanly to its column-matched peer.
+			name: "co-located cloud hotspots disambiguated by offset",
+			candidates: []matchableHotspot{
+				cand("h-MF", "python:S4823", 35, 35),
+				cand("h-MG", "python:S4823", 35, 17),
+			},
+			sourceRule:   "python:S4823",
+			sourceLine:   35,
+			sourceOffset: 17,
+			wantKey:      "h-MG",
+			wantOutcome:  syncOutcomeSynced,
 		},
 		{
-			name:        "match among other rules on same file — synced (a)",
-			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 10), cand("h-2", "javasecurity:S1", 42), cand("h-3", "javasecurity:S2", 42)},
-			sourceRule:  "javasecurity:S1",
-			sourceLine:  42,
-			wantKey:     "h-2",
-			wantOutcome: syncOutcomeSynced,
+			// Same call shape, source on the OTHER column.
+			name: "co-located cloud hotspots — pick by offset 35",
+			candidates: []matchableHotspot{
+				cand("h-MF", "python:S4823", 35, 35),
+				cand("h-MG", "python:S4823", 35, 17),
+			},
+			sourceRule:   "python:S4823",
+			sourceLine:   35,
+			sourceOffset: 35,
+			wantKey:      "h-MF",
+			wantOutcome:  syncOutcomeSynced,
+		},
+
+		// --- Phase 2: (rule, line) match (offset unavailable / zero) ---
+		{
+			name:         "exact rule + line match — synced (offset absent)",
+			candidates:   []matchableHotspot{cand("h-1", "javasecurity:S1", 42, 0)},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantKey:      "h-1",
+			wantOutcome:  syncOutcomeSynced,
 		},
 		{
-			name:        "two same-rule+line — line_mismatch (b)",
-			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 42), cand("h-2", "javasecurity:S1", 42)},
-			sourceRule:  "javasecurity:S1",
-			sourceLine:  42,
-			wantOutcome: syncOutcomeLineMismatch,
+			name: "rule disambiguates among same-line candidates (#392 regression guard)",
+			candidates: []matchableHotspot{
+				cand("h-1", "javasecurity:S1", 42, 0),
+				cand("h-2", "javasecurity:S2", 42, 0),
+			},
+			sourceRule:   "javasecurity:S2",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantKey:      "h-2",
+			wantOutcome:  syncOutcomeSynced,
 		},
 		{
-			name:        "different rule on the line — not_found (c)",
-			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S2", 42)},
-			sourceRule:  "javasecurity:S1",
-			sourceLine:  42,
-			wantOutcome: syncOutcomeNotFound,
+			name: "two same-rule same-line candidates with NO offset — line_mismatch",
+			candidates: []matchableHotspot{
+				cand("h-1", "javasecurity:S1", 42, 0),
+				cand("h-2", "javasecurity:S1", 42, 0),
+			},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantOutcome:  syncOutcomeLineMismatch,
 		},
 		{
-			name:        "rule matches but on different line — not_found (c)",
-			candidates:  []matchableHotspot{cand("h-1", "javasecurity:S1", 40)},
-			sourceRule:  "javasecurity:S1",
-			sourceLine:  42,
-			wantOutcome: syncOutcomeNotFound,
+			// Source has offset but cloud doesn't — phase 1 yields
+			// nothing, phase 2 falls back and picks the single
+			// rule+line match.
+			name: "source has offset, cloud doesn't — phase 2 still resolves",
+			candidates: []matchableHotspot{
+				cand("h-1", "javasecurity:S1", 42, 0),
+			},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 17,
+			wantKey:      "h-1",
+			wantOutcome:  syncOutcomeSynced,
+		},
+
+		// --- Phase 3: empty-ruleKey fallback ---
+		{
+			name:         "empty-ruleKey candidate falls back to line-only — synced",
+			candidates:   []matchableHotspot{cand("h-1", "", 42, 0)},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantKey:      "h-1",
+			wantOutcome:  syncOutcomeSynced,
+		},
+		{
+			name: "two empty-ruleKey candidates on the same line — line_mismatch",
+			candidates: []matchableHotspot{
+				cand("h-1", "", 42, 0),
+				cand("h-2", "", 42, 0),
+			},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantOutcome:  syncOutcomeLineMismatch,
+		},
+		{
+			// Non-empty cloud rule that doesn't match the source's rule
+			// must NOT be picked by phase 3.
+			name: "non-matching cloud rule on the line — not picked by fallback",
+			candidates: []matchableHotspot{
+				cand("h-1", "javasecurity:S2", 42, 0),
+			},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantOutcome:  syncOutcomeNotFound,
+		},
+		{
+			// Earlier phase wins: a precise rule+line match must not
+			// be undone by an empty-rule candidate on the same line.
+			name: "phase 2 match wins over phase 3 candidate on same line",
+			candidates: []matchableHotspot{
+				cand("h-1", "javasecurity:S1", 42, 0),
+				cand("h-2", "", 42, 0),
+			},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantKey:      "h-1",
+			wantOutcome:  syncOutcomeSynced,
+		},
+
+		// --- General negatives ---
+		{
+			name:         "no candidate on the source line — not_found",
+			candidates:   []matchableHotspot{cand("h-1", "javasecurity:S1", 40, 0)},
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantOutcome:  syncOutcomeNotFound,
+		},
+		{
+			name:         "empty candidate set — not_found",
+			candidates:   nil,
+			sourceRule:   "javasecurity:S1",
+			sourceLine:   42,
+			sourceOffset: 0,
+			wantOutcome:  syncOutcomeNotFound,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, outcome := classifyHotspotCandidatesByLine(tc.candidates, tc.sourceRule, tc.sourceLine)
+			got, outcome := classifyHotspotCandidatesByLine(tc.candidates, tc.sourceRule, tc.sourceLine, tc.sourceOffset)
 			if outcome != tc.wantOutcome {
 				t.Errorf("outcome = %v, want %v", outcome, tc.wantOutcome)
 			}
@@ -397,6 +510,32 @@ func TestDedupeActionableHotspotsNoCollisions(t *testing.T) {
 	out := dedupeActionableHotspots(in)
 	if len(out) != 4 {
 		t.Errorf("expected 4 distinct groups (no dedup), got %d", len(out))
+	}
+}
+
+// #392 follow-up: two hotspots of the same rule firing on different
+// columns of the same line (e.g. sys.argv[1] and sys.argv[2]) must
+// stay as TWO distinct source reps post-dedup. Cross-branch copies
+// of the SAME (component, rule, line, offset) still collapse.
+func TestDedupeActionableHotspotsOffsetDistinguishesCoLocated(t *testing.T) {
+	in := []matchableHotspot{
+		// Branch main: two hotspots at line 35, columns 17 and 35.
+		{Key: "main-a", Component: "p:f.py", RuleKey: "py:S4823", Line: 35, Offset: 17, Status: "REVIEWED", Resolution: "SAFE"},
+		{Key: "main-b", Component: "p:f.py", RuleKey: "py:S4823", Line: 35, Offset: 35, Status: "REVIEWED", Resolution: "SAFE"},
+		// Branch develop: same two hotspots — should collapse with main's siblings.
+		{Key: "dev-a", Component: "p:f.py", RuleKey: "py:S4823", Line: 35, Offset: 17, Status: "REVIEWED", Resolution: "SAFE"},
+		{Key: "dev-b", Component: "p:f.py", RuleKey: "py:S4823", Line: 35, Offset: 35, Status: "REVIEWED", Resolution: "SAFE"},
+	}
+	out := dedupeActionableHotspots(in)
+	if len(out) != 2 {
+		t.Fatalf("expected 2 distinct (line, offset) groups, got %d: %+v", len(out), out)
+	}
+	offsets := map[int]bool{}
+	for _, h := range out {
+		offsets[h.Offset] = true
+	}
+	if !offsets[17] || !offsets[35] {
+		t.Errorf("expected both column offsets (17, 35) preserved as distinct reps, got %v", offsets)
 	}
 }
 


### PR DESCRIPTION
## Summary
Hotspot status sync left some REVIEWED hotspots stuck at TO_REVIEW on SonarCloud — observed live as 6 of 31 SAFE hotspots not migrating on `python:S4823`. The cause is **co-located hotspots**: when the same rule fires twice on a single line (e.g. `sys.argv[1]` and `sys.argv[2]` on one line), neither the source-side dedup nor the cloud-side matcher could tell the two apart. Result: dedup collapsed them to one source rep, the matcher saw two cloud candidates with identical `(rule, line)` and returned `syncOutcomeLineMismatch`, both cloud hotspots stayed TO_REVIEW.

Debug-log evidence from the user's run on `conf/ruff2sonar.py:35`:
```
syncHotspotMetadata: multiple cloud counterparts on source line, skipping
  source_key=0c4fdb5a-… rule=python:S4823 line=35
  candidates=[AZ7KgsyaRa2zbPEpvgMF AZ7KgsyaRa2zbPEpvgMG]
```
…with the two cloud hotspots distinguishable only by `textRange.startOffset` (17 and 35).

## Fix
Both SonarCloud's `/api/hotspots/search` and the source extract carry `textRange.startOffset` per hotspot. Thread it through:

| Layer | Change |
|---|---|
| `matchableHotspot` | new `Offset int` |
| `parseMatchableHotspot` + new `extractHotspotStartOffset` | parses `textRange.startOffset` on both source and cloud records (treats missing as `0 == "unknown"` so older API shapes still work) |
| `dedupeActionableHotspots` | groupKey gains `Offset` → co-located source hotspots stay as distinct reps; cross-branch duplicates of the same `(component, rule, line, offset)` still collapse |
| `classifyHotspotCandidatesByLine` | three-phase: (1) precise `(rule, line, offset)`; (2) `(rule, line)` — common case; (3) empty-ruleKey line-only — preserves the 2026-06-09 audit fallback |

Each phase short-circuits when it finds a unique match; an earlier phase always wins over a later one so an empty-rule candidate on the same line can never undo a precise rule+line match.

Fixes #392.

## Test plan
- [x] `go test ./...` — all packages green, with new coverage in `tasks_hotspotsync_test.go`:
  - `TestClassifyHotspotCandidatesByLine` (12 cases): live `(line=35, offsets 17/35)` scenario, phase-2 fallback when source has offset but cloud doesn't, empty-rule phase-3 fallback, "earlier phase wins" precedence, general negatives.
  - `TestDedupeActionableHotspotsOffsetDistinguishesCoLocated`: two source hotspots `(line=35, offset=17)` and `(line=35, offset=35)` stay distinct after cross-branch dedup.
- [x] Manual against the live `latest-unbound_okorach-oss_sonar-tools` project: all 31 SAFE hotspots now sync (was 14 in the previous build); the lone ACKNOWLEDGED hotspot still demotes to TO_REVIEW per #323.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
