### PR TITLE
Bump version to v1.0.0-SNAPSHOT

### DIFF
--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -4,6 +4,6 @@
 
 package version
 
-const Version = "v2026.06.16-BETA"
+const Version = "v1.0.0-SNAPSHOT"
 
 const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary
- Bumps `internal/version.Version` from `v2026.06.16-BETA` to `v1.0.0-SNAPSHOT`
- Switches the versioning scheme from date-based BETA to semver SNAPSHOT in preparation for 1.0

## Test plan
- [x] `go build ./...` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)