### PR TITLE
Bump version to v2026.06.16-BETA

### DIFF
--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -4,6 +4,6 @@
 
 package version
 
-const Version = "v2026.06.12-BETA"
+const Version = "v2026.06.16-BETA"
 
 const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary
- Bumps `internal/version.Version` from `v2026.06.12-BETA` to `v2026.06.16-BETA`

## Test plan
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)