### PR TITLE
Issue #400: extract issues with componentKeys on every SQ version

### DIFF
--- a/go/internal/extract/helpers.go
+++ b/go/internal/extract/helpers.go
@@ -273,7 +273,7 @@ func perProjectIssueCount(taskName string, extraParams url.Values) func(ctx cont
 		return forEachDep(ctx, e, taskName, "getProjects",
 			func(ctx context.Context, item json.RawMessage, w *ChunkWriter) error {
 				key := extractField(item, "key")
-				params := url.Values{"components": {key}, "ps": {"1"}}
+				params := url.Values{"componentKeys": {key}, "ps": {"1"}}
 				for k, v := range extraParams {
 					params[k] = v
 				}

--- a/go/internal/extract/tasks_issues.go
+++ b/go/internal/extract/tasks_issues.go
@@ -104,7 +104,7 @@ func makeExpandedIssueTask(taskName string, resolutionValues []string, extraPara
 func fetchIssueCombos(ctx context.Context, e *Executor, w *ChunkWriter, projectKey string,
 	combos []map[string]string, extraParams url.Values, meta map[string]any) error {
 	for _, combo := range combos {
-		params := url.Values{"components": {projectKey}, "ps": {"1"}}
+		params := url.Values{"componentKeys": {projectKey}, "ps": {"1"}}
 		for k, v := range combo {
 			params.Set(k, v)
 		}
@@ -168,7 +168,7 @@ func fetchChunkedRuleIssues(ctx context.Context, e *Executor, w *ChunkWriter,
 	projectKey string, chunks [][]string, meta map[string]any) error {
 	for _, chunk := range chunks {
 		raw, err := e.Raw.Get(ctx, issuesSearchAPI,
-			url.Values{"components": {projectKey}, "rules": {strings.Join(chunk, ",")}, "ps": {"1"}})
+			url.Values{"componentKeys": {projectKey}, "rules": {strings.Join(chunk, ",")}, "ps": {"1"}})
 		if err != nil {
 			return err
 		}

--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -70,9 +70,16 @@ func projectIssuesFullTask() func(ctx context.Context, e *Executor) error {
 		return forEachProjectBranch(ctx, e, "getProjectIssuesFull",
 			func(ctx context.Context, projectKey, branch string, w *ChunkWriter) error {
 				params := url.Values{
-					"components": {projectKey},
-					"branch":     {branch},
-					"ps":         {"500"},
+					// componentKeys (not components) is the canonical project
+					// filter on /api/issues/search across every SQ version we
+					// support — 9.9, 10.x, current, and SQC. SQ 9.9 silently
+					// ignores `components`, returning the global issue set
+					// instead, which then gets enriched per-project and
+					// pollutes every project's import with the first ~10k
+					// issues server-wide. #400.
+					"componentKeys": {projectKey},
+					"branch":        {branch},
+					"ps":            {"500"},
 				}
 				// additionalFields=_all is what brings comments and
 				// changelog into the response — the data only the

--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -234,6 +235,61 @@ func TestProjectIssuesFullTask(t *testing.T) {
 	items, _ := e.Store.ReadAll("getProjectIssuesFull")
 	if len(items) != 1 {
 		t.Fatalf("expected 1 issue, got %d", len(items))
+	}
+}
+
+// #400 regression: the /api/issues/search project filter must be
+// passed as componentKeys (not components). SQ 9.9 only knows the
+// historical componentKeys name; the newer components name is
+// silently ignored there, so the API returns the global issue set
+// (capped at 10k) for every project. The records then get enriched
+// per-project, polluting each project's scanner-report import with
+// the same ~10k server-wide issues — explaining the massive 9.9
+// issue-loss bug.
+func TestProjectIssuesFullTaskUsesComponentKeysParam(t *testing.T) {
+	var (
+		mu   sync.Mutex
+		urls []string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		urls = append(urls, r.URL.RawQuery)
+		mu.Unlock()
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{
+				{"key": "issue-1", "rule": "java:S100"},
+			},
+			"paging": map[string]any{"total": 1, "pageIndex": 1, "pageSize": 500},
+		})
+	}))
+	defer srv.Close()
+
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
+
+	w, _ := e.Store.Writer("getProjects")
+	b, _ := json.Marshal(map[string]any{"key": "p1"})
+	w.WriteOne(b)
+	e.Store.Writer("getBranches")
+
+	if err := projectIssuesFullTask()(ctx(t), e); err != nil {
+		t.Fatalf("projectIssuesFullTask: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(urls) == 0 {
+		t.Fatal("expected at least one /api/issues/search call")
+	}
+	for _, q := range urls {
+		if !strings.Contains(q, "componentKeys=p1") {
+			t.Errorf("expected componentKeys=p1 in query, got %q", q)
+		}
+		// Guard against accidentally regressing back to the broken name.
+		if strings.Contains(q, "components=p1") {
+			t.Errorf("query must not use components=; SQ 9.9 ignores it. got %q", q)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #400.

The supplied DEBUG log `migrate-99.log` made the root cause unambiguous: every "report packaged" line — across all 70 projects and every branch — reported `issues=9996` or `issues=9997`, including projects with `components=1`. 9996/9997 is exactly SQ's 10,000-result paging cap (PageLimit=20 × pageSize=500). Identical counts on unrelated projects mean the per-project filter on `/api/issues/search` was being silently ignored at extract time.

Cause: the extract used `components=` as the project filter. On SQ 9.9, `/api/issues/search` only accepts the historical name `componentKeys`; the newer `components` name was added later. SQ 9.9 silently ignored the unknown param and returned the global issue set, which the extract then enriched with each iteration's `projectKey` — so every project's import received the same ~10k server-wide issues. The compute engine then kept only the ones whose component happened to also exist in that project's component tree, explaining the user's observation of ~22% issue retention (191 source → 42 target on `okorach-oss_sonar-tools`).

Fix: switch the four `/api/issues/search` call sites in the extract package from `components` to `componentKeys`. The legacy pipeline helpers already used `componentKeys` (see `go/internal/pipeline/helpers.go:56`), and the name is accepted on SQ 9.9, 10.x, current, and SQC, so no version gate is needed.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./...` all packages pass
- [x] New `TestProjectIssuesFullTaskUsesComponentKeysParam` asserts the inbound `/api/issues/search` URL carries `componentKeys=<projectKey>` and fails if `components=` ever reappears
- [ ] Manual: re-run the failing 9.9 migration and confirm per-project `issues=N` values in the "report packaged" log lines now reflect each project's real issue count instead of clustering at 9996/9997

🤖 Generated with [Claude Code](https://claude.com/claude-code)
