### PR TITLE
Issue #406: rename --url/--token to --source_*/--target_* with deprecated aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ The minimal JSON configuration file should look like this
     }
 }
 ```
-**Note**: If you don't want to disclose tokens or URL in the configuration file, you can pass them on the tool command line (as `--url` and `--token` parameters)
+**Note**: If you don't want to disclose tokens or URL in the configuration file, you can pass them on the tool command line:
+- `--source_url` and `--source_token` for `extract`
+- `--target_url` and `--target_token` for `migrate` and `reset`.
+- `--source_url`, `--source_token`, `--target_url`, `--target_token` for `transfer`.
+
 **Note**: SQS = SonarQube Server, SQC = SonarQube Cloud
 
 
@@ -110,20 +114,20 @@ Or use a **config file** to keep tokens out of your shell history:
 
 ```bash
 # Example with URL and Token passed on the command line if not in the configuration file
-./sonar-migration-tool extract --url <YOUR_SQS_URL> --token <YOUR_SQS_TOKEN>
+./sonar-migration-tool extract --source_url <YOUR_SQS_URL> --source_token <YOUR_SQS_TOKEN>
 ./sonar-migration-tool structure
 ./sonar-migration-tool mappings
 
 # → edit organizations.csv to set sonarcloud_org_key per row
 
-./sonar-migration-tool migrate --url <YOUR_SQC_URL> --token <YOUR_SQC_TOKEN>
+./sonar-migration-tool migrate --target_url <YOUR_SQC_URL> --target_token <YOUR_SQC_TOKEN>
 ```
 **Note**: SQS = SonarQube Server, SQC = SonarQube Cloud
 
 
-The config file uses the same unified shape as every other command — one top-level block of shared defaults plus `source` and `target` sub-objects. `concurrency`, `timeout`, `export_directory`, mTLS (`pem_file_path` / `key_file_path` / `cert_password`), and `--default_organization` / `--enterprise_key` are all honored either via the JSON file or as CLI overrides.
+The config file uses the same unified shape as every other command — one top-level block of shared defaults plus `source` and `target` sub-objects. `concurrency`, `timeout`, `export_directory`, mTLS (`pem_file_path`, `key_file_path`, `cert_password`), and `--default_organization` / `--enterprise_key` are all honored either via the JSON file or as CLI overrides.
 
-Add `--url` to target a different SonarQube Cloud instance (e.g. `--target_url https://sc-staging.io` for staging).
+Add `--target_url` to target a different SonarQube Cloud instance (e.g. `--target_url https://sc-staging.io` for staging).
 
 Full reference, flags, multi-server migration, and resume support:
 👉 **[Using `migrate` — Migrate All Projects](docs/MIGRATE.md)**
@@ -212,17 +216,17 @@ You may want to rerun the command with the extra `--debug` flag to get more trou
 * Run `migration` 
 
 ```bash
-./sonar-migration-tool extract --url <YOUR_SQS_1_URL> --token <YOUR_SQS_1_TOKEN>
-./sonar-migration-tool extract --url <YOUR_SQS_2_URL> --token <YOUR_SQS_n_TOKEN>
+./sonar-migration-tool extract --source_url <YOUR_SQS_1_URL> --source_token <YOUR_SQS_1_TOKEN>
+./sonar-migration-tool extract --source_url <YOUR_SQS_2_URL> --source_token <YOUR_SQS_n_TOKEN>
 ...
-./sonar-migration-tool extract --url <YOUR_SQS_n_URL> --token <YOUR_SQS_n_TOKEN>
+./sonar-migration-tool extract --source_url <YOUR_SQS_n_URL> --source_token <YOUR_SQS_n_TOKEN>
 
 ./sonar-migration-tool structure
 ./sonar-migration-tool mappings
 
 # → edit organizations.csv to set sonarcloud_org_key per row (column 2)
 
-./sonar-migration-tool migrate --enterprise_key <YOUR_SQC_ENTERPRISE_KEY> --url <SQC_URL> --token <SQC_TOKEN>
+./sonar-migration-tool migrate --enterprise_key <YOUR_SQC_ENTERPRISE_KEY> --target_url <SQC_URL> --target_token <SQC_TOKEN>
 ```
 **Note**: SQS = SonarQube Server, SQC = SonarQube Cloud
 

--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -91,14 +91,14 @@ CLI flags **override** the corresponding config field when both are set.
 ### `extract`
 
 ```bash
-sonar-migration-tool extract --url <url> --token <token> [flags]
+sonar-migration-tool extract --source_url <url> --source_token <token> [flags]
 ```
 
 | Flag | Description |
 |---|---|
 | `-c, --config <path>` | Path to JSON configuration file. |
-| `--url <url>` | SonarQube Server URL. |
-| `--token <token>` | SonarQube Server authentication token. |
+| `--source_url <url>` | SonarQube Server URL. (Legacy `--url` is still accepted but deprecated.) |
+| `--source_token <token>` | SonarQube Server authentication token. (Legacy `--token` is still accepted but deprecated.) |
 | `--export_directory <dir>` | Output directory (default `./migration-files`). |
 | `--extract_type <name>` | Type of extract to run (default `all`). |
 | `--extract_id <id>` | Resume a previous extraction. |
@@ -128,15 +128,15 @@ sonar-migration-tool predictive-report --config config.json
 ### `migrate`
 
 ```bash
-sonar-migration-tool migrate --token <token> --enterprise_key <key> [flags]
+sonar-migration-tool migrate --target_token <token> --enterprise_key <key> [flags]
 ```
 
 | Flag | Description |
 |---|---|
 | `-c, --config <path>` | Path to JSON configuration file. |
-| `--token <token>` | SonarQube Cloud authentication token. |
+| `--target_token <token>` | SonarQube Cloud authentication token. (Legacy `--token` is still accepted but deprecated.) |
 | `--enterprise_key <key>` | SonarQube Cloud enterprise key. |
-| `--url <url>` | SonarQube Cloud URL (default `https://sonarcloud.io/`). |
+| `--target_url <url>` | SonarQube Cloud URL (default `https://sonarcloud.io/`). (Legacy `--url` is still accepted but deprecated.) |
 | `--export_directory <dir>` | Directory containing the extract output. |
 | `--edition <name>` | SonarQube Cloud license edition. |
 | `--run_id <id>` | Resume a failed migration. |

--- a/docs/MIGRATE.md
+++ b/docs/MIGRATE.md
@@ -105,10 +105,10 @@ Connect to SonarQube Server and export all the data needed for migration.
 
 ```bash
 # From source
-go run . extract --url <URL> --token <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
+go run . extract --source_url <URL> --source_token <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
 
 # Built binary
-sonar-migration-tool extract --url <URL> --token <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
+sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> --export_directory ./files/ [--concurrency 25] [--timeout 60]
 ```
 
 | Flag | Description |
@@ -198,10 +198,10 @@ Push everything to SonarQube Cloud. You'll need your SonarQube Cloud admin token
 
 ```bash
 # From source
-go run . migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
+go run . migrate --target_token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
 
 # Built binary
-sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
+sonar-migration-tool migrate --target_token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --export_directory ./files/ [--run_id <id>] [--skip_profiles]
 ```
 
 | Flag | Description |
@@ -212,7 +212,7 @@ sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> -
 | `--skip_profiles` | Skip quality profile migration/provisioning |
 | `--default_organization` | SonarQube Cloud organization key applied to every project when `organizations.csv` has no mapping. Ignored (with a WARN) if any row already carries a `sonarcloud_org_key`. Useful for small instances where every SQS project migrates into one SQC org. |
 | `--edition` | SonarQube Cloud license edition |
-| `--url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
+| `--target_url` | SonarQube Cloud URL (default: `https://sonarcloud.io/`) |
 | `--concurrency` | Max concurrent requests |
 | `--export_directory` | Directory containing SonarQube exports (default: `./migration-files`) |
 
@@ -235,10 +235,10 @@ If a step fails partway through, you can pick up where you left off:
 
 ```bash
 # Resume an extraction
-sonar-migration-tool extract --url <URL> --token <TOKEN> --extract_id <PREVIOUS_EXTRACT_ID> --export_directory ./files/
+sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> --extract_id <PREVIOUS_EXTRACT_ID> --export_directory ./files/
 
 # Resume a migration
-sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --run_id <PREVIOUS_RUN_ID> --export_directory ./files/
+sonar-migration-tool migrate --target_token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --run_id <PREVIOUS_RUN_ID> --export_directory ./files/
 ```
 
 The tool tracks which tasks have already completed and skips them automatically.
@@ -326,7 +326,7 @@ sonar-migration-tool reset <TOKEN> <ENTERPRISE_KEY> --export_directory ./files/
 - Use `--config` with a JSON file for repeatable, scripted migrations.
 - For large instances (50,000+ projects), lower concurrency and increase timeout:
   ```bash
-  sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 10 --timeout 120 --export_directory ./files/
+  sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> --concurrency 10 --timeout 120 --export_directory ./files/
   ```
 
 ---

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -49,7 +49,7 @@ This guide covers common issues when using the SonarQube to SonarCloud migration
 **Solution**: Increase the timeout:
 
 ```bash
-sonar-migration-tool extract --url <URL> --token <TOKEN> --timeout 120 --export_directory ./files/
+sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> --timeout 120 --export_directory ./files/
 ```
 
 ---
@@ -65,7 +65,7 @@ sonar-migration-tool extract --url <URL> --token <TOKEN> --timeout 120 --export_
 2. For self-signed certificates, use mTLS options:
 
 ```bash
-sonar-migration-tool extract --url <URL> --token <TOKEN> \
+sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> \
   --pem_file_path ./certs/client.pem \
   --key_file_path ./certs/client.key \
   --export_directory ./files/
@@ -81,7 +81,7 @@ sonar-migration-tool extract --url <URL> --token <TOKEN> \
 **Solution**: Resume using the `--run_id` flag:
 
 ```bash
-sonar-migration-tool migrate --token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --run_id <RUN_ID> --export_directory ./files/
+sonar-migration-tool migrate --target_token <TOKEN> --enterprise_key <ENTERPRISE_KEY> --run_id <RUN_ID> --export_directory ./files/
 ```
 
 Completed tasks are skipped automatically.
@@ -113,7 +113,7 @@ Completed tasks are skipped automatically.
 Reduce concurrency and increase timeout:
 
 ```bash
-sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 5 --timeout 120 --export_directory ./files/
+sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> --concurrency 5 --timeout 120 --export_directory ./files/
 ```
 
 ---
@@ -124,7 +124,7 @@ sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 5 --timeo
 For large instances (50,000+ projects), lower the concurrency:
 
 ```bash
-sonar-migration-tool extract --url <URL> --token <TOKEN> --concurrency 10 --export_directory ./files/
+sonar-migration-tool extract --source_url <URL> --source_token <TOKEN> --concurrency 10 --export_directory ./files/
 ```
 
 ---

--- a/go/cmd/extract.go
+++ b/go/cmd/extract.go
@@ -23,7 +23,7 @@ var extractCmd = &cobra.Command{
 			return err
 		}
 		if cfg.URL == "" || cfg.Token == "" {
-			return fmt.Errorf("URL and TOKEN are required (--url/--token flags or in config file)")
+			return fmt.Errorf("URL and TOKEN are required (--source_url/--source_token flags or in config file)")
 		}
 		skipped, err := extract.RunExtract(cmd.Context(), cfg)
 		if err != nil {
@@ -43,8 +43,14 @@ var extractCmd = &cobra.Command{
 func init() {
 	f := extractCmd.Flags()
 	f.String("config", "", "Path to JSON configuration file")
-	f.String("url", "", "URL of the SonarQube Server")
-	f.String("token", "", "Authentication token for the SonarQube Server")
+	f.String(flagSourceURL, "", "URL of the SonarQube Server")
+	f.String(flagSourceToken, "", "Authentication token for the SonarQube Server")
+	// Deprecated aliases (#406): kept so existing scripts keep working.
+	// MarkDeprecated hides the flag from --help and prints a warning when used.
+	f.String("url", "", "")
+	f.String("token", "", "")
+	_ = f.MarkDeprecated("url", "use --source_url instead")
+	_ = f.MarkDeprecated("token", "use --source_token instead")
 	f.String("pem_file_path", "", "Path to client certificate pem file")
 	f.String("key_file_path", "", "Path to client certificate key file")
 	f.String("cert_password", "", "Password for client certificate")
@@ -72,9 +78,13 @@ func buildExtractConfig(cmd *cobra.Command, args []string) (extract.ExtractConfi
 		cfg = loaded
 	}
 
-	// Flags override config file.
+	// Flags override config file. Apply the deprecated --url/--token
+	// aliases first so the primary --source_url/--source_token wins when
+	// both are passed (#406).
 	overrideString(cmd, "url", &cfg.URL)
 	overrideString(cmd, "token", &cfg.Token)
+	overrideString(cmd, flagSourceURL, &cfg.URL)
+	overrideString(cmd, flagSourceToken, &cfg.Token)
 	overrideString(cmd, "pem_file_path", &cfg.PEMFilePath)
 	overrideString(cmd, "key_file_path", &cfg.KeyFilePath)
 	overrideString(cmd, "cert_password", &cfg.CertPassword)

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -26,7 +26,7 @@ organization keys to organizations.csv.`,
 			return err
 		}
 		if cfg.Token == "" || cfg.EnterpriseKey == "" {
-			return fmt.Errorf("TOKEN and ENTERPRISE_KEY are required (--token/--enterprise_key flags or in config file)")
+			return fmt.Errorf("TOKEN and ENTERPRISE_KEY are required (--target_token/--enterprise_key flags or in config file)")
 		}
 		runID, err := migrate.RunMigrate(cmd.Context(), cfg)
 		// Attempt the summary report whenever a run directory exists, even
@@ -50,10 +50,15 @@ organization keys to organizations.csv.`,
 func init() {
 	f := migrateCmd.Flags()
 	f.String("config", "", "Path to JSON configuration file")
-	f.String("token", "", "SonarQube Cloud authentication token")
+	f.String(flagTargetToken, "", "SonarQube Cloud authentication token")
 	f.String("enterprise_key", "", "SonarQube Cloud enterprise key")
 	f.String("edition", "", "SonarQube Cloud license edition")
-	f.String("url", "", "URL of SonarQube Cloud")
+	f.String(flagTargetURL, "", "URL of SonarQube Cloud")
+	// Deprecated aliases (#406): kept so existing scripts keep working.
+	f.String("url", "", "")
+	f.String("token", "", "")
+	_ = f.MarkDeprecated("url", "use --target_url instead")
+	_ = f.MarkDeprecated("token", "use --target_token instead")
 	f.String("run_id", "", "ID of a run to resume in case of failures")
 	f.Int("concurrency", 0, "Maximum number of concurrent requests")
 	f.Int("timeout", 0, "Per-HTTP-request timeout in seconds (default: 60). Maps to the top-level timeout config field.")
@@ -80,11 +85,15 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 		cfg = loaded
 	}
 
-	// Flags override config file.
+	// Flags override config file. Apply the deprecated --url/--token
+	// aliases first so the primary --target_url/--target_token wins when
+	// both are passed (#406).
 	overrideString(cmd, "token", &cfg.Token)
+	overrideString(cmd, "url", &cfg.URL)
+	overrideString(cmd, flagTargetToken, &cfg.Token)
+	overrideString(cmd, flagTargetURL, &cfg.URL)
 	overrideString(cmd, "enterprise_key", &cfg.EnterpriseKey)
 	overrideString(cmd, "edition", &cfg.Edition)
-	overrideString(cmd, "url", &cfg.URL)
 	overrideString(cmd, "run_id", &cfg.RunID)
 	overrideString(cmd, "export_directory", &cfg.ExportDirectory)
 	overrideString(cmd, "target_task", &cfg.TargetTask)

--- a/go/cmd/migrate_test.go
+++ b/go/cmd/migrate_test.go
@@ -16,10 +16,10 @@ func newMigrateTestCmd() *cobra.Command {
 	cmd := &cobra.Command{Use: "migrate"}
 	f := cmd.Flags()
 	f.String("config", "", "")
-	f.String("token", "", "")
+	f.String(flagTargetToken, "", "")
+	f.String(flagTargetURL, "", "")
 	f.String("enterprise_key", "", "")
 	f.String("edition", "", "")
-	f.String("url", "", "")
 	f.String("run_id", "", "")
 	f.Int("concurrency", 0, "")
 	f.String("export_directory", "", "")
@@ -27,6 +27,9 @@ func newMigrateTestCmd() *cobra.Command {
 	f.Bool("skip_profiles", false, "")
 	f.Bool("debug", false, "")
 	f.String("default_organization", "", "")
+	// Deprecated aliases — registered so tests can exercise back-compat (#406).
+	f.String("token", "", "")
+	f.String("url", "", "")
 	return cmd
 }
 
@@ -88,7 +91,7 @@ func TestBuildMigrateConfig_DefaultOrganization_ConfigOnly(t *testing.T) {
 // Neither config nor CLI → empty.
 func TestBuildMigrateConfig_DefaultOrganization_Unset(t *testing.T) {
 	cmd := newMigrateTestCmd()
-	_ = cmd.Flags().Set("token", "tok")
+	_ = cmd.Flags().Set(flagTargetToken, "tok")
 	_ = cmd.Flags().Set("enterprise_key", "ent")
 	cfg, err := buildMigrateConfig(cmd, nil)
 	if err != nil {
@@ -99,5 +102,44 @@ func TestBuildMigrateConfig_DefaultOrganization_Unset(t *testing.T) {
 	}
 	if cfg.Token != "tok" || cfg.EnterpriseKey != "ent" {
 		t.Errorf("expected token/enterprise_key from flags, got %q / %q", cfg.Token, cfg.EnterpriseKey)
+	}
+}
+
+// Issue #406: the deprecated --url/--token flags must still work so existing
+// scripts don't break. The new --target_url/--target_token wins when both
+// are passed.
+func TestBuildMigrateConfig_DeprecatedFlagsStillWork(t *testing.T) {
+	cmd := newMigrateTestCmd()
+	_ = cmd.Flags().Set("token", "legacy-tok")
+	_ = cmd.Flags().Set("url", "https://legacy.example.com/")
+	_ = cmd.Flags().Set("enterprise_key", "ent")
+	cfg, err := buildMigrateConfig(cmd, nil)
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if cfg.Token != "legacy-tok" {
+		t.Errorf("deprecated --token should still populate cfg.Token, got %q", cfg.Token)
+	}
+	if cfg.URL != "https://legacy.example.com/" {
+		t.Errorf("deprecated --url should still populate cfg.URL, got %q", cfg.URL)
+	}
+}
+
+func TestBuildMigrateConfig_NewFlagsWinOverDeprecated(t *testing.T) {
+	cmd := newMigrateTestCmd()
+	_ = cmd.Flags().Set("token", "legacy-tok")
+	_ = cmd.Flags().Set("url", "https://legacy.example.com/")
+	_ = cmd.Flags().Set(flagTargetToken, "new-tok")
+	_ = cmd.Flags().Set(flagTargetURL, "https://new.example.com/")
+	_ = cmd.Flags().Set("enterprise_key", "ent")
+	cfg, err := buildMigrateConfig(cmd, nil)
+	if err != nil {
+		t.Fatalf("buildMigrateConfig: %v", err)
+	}
+	if cfg.Token != "new-tok" {
+		t.Errorf("--target_token should win over deprecated --token, got %q", cfg.Token)
+	}
+	if cfg.URL != "https://new.example.com/" {
+		t.Errorf("--target_url should win over deprecated --url, got %q", cfg.URL)
 	}
 }

--- a/go/cmd/reset.go
+++ b/go/cmd/reset.go
@@ -59,7 +59,10 @@ func init() {
 	f := resetCmd.Flags()
 	f.String("config", "", "Path to JSON configuration file (same format as migrate --config)")
 	f.String("edition", "enterprise", "SonarQube Cloud license edition")
-	f.String("url", "https://sonarcloud.io/", "URL of SonarQube Cloud")
+	f.String(flagTargetURL, "https://sonarcloud.io/", "URL of SonarQube Cloud")
+	// Deprecated alias (#406): kept so existing scripts keep working.
+	f.String("url", "https://sonarcloud.io/", "")
+	_ = f.MarkDeprecated("url", "use --target_url instead")
 	f.Int("concurrency", 25, "Maximum number of concurrent requests")
 	f.String("export_directory", DefaultExportDirectory, "Directory to place all interim files")
 	f.Bool(flagResetYes, false, "Skip the interactive confirmation prompt and reset every listed organization (intended for non-interactive / scripted use). #381.")
@@ -85,9 +88,11 @@ func buildResetConfig(cmd *cobra.Command, args []string) (migrate.ResetConfig, e
 		cfg.EnterpriseKey = args[1]
 	}
 
-	// Flags override everything.
+	// Flags override everything. Apply the deprecated --url alias first
+	// so the primary --target_url wins when both are passed (#406).
 	overrideString(cmd, "edition", &cfg.Edition)
 	overrideString(cmd, "url", &cfg.URL)
+	overrideString(cmd, flagTargetURL, &cfg.URL)
 	overrideString(cmd, "export_directory", &cfg.ExportDirectory)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	if cmd.Flags().Changed("debug") {

--- a/go/cmd/reset_test.go
+++ b/go/cmd/reset_test.go
@@ -22,10 +22,12 @@ func newResetTestCmd() *cobra.Command {
 	f := cmd.Flags()
 	f.String("config", "", "")
 	f.String("edition", "enterprise", "")
-	f.String("url", "https://sonarcloud.io/", "")
+	f.String(flagTargetURL, "https://sonarcloud.io/", "")
 	f.Int("concurrency", 25, "")
 	f.String("export_directory", "/app/files/", "")
 	f.Bool("debug", false, "")
+	// Deprecated alias — registered so tests can exercise back-compat (#406).
+	f.String("url", "https://sonarcloud.io/", "")
 	return cmd
 }
 
@@ -88,7 +90,7 @@ func TestBuildResetConfigFlagsOverrideConfig(t *testing.T) {
 
 	cmd := newResetTestCmd()
 	_ = cmd.Flags().Set("config", path)
-	_ = cmd.Flags().Set("url", "https://flag.example.com/")
+	_ = cmd.Flags().Set(flagTargetURL, "https://flag.example.com/")
 	_ = cmd.Flags().Set("concurrency", "99")
 	_ = cmd.Flags().Set("debug", "true")
 
@@ -136,7 +138,7 @@ func TestBuildResetConfigPositionalArgsOverrideConfig(t *testing.T) {
 
 func TestBuildResetConfigNoConfigUsesPositionalAndFlags(t *testing.T) {
 	cmd := newResetTestCmd()
-	_ = cmd.Flags().Set("url", "https://manual.example.com/")
+	_ = cmd.Flags().Set(flagTargetURL, "https://manual.example.com/")
 	_ = cmd.Flags().Set("export_directory", "/manual/dir")
 
 	cfg, err := buildResetConfig(cmd, []string{"tok", "ent"})
@@ -155,6 +157,33 @@ func TestBuildResetConfigNoConfigUsesPositionalAndFlags(t *testing.T) {
 	}
 	if cfg.ExportDirectory != "/manual/dir" {
 		t.Errorf("ExportDirectory: got %q", cfg.ExportDirectory)
+	}
+}
+
+// Issue #406: the deprecated --url flag must still work so existing scripts
+// don't break. The new --target_url wins when both are passed.
+func TestBuildResetConfig_DeprecatedURLStillWorks(t *testing.T) {
+	cmd := newResetTestCmd()
+	_ = cmd.Flags().Set("url", "https://legacy.example.com/")
+	cfg, err := buildResetConfig(cmd, []string{"tok", "ent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.URL != "https://legacy.example.com/" {
+		t.Errorf("deprecated --url should populate cfg.URL, got %q", cfg.URL)
+	}
+}
+
+func TestBuildResetConfig_NewURLWinsOverDeprecated(t *testing.T) {
+	cmd := newResetTestCmd()
+	_ = cmd.Flags().Set("url", "https://legacy.example.com/")
+	_ = cmd.Flags().Set(flagTargetURL, "https://new.example.com/")
+	cfg, err := buildResetConfig(cmd, []string{"tok", "ent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.URL != "https://new.example.com/" {
+		t.Errorf("--target_url should win over deprecated --url, got %q", cfg.URL)
 	}
 }
 

--- a/scripts/execute_full_migration.sh
+++ b/scripts/execute_full_migration.sh
@@ -181,10 +181,10 @@ print_step "Step 5: Migrating to SonarCloud"
 print_warning "This step may take several minutes depending on the number of projects..."
 
 if ! (cd "$GO_DIR" && go run . migrate \
-    "$SONARCLOUD_TOKEN" \
-    "$SONARCLOUD_ENTERPRISE_KEY" \
-    --url="$SONARCLOUD_URL" \
+    --target_url="$SONARCLOUD_URL" \
+    --target_token="$SONARCLOUD_TOKEN" \
     --export_directory="$EXPORT_DIR_ABS" \
+    --enterprise_key="$SONARCLOUD_ENTERPRISE_KEY" \
     --concurrency="$CONCURRENCY"); then
     print_error "Migration failed"
     exit 1


### PR DESCRIPTION
## Summary
- `extract`: `--source_url` / `--source_token` become the primary flags; `--url` / `--token` kept as `MarkDeprecated` aliases for back-compat.
- `migrate`: `--target_url` / `--target_token` become the primary flags; `--url` / `--token` kept as deprecated aliases.
- `reset`: `--target_url` becomes the primary flag; `--url` kept as deprecated alias.
- Primary flag wins when both the primary and the deprecated alias are passed.
- Error messages updated to reference the new flag names.
- Adds back-compat tests confirming deprecated aliases still work and that the primary flag wins.
- README, `docs/MIGRATE.md`, `docs/ADVANCED-CONFIG.md`, `docs/TROUBLESHOOTING.md`, and `scripts/execute_full_migration.sh` updated to use the new flag names.
- Config-file JSON keys (`"url"`, `"token"` inside `source`/`target` blocks) intentionally unchanged — nesting already disambiguates them.

Closes #406

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (including new back-compat tests in `cmd/`)
- [ ] Run `extract --source_url ... --source_token ...` and confirm it works
- [ ] Run `extract --url ... --token ...` and confirm it works with a deprecation warning on stderr
- [ ] Confirm `--help` for each command shows only the primary flags (not the deprecated aliases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)