### PR TITLE
Issue #398: CLI/config parity + extract --skip_issue_sync

### DIFF
--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -91,12 +91,14 @@ CLI flags **override** the corresponding config field when both are set.
 ### `extract`
 
 ```bash
-sonar-migration-tool extract [url] [token] [flags]
+sonar-migration-tool extract --url <url> --token <token> [flags]
 ```
 
 | Flag | Description |
 |---|---|
 | `-c, --config <path>` | Path to JSON configuration file. |
+| `--url <url>` | SonarQube Server URL. |
+| `--token <token>` | SonarQube Server authentication token. |
 | `--export_directory <dir>` | Output directory (default `./migration-files`). |
 | `--extract_type <name>` | Type of extract to run (default `all`). |
 | `--extract_id <id>` | Resume a previous extraction. |
@@ -104,6 +106,7 @@ sonar-migration-tool extract [url] [token] [flags]
 | `--concurrency <n>` | Max concurrent requests. |
 | `--timeout <s>` | Request timeout in seconds. |
 | `--skip_project_data_migration` | Skip the issue / source / SCM-blame extract (extracted by default). |
+| `--skip_issue_sync` | Drop the per-issue / per-hotspot sync metadata from the extract (no `additionalFields=_all`, no per-hotspot detail). Pair with migrate-side `--skip_issue_sync`. #398. |
 | `--exclude_branches <pattern>` | Glob pattern for non-main branches to skip during project data import. Repeatable (pass multiple times for multiple patterns). Main branch is never excluded. |
 | `--pem_file_path <path>` | mTLS PEM file. |
 | `--key_file_path <path>` | mTLS key file. |
@@ -125,12 +128,14 @@ sonar-migration-tool predictive-report --config config.json
 ### `migrate`
 
 ```bash
-sonar-migration-tool migrate [token] [enterprise_key] [flags]
+sonar-migration-tool migrate --token <token> --enterprise_key <key> [flags]
 ```
 
 | Flag | Description |
 |---|---|
 | `-c, --config <path>` | Path to JSON configuration file. |
+| `--token <token>` | SonarQube Cloud authentication token. |
+| `--enterprise_key <key>` | SonarQube Cloud enterprise key. |
 | `--url <url>` | SonarQube Cloud URL (default `https://sonarcloud.io/`). |
 | `--export_directory <dir>` | Directory containing the extract output. |
 | `--edition <name>` | SonarQube Cloud license edition. |

--- a/docs/MIGRATE.md
+++ b/docs/MIGRATE.md
@@ -105,10 +105,10 @@ Connect to SonarQube Server and export all the data needed for migration.
 
 ```bash
 # From source
-go run . extract <URL> <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
+go run . extract --url <URL> --token <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
 
 # Built binary
-sonar-migration-tool extract <URL> <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
+sonar-migration-tool extract --url <URL> --token <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
 ```
 
 | Flag | Description |
@@ -198,10 +198,10 @@ Push everything to SonarQube Cloud. You'll need your SonarQube Cloud admin token
 
 ```bash
 # From source
-go run . migrate <TOKEN> <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
+go run . migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
 
 # Built binary
-sonar-migration-tool migrate <TOKEN> <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
+sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
 ```
 
 | Flag | Description |
@@ -235,10 +235,10 @@ If a step fails partway through, you can pick up where you left off:
 
 ```bash
 # Resume an extraction
-sonar-migration-tool extract <URL> <TOKEN> --extract_id <PREVIOUS_EXTRACT_ID> --export_directory ./files/
+sonar-migration-tool extract --url <URL> --token <TOKEN> --extract_id <PREVIOUS_EXTRACT_ID> --export_directory ./files/
 
 # Resume a migration
-sonar-migration-tool migrate <TOKEN> <ENTERPRISE_KEY> --run_id <PREVIOUS_RUN_ID> --export_directory ./files/
+sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --run_id <PREVIOUS_RUN_ID> --export_directory ./files/
 ```
 
 The tool tracks which tasks have already completed and skips them automatically.
@@ -326,7 +326,7 @@ sonar-migration-tool reset <TOKEN> <ENTERPRISE_KEY> --export_directory ./files/
 - Use `--config` with a JSON file for repeatable, scripted migrations.
 - For large instances (50,000+ projects), lower concurrency and increase timeout:
   ```bash
-  sonar-migration-tool extract <URL> <TOKEN> --concurrency 10 --timeout 120 --export_directory ./files/
+  sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 10 --timeout 120 --export_directory ./files/
   ```
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -49,7 +49,7 @@ This guide covers common issues when using the SonarQube to SonarCloud migration
 **Solution**: Increase the timeout:
 
 ```bash
-sonar-migration-tool extract <URL> <TOKEN> --timeout 120 --export_directory ./files/
+sonar-migration-tool extract --url <URL> --token <TOKEN> --timeout 120 --export_directory ./files/
 ```
 
 ---
@@ -65,7 +65,7 @@ sonar-migration-tool extract <URL> <TOKEN> --timeout 120 --export_directory ./fi
 2. For self-signed certificates, use mTLS options:
 
 ```bash
-sonar-migration-tool extract <URL> <TOKEN> \
+sonar-migration-tool extract --url <URL> --token <TOKEN> \
   --pem_file_path ./certs/client.pem \
   --key_file_path ./certs/client.key \
   --export_directory ./files/
@@ -81,7 +81,7 @@ sonar-migration-tool extract <URL> <TOKEN> \
 **Solution**: Resume using the `--run_id` flag:
 
 ```bash
-sonar-migration-tool migrate <TOKEN> <ENTERPRISE_KEY> --run_id <RUN_ID> --export_directory ./files/
+sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --run_id <RUN_ID> --export_directory ./files/
 ```
 
 Completed tasks are skipped automatically.
@@ -113,7 +113,7 @@ Completed tasks are skipped automatically.
 Reduce concurrency and increase timeout:
 
 ```bash
-sonar-migration-tool extract <URL> <TOKEN> --concurrency 5 --timeout 120 --export_directory ./files/
+sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 5 --timeout 120 --export_directory ./files/
 ```
 
 ---
@@ -124,7 +124,7 @@ sonar-migration-tool extract <URL> <TOKEN> --concurrency 5 --timeout 120 --expor
 For large instances (50,000+ projects), lower the concurrency:
 
 ```bash
-sonar-migration-tool extract <URL> <TOKEN> --concurrency 10 --export_directory ./files/
+sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 10 --export_directory ./files/
 ```
 
 ---

--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -13,17 +13,17 @@ import (
 )
 
 var extractCmd = &cobra.Command{
-	Use:   "extract [url] [token]",
+	Use:   "extract",
 	Short: "Extract data from a SonarQube Server instance",
 	Long:  "Extracts data from a SonarQube Server instance and stores it in the export directory as new line delimited json files.",
-	Args:  cobra.MaximumNArgs(2),
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := buildExtractConfig(cmd, args)
 		if err != nil {
 			return err
 		}
 		if cfg.URL == "" || cfg.Token == "" {
-			return fmt.Errorf("URL and TOKEN are required (either as arguments or in config file)")
+			return fmt.Errorf("URL and TOKEN are required (--url/--token flags or in config file)")
 		}
 		skipped, err := extract.RunExtract(cmd.Context(), cfg)
 		if err != nil {
@@ -43,6 +43,8 @@ var extractCmd = &cobra.Command{
 func init() {
 	f := extractCmd.Flags()
 	f.String("config", "", "Path to JSON configuration file")
+	f.String("url", "", "URL of the SonarQube Server")
+	f.String("token", "", "Authentication token for the SonarQube Server")
 	f.String("pem_file_path", "", "Path to client certificate pem file")
 	f.String("key_file_path", "", "Path to client certificate key file")
 	f.String("cert_password", "", "Password for client certificate")
@@ -53,6 +55,7 @@ func init() {
 	f.String("extract_id", "", "ID of an extract to resume in case of failures")
 	f.String("target_task", "", "Target task to complete; all dependent tasks will be included")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip extracting project data (issues, hotspots, source code, SCM blame). Defaults to false — project data is extracted by default. #303.")
+	f.Bool(flagSkipIssueSync, false, "Skip extracting per-issue and per-hotspot sync metadata (comments, changelog, hotspot detail). Pair with migrate-side --skip_issue_sync. Defaults to false. #398.")
 }
 
 func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfig, error) {
@@ -69,15 +72,9 @@ func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfi
 		cfg = loaded
 	}
 
-	// CLI args override config file.
-	if len(args) > 0 && args[0] != "" {
-		cfg.URL = args[0]
-	}
-	if len(args) > 1 && args[1] != "" {
-		cfg.Token = args[1]
-	}
-
-	// Flags override everything.
+	// Flags override config file.
+	overrideString(cmd, "url", &cfg.URL)
+	overrideString(cmd, "token", &cfg.Token)
 	overrideString(cmd, "pem_file_path", &cfg.PEMFilePath)
 	overrideString(cmd, "key_file_path", &cfg.KeyFilePath)
 	overrideString(cmd, "cert_password", &cfg.CertPassword)
@@ -95,6 +92,14 @@ func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfi
 		v, _ := cmd.Flags().GetBool(flagSkipProjectDataMigration)
 		if v {
 			cfg.SkipProjectDataMigration = true
+		}
+	}
+	// --skip_issue_sync is one-way: passing the flag forces opt-out,
+	// CLI false does NOT undo a config-file skip_issue_sync: true. #398.
+	if cmd.Flags().Changed(flagSkipIssueSync) {
+		v, _ := cmd.Flags().GetBool(flagSkipIssueSync)
+		if v {
+			cfg.SkipIssueSync = true
 		}
 	}
 	cfg.IncludeProjectData = !cfg.SkipProjectDataMigration

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -14,19 +14,19 @@ import (
 )
 
 var migrateCmd = &cobra.Command{
-	Use:   "migrate [token] [enterprise_key]",
+	Use:   "migrate",
 	Short: "Migrate configurations to SonarQube Cloud",
 	Long: `Migrate SonarQube Server configurations to SonarQube Cloud.
 User must run structure and mappings commands and add SonarQube Cloud
 organization keys to organizations.csv.`,
-	Args: cobra.MaximumNArgs(2),
+	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := buildMigrateConfig(cmd, args)
 		if err != nil {
 			return err
 		}
 		if cfg.Token == "" || cfg.EnterpriseKey == "" {
-			return fmt.Errorf("TOKEN and ENTERPRISE_KEY are required (either as arguments or in config file)")
+			return fmt.Errorf("TOKEN and ENTERPRISE_KEY are required (--token/--enterprise_key flags or in config file)")
 		}
 		runID, err := migrate.RunMigrate(cmd.Context(), cfg)
 		// Attempt the summary report whenever a run directory exists, even
@@ -50,6 +50,8 @@ organization keys to organizations.csv.`,
 func init() {
 	f := migrateCmd.Flags()
 	f.String("config", "", "Path to JSON configuration file")
+	f.String("token", "", "SonarQube Cloud authentication token")
+	f.String("enterprise_key", "", "SonarQube Cloud enterprise key")
 	f.String("edition", "", "SonarQube Cloud license edition")
 	f.String("url", "", "URL of SonarQube Cloud")
 	f.String("run_id", "", "ID of a run to resume in case of failures")
@@ -78,15 +80,9 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 		cfg = loaded
 	}
 
-	// CLI args override config file.
-	if len(args) > 0 && args[0] != "" {
-		cfg.Token = args[0]
-	}
-	if len(args) > 1 && args[1] != "" {
-		cfg.EnterpriseKey = args[1]
-	}
-
-	// Flags override everything.
+	// Flags override config file.
+	overrideString(cmd, "token", &cfg.Token)
+	overrideString(cmd, "enterprise_key", &cfg.EnterpriseKey)
 	overrideString(cmd, "edition", &cfg.Edition)
 	overrideString(cmd, "url", &cfg.URL)
 	overrideString(cmd, "run_id", &cfg.RunID)

--- a/go/cmd/migrate_test.go
+++ b/go/cmd/migrate_test.go
@@ -16,6 +16,8 @@ func newMigrateTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "migrate"}
 	f := cmd.Flags()
 	f.String("config", "", "")
+	f.String("token", "", "")
+	f.String("enterprise_key", "", "")
 	f.String("edition", "", "")
 	f.String("url", "", "")
 	f.String("run_id", "", "")
@@ -86,11 +88,16 @@ func TestBuildMigrateConfig_DefaultOrganization_ConfigOnly(t *testing.T) {
 // Neither config nor CLI → empty.
 func TestBuildMigrateConfig_DefaultOrganization_Unset(t *testing.T) {
 	cmd := newMigrateTestCmd()
-	cfg, err := buildMigrateConfig(cmd, []string{"tok", "ent"})
+	_ = cmd.Flags().Set("token", "tok")
+	_ = cmd.Flags().Set("enterprise_key", "ent")
+	cfg, err := buildMigrateConfig(cmd, nil)
 	if err != nil {
 		t.Fatalf("buildMigrateConfig: %v", err)
 	}
 	if cfg.DefaultOrganization != "" {
 		t.Errorf("expected empty, got %q", cfg.DefaultOrganization)
+	}
+	if cfg.Token != "tok" || cfg.EnterpriseKey != "ent" {
+		t.Errorf("expected token/enterprise_key from flags, got %q / %q", cfg.Token, cfg.EnterpriseKey)
 	}
 }

--- a/go/internal/extract/config_file.go
+++ b/go/internal/extract/config_file.go
@@ -40,6 +40,7 @@ type configFileShape struct {
 	ExtractID                string `json:"extract_id"`
 	TargetTask               string `json:"target_task"`
 	SkipProjectDataMigration bool   `json:"skip_project_data_migration"`
+	SkipIssueSync            bool   `json:"skip_issue_sync"` // #398
 
 	// Shape 2 (command-sectioned).
 	Extract *configFileShape `json:"extract"`
@@ -151,6 +152,7 @@ func (s configFileShape) toExtractConfig() ExtractConfig {
 		// #303: top-level skip_project_data_migration drives whether
 		// the extract pulls issue / source / SCM-blame data.
 		cfg.SkipProjectDataMigration = s.SkipProjectDataMigration
+		cfg.SkipIssueSync = s.SkipIssueSync
 	case s.SonarQube != nil:
 		cfg.URL = s.SonarQube.URL
 		cfg.Token = s.SonarQube.Token
@@ -160,6 +162,7 @@ func (s configFileShape) toExtractConfig() ExtractConfig {
 			cfg.Timeout = s.Settings.Timeout
 		}
 		cfg.SkipProjectDataMigration = s.SkipProjectDataMigration
+		cfg.SkipIssueSync = s.SkipIssueSync
 	case s.Extract != nil:
 		return s.Extract.toExtractConfig()
 	default:
@@ -175,6 +178,7 @@ func (s configFileShape) toExtractConfig() ExtractConfig {
 		cfg.ExtractID = s.ExtractID
 		cfg.TargetTask = s.TargetTask
 		cfg.SkipProjectDataMigration = s.SkipProjectDataMigration
+		cfg.SkipIssueSync = s.SkipIssueSync
 	}
 	return cfg
 }

--- a/go/internal/extract/config_file_test.go
+++ b/go/internal/extract/config_file_test.go
@@ -91,7 +91,8 @@ func TestLoadExtractConfigFileSnakeCaseFields(t *testing.T) {
 		"timeout": 90,
 		"extract_id": "resume-me",
 		"target_task": "getRules",
-		"skip_project_data_migration": true
+		"skip_project_data_migration": true,
+		"skip_issue_sync": true
 	}`)
 	f.Close()
 
@@ -113,6 +114,7 @@ func TestLoadExtractConfigFileSnakeCaseFields(t *testing.T) {
 		ExtractID:                "resume-me",
 		TargetTask:               "getRules",
 		SkipProjectDataMigration: true,
+		SkipIssueSync:            true,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("snake_case round-trip mismatch\n got=%+v\nwant=%+v", got, want)

--- a/go/internal/extract/extract.go
+++ b/go/internal/extract/extract.go
@@ -38,7 +38,14 @@ type ExtractConfig struct {
 	TargetTask               string
 	IncludeProjectData       bool
 	SkipProjectDataMigration bool // #303. Set true to skip project-data tasks (issues, source, SCM blame).
-	Debug                    bool // Enable HTTP request/response logging via SDK debug transport
+	// SkipIssueSync, when true, omits the per-issue / per-hotspot sync
+	// metadata from the extract: drops additionalFields=_all on
+	// /api/issues/search (no comments/changelog) and skips the
+	// /api/hotspots/show round-trip used to enrich REVIEWED hotspots
+	// with comments. Pair with migrate-side --skip_issue_sync so the
+	// trailing sync also skips. #398.
+	SkipIssueSync bool
+	Debug         bool // Enable HTTP request/response logging via SDK debug transport
 	// ProjectKeys, when non-empty, limits extraction to these project keys.
 	// The /api/projects/search endpoint filters server-side, so only the
 	// requested projects are fetched and all downstream per-project tasks
@@ -48,14 +55,15 @@ type ExtractConfig struct {
 
 // Executor is the runtime context passed to every task function.
 type Executor struct {
-	Raw         *RawClient
-	Store       *DataStore
-	ServerURL   string
-	Edition     Edition
-	Version     common.Version
-	Sem         chan struct{}
-	Logger      *slog.Logger
-	ProjectKeys []string // non-empty → limit extraction to these project keys
+	Raw           *RawClient
+	Store         *DataStore
+	ServerURL     string
+	Edition       Edition
+	Version       common.Version
+	Sem           chan struct{}
+	Logger        *slog.Logger
+	ProjectKeys   []string // non-empty → limit extraction to these project keys
+	SkipIssueSync bool     // drop additionalFields=_all + hotspot detail enrichment. #398.
 
 	mu              sync.Mutex
 	skippedProjects map[string]bool
@@ -129,6 +137,7 @@ func RunExtract(ctx context.Context, cfg ExtractConfig) ([]string, error) {
 
 	executor := newExecutor(raw, store, client.BaseURL(), edition, version, cfg.Concurrency)
 	executor.ProjectKeys = cfg.ProjectKeys
+	executor.SkipIssueSync = cfg.SkipIssueSync
 	if err := executePhases(ctx, executor, plan, registry, store); err != nil {
 		return nil, err
 	}

--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -70,10 +70,16 @@ func projectIssuesFullTask() func(ctx context.Context, e *Executor) error {
 		return forEachProjectBranch(ctx, e, "getProjectIssuesFull",
 			func(ctx context.Context, projectKey, branch string, w *ChunkWriter) error {
 				params := url.Values{
-					"components":       {projectKey},
-					"branch":           {branch},
-					"ps":               {"500"},
-					"additionalFields": {"_all"},
+					"components": {projectKey},
+					"branch":     {branch},
+					"ps":         {"500"},
+				}
+				// additionalFields=_all is what brings comments and
+				// changelog into the response — the data only the
+				// migrate-side per-issue sync would consume. Skip it
+				// when the operator opted out of that sync. #398.
+				if !e.SkipIssueSync {
+					params.Set("additionalFields", "_all")
 				}
 				if e.Version.Less(issueStatusesRename) {
 					params.Set("statuses", "OPEN,CONFIRMED,REOPENED,RESOLVED")
@@ -163,7 +169,13 @@ func projectHotspotsFullTask() func(ctx context.Context, e *Executor) error {
 				}
 
 				enriched := enrichAll(all, meta)
-				enrichHotspotDetails(ctx, e, enriched)
+				// enrichHotspotDetails issues one /api/hotspots/show
+				// call per REVIEWED hotspot purely to pick up comments
+				// + rule — data only the migrate-side hotspot sync
+				// would consume. Skip when opted out. #398.
+				if !e.SkipIssueSync {
+					enrichHotspotDetails(ctx, e, enriched)
+				}
 				return w.WriteChunk(enriched)
 			})
 	}

--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -237,6 +237,112 @@ func TestProjectIssuesFullTask(t *testing.T) {
 	}
 }
 
+// #398: with SkipIssueSync=true the issue search must NOT request
+// additionalFields=_all (which is what brings comments / changelog).
+// Without that gate, the heavy payload would still be fetched even
+// though the operator opted out of the downstream sync.
+func TestProjectIssuesFullTaskSkipIssueSync(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		params []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		params = append(params, r.URL.Query().Get("additionalFields"))
+		mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{
+				{"key": "issue-1", "rule": "java:S100"},
+			},
+			"paging": map[string]any{"total": 1, "pageIndex": 1, "pageSize": 500},
+		})
+	}))
+	defer srv.Close()
+
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
+	e.SkipIssueSync = true
+
+	w, _ := e.Store.Writer("getProjects")
+	b, _ := json.Marshal(map[string]any{"key": "p1"})
+	w.WriteOne(b)
+	e.Store.Writer("getBranches")
+
+	if err := projectIssuesFullTask()(ctx(t), e); err != nil {
+		t.Fatalf("projectIssuesFullTask: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(params) == 0 {
+		t.Fatal("expected at least one /api/issues/search call")
+	}
+	for _, p := range params {
+		if p != "" {
+			t.Errorf("expected additionalFields to be unset with SkipIssueSync=true, got %q", p)
+		}
+	}
+}
+
+// #398: with SkipIssueSync=true the hotspot task must NOT fetch
+// /api/hotspots/show per REVIEWED hotspot — that round-trip exists
+// only to enrich the record with comments + rule for the migrate-side
+// sync.
+func TestProjectHotspotsFullTaskSkipsDetailEnrichment(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		showHits int
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/hotspots/search":
+			status := r.URL.Query().Get("status")
+			if status == "REVIEWED" {
+				json.NewEncoder(w).Encode(map[string]any{
+					"hotspots": []map[string]any{
+						{"key": "hs-1", "status": "REVIEWED", "resolution": "ACKNOWLEDGED"},
+					},
+					"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+				})
+				return
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"hotspots": []map[string]any{},
+				"paging":   map[string]any{"pageIndex": 1, "pageSize": 500, "total": 0},
+			})
+		case "/api/hotspots/show":
+			mu.Lock()
+			showHits++
+			mu.Unlock()
+			json.NewEncoder(w).Encode(map[string]any{"key": "hs-1"})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
+	e.SkipIssueSync = true
+
+	pw, _ := e.Store.Writer("getProjects")
+	b, _ := json.Marshal(map[string]any{"key": "p1"})
+	pw.WriteOne(b)
+	e.Store.Writer("getBranches")
+
+	if err := projectHotspotsFullTask()(ctx(t), e); err != nil {
+		t.Fatalf("projectHotspotsFullTask: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if showHits != 0 {
+		t.Errorf("expected zero /api/hotspots/show calls with SkipIssueSync=true, got %d", showHits)
+	}
+}
+
 // #323: SonarQube Server's /api/hotspots/search defaults to TO_REVIEW
 // on several versions when `status` is omitted, silently dropping
 // REVIEWED (incl. ACKNOWLEDGED) hotspots from the extract — so the


### PR DESCRIPTION
## Summary

Closes #398.

- `extract` and `migrate` drop their positional args (`[url]`, `[token]`, `[enterprise_key]`) in favor of named flags (`--url`, `--token`, `--enterprise_key`). Every config-file field now has a CLI equivalent.
- New `--skip_issue_sync` flag on `extract`: drops `additionalFields=_all` from `/api/issues/search` (no comments / changelog) and skips the per-hotspot `/api/hotspots/show` round-trip. Both are heavy fetches that only the migrate-side metadata sync would have consumed, so this is pure waste when the operator already knows they will pair it with migrate's `--skip_issue_sync`. One-way override: CLI `true` wins, CLI `false` does not undo a config-file `true`.
- Plumbed through all four config-file shapes (flat / unified / command-sectioned / side-sectioned) and the `Executor`. Tests cover the snake-case round-trip and assert zero `additionalFields=_all` / zero `/api/hotspots/show` calls when the flag is on.

Breaking change: the positional argument form on `extract` / `migrate` is removed. Docs (`MIGRATE.md`, `TROUBLESHOOTING.md`, `ADVANCED-CONFIG.md`) updated to the flag form.

`reset` still takes positional `[token] [enterprise_key]` — out of scope for #398.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass (cmd, internal/extract, internal/migrate, …)
- [x] `go run . extract --help` shows `--url`, `--token`, `--skip_issue_sync`; positionals gone from `Usage:`
- [x] `go run . migrate --help` shows `--token`, `--enterprise_key`; positionals gone from `Usage:`
- [ ] Manual: run `extract --skip_issue_sync` against a recorded server and confirm absence of `additionalFields=_all` in `/api/issues/search` calls and zero `/api/hotspots/show` hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)
