### PR TITLE
Issue #395: edition parser accepts display-form values

### DIFF
--- a/go/internal/common/common_test.go
+++ b/go/internal/common/common_test.go
@@ -21,6 +21,8 @@ func TestEditionParsing(t *testing.T) {
 		{`{"edition":"community"}`, EditionCommunity},
 		{`{"edition":"developer"}`, EditionDeveloper},
 		{`{"edition":"datacenter"}`, EditionDatacenter},
+		// #395: a truly unrecognised non-empty value falls back to
+		// Community (with a Warn line that this test doesn't assert).
 		{`{"edition":"unknown"}`, EditionCommunity},
 		{`{}`, EditionCommunity},
 		{`invalid`, EditionCommunity},
@@ -31,6 +33,20 @@ func TestEditionParsing(t *testing.T) {
 		{`{"System":{"Edition":"Community"}}`, EditionCommunity},
 		// Top-level takes precedence over nested.
 		{`{"edition":"developer","System":{"Edition":"Enterprise"}}`, EditionDeveloper},
+		// #395: api/system/info reports the edition in display form
+		// — i.e. with a space and mixed case. parseEditionString
+		// normalises (lowercase + strip whitespace) and then matches
+		// by prefix so display-form values resolve correctly.
+		{`{"edition":"Data Center"}`, EditionDatacenter},
+		{`{"edition":"data center"}`, EditionDatacenter},
+		{`{"edition":"DATA CENTER"}`, EditionDatacenter},
+		{`{"edition":"  Data  Center  "}`, EditionDatacenter},
+		{`{"edition":"Data Center Edition"}`, EditionDatacenter},
+		{`{"edition":"Enterprise Edition"}`, EditionEnterprise},
+		{`{"edition":"Developer Edition"}`, EditionDeveloper},
+		{`{"edition":"Community Edition"}`, EditionCommunity},
+		{`{"System":{"Edition":"Data Center"}}`, EditionDatacenter},
+		{`{"System":{"Edition":"Data Center Edition"}}`, EditionDatacenter},
 	}
 	for _, tt := range tests {
 		got := ParseEdition([]byte(tt.input))

--- a/go/internal/common/edition.go
+++ b/go/internal/common/edition.go
@@ -6,6 +6,7 @@ package common
 
 import (
 	"encoding/json"
+	"log/slog"
 	"strings"
 )
 
@@ -48,7 +49,25 @@ func ParseEdition(raw json.RawMessage) Edition {
 	return EditionCommunity
 }
 
-// parseEditionString extracts and normalises an edition from a raw JSON string.
+// parseEditionString extracts and normalises an edition from a raw
+// JSON string into one of the four enum values.
+//
+// Normalisation contract (#395): the SonarQube Server api/system/info
+// payload carries the edition in display form — e.g. "Data Center"
+// with a space, or a future "Data Center Edition" — which used to
+// fall through the exact-match switch and silently downgrade real
+// Data Center servers to Community. We now:
+//
+//  1. lowercase + strip every space, so "Data Center" → "datacenter"
+//     and "  DATA  CENTER  " → "datacenter";
+//  2. accept any prefix match against the known enums, so a future
+//     "Data Center Edition" → "datacenter" too. None of the four
+//     enum values is a prefix of another, so prefix ordering is
+//     unambiguous.
+//
+// Truly-unknown non-empty values are still treated as "no match"
+// (caller falls back to EditionCommunity) but we log one slog.Warn
+// so the silent-downgrade no longer happens invisibly.
 func parseEditionString(raw json.RawMessage) (Edition, bool) {
 	if raw == nil {
 		return "", false
@@ -57,10 +76,16 @@ func parseEditionString(raw json.RawMessage) (Edition, bool) {
 	if json.Unmarshal(raw, &s) != nil {
 		return "", false
 	}
-	ed := Edition(strings.ToLower(s))
-	switch ed {
-	case EditionCommunity, EditionDeveloper, EditionEnterprise, EditionDatacenter:
-		return ed, true
+	if s == "" {
+		return "", false
 	}
+	normalised := strings.ReplaceAll(strings.ToLower(s), " ", "")
+	for _, ed := range AllEditions {
+		if strings.HasPrefix(normalised, string(ed)) {
+			return ed, true
+		}
+	}
+	slog.Warn("unrecognised SonarQube edition value — falling back to community",
+		"raw_value", s)
 	return "", false
 }


### PR DESCRIPTION
## Summary
`parseEditionString` (`internal/common/edition.go`) lowercased the raw value and matched it against exact enum literals (`community` / `developer` / `enterprise` / `datacenter`). SonarQube Server's `api/system/info` payload reports the edition in **display form** — e.g. `"Data Center"` with a space — which lowercases to `"data center"` and does NOT equal `"datacenter"`. Both the top-level `edition` and nested `System.Edition` lookups missed, `ParseEdition` fell through to `EditionCommunity`, and `FilterByEditionGeneric` stripped every Enterprise / Data-Center-only task (portfolios, applications, …) from the plan. The migration ran successfully but silently skipped entire categories of data on a real Data Center server.

The `api/navigation/global` fallback returns the lowercase form, which has been masking the bug whenever the admin token couldn't reach `api/system/info` (403 path) — but the primary path is broken.

## Fix
`parseEditionString` now:

1. **Normalises** the input: `strings.ToLower` + `strings.ReplaceAll(s, " ", "")`. `"Data Center"` → `"datacenter"`, `"  DATA  CENTER  "` → `"datacenter"`.
2. **Matches by prefix** against `AllEditions` so future display-form variants like `"Data Center Edition"` / `"Enterprise Edition"` also resolve. None of the four edition values is a prefix of another, so prefix ordering is unambiguous.
3. **Warns on truly-unknown values**: a non-empty raw value that matches nothing emits one `slog.Warn` naming the value and keeps the existing Community fallback. Defaulting to Enterprise instead would cascade 403/404s on Community servers, but the silent-downgrade is no longer invisible.

Fixes #395.

## Test plan
- [x] `go test ./...` — full suite green. `TestEditionParsing` gains 10 new cases: `"Data Center"`, `"data center"`, `"DATA CENTER"`, `"  Data  Center  "`, `"Data Center Edition"`, `"Enterprise Edition"`, `"Developer Edition"`, `"Community Edition"`, plus two `System.Edition` display-form cases.
- [ ] Manual: point `./sonar-migration-tool extract` at a Data Center instance and confirm the run log records `edition=datacenter` (not `community`) and the plan includes Enterprise/Data-Center-only tasks (`getApplications`, `getPortfolios`, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
