### PR TITLE
Issue #203: log rate-limit pause/resume; banner only on failure

### DIFF
--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -9,6 +9,7 @@ This page lists **every** option `sonar-migration-tool` accepts — JSON config 
 - [`source` block — consumed by `extract`](#source-block--consumed-by-extract)
 - [`target` block — consumed by `migrate` / `reset`](#target-block--consumed-by-migrate--reset)
 - [Per-command CLI flags](#per-command-cli-flags)
+- [SonarQube Cloud API rate limiting handling](#sonarqube-cloud-api-rate-limiting-handling)
 - [Legacy config shapes](#legacy-config-shapes)
 - [Security tips](#security-tips)
 
@@ -218,6 +219,88 @@ Available on every command:
 | `--debug` | Verbose request/response logging. |
 | `-h, --help` | Help for the command. |
 | `-v, --version` | Print version and exit. |
+
+---
+
+## SonarQube Cloud API rate limiting handling
+
+The `migrate` step is highly API-intensive, and the production SonarQube Cloud platform
+protects its API with rate limiting. A large migration will likely hit that limit. The tool
+handles this automatically — there is nothing to configure — by retrying throttled requests
+with backoff and pausing affected work until the limit clears. This section documents what it
+does and what you will see in the logs.
+
+### What gets retried
+
+| Outcome | Retried? |
+|---|---|
+| `429 Too Many Requests` | Yes |
+| `500`, `502`, `503`, `504` | Yes |
+| Network / connection errors | Yes |
+| Other `4xx` (e.g. `400`, `401`, `403`, `404`) | No — these indicate a caller mistake and fail immediately |
+
+### Backoff schedules
+
+The wait between attempts depends on why the request failed. Every wait also gets up to
+**+50 % random jitter** added, so concurrent workers don't retry in lockstep.
+
+| Trigger | Waits between attempts | Retries |
+|---|---|---|
+| `5xx` / network error | 100 ms, 200 ms, 400 ms | 3 |
+| SonarQube Cloud `429` (application rate limit) | 5 s, 15 s, 30 s, 60 s, 120 s, 300 s | 6 |
+| Cloudflare / unclassified `429` | 2 s | 1 (fail fast) |
+
+A `429` may carry a `Retry-After` header; when present, the tool honors it (using the larger of
+the header value and the scheduled wait), capped at **300 s** to guard against a misconfigured
+proxy asking for an unreasonable delay.
+
+For a sustained SonarQube Cloud rate limit, the worst-case pause for a single request before it
+gives up is the sum of its schedule — roughly **8.8 minutes** (plus jitter). When a request
+exhausts its schedule still seeing `429`, that request fails and the error is reported; the tool
+does not abort the whole migration.
+
+### Classification and coordinated pausing
+
+Each `429` is classified by its body and headers as one of:
+
+- **SonarQube Cloud rate limit** — the documented application limit (JSON error envelope). Uses
+  the long schedule above.
+- **Cloudflare rate limit** — identified by Cloudflare headers (`CF-Ray`, `CF-Mitigated`,
+  `Server: cloudflare`) or its branded HTML error page. Fails fast, since this often needs
+  operator attention rather than waiting.
+- **Unknown 429** — anything else; surfaced in the report for review.
+
+When a SonarQube Cloud rate limit is hit, a **shared gate** makes all concurrent workers pause on
+the same window rather than each independently hammering an already-exhausted quota.
+
+### What you'll see in the logs
+
+When rate limiting is encountered, the tool logs the pause and, once a throttled request gets
+through, logs that the migration has resumed:
+
+```
+WARN  API rate limiting hit — pausing requests and retrying with backoff  kind=sqc-rate-limit retryAfter=… waitChosen=…
+INFO  API rate limiting cleared — migration resuming  pausedFor=… retries=…
+```
+
+These two lines are emitted **once per rate-limiting episode** — a burst of many throttled
+requests produces a single pause/resume pair, not one line per request. Individual retries are
+also logged at `WARN` as `retrying request` (with `attempt`/`maxAttempts`), and the first hit of
+each kind logs a one-time `rate limiting detected` line including a snippet of the response body.
+
+### Report artifact
+
+If any `429` was observed during a run, the tool writes a `rate_limit_events.json` artifact into
+the run directory (counts per kind, cumulative and longest pause, and a snapshot of the first
+event of each kind). Clean runs produce no artifact.
+
+The PDF migration report stays quiet about rate limiting that was handled gracefully — if the
+tool paused and resumed without failing any task, there is **no banner**, regardless of how long
+it paused. An amber rate-limit notice is shown only when rate limiting was *not* worked around:
+
+- a task failed with `429` as its terminal status (re-run with `--run-id` to resume), or
+- a non-standard `429` (Cloudflare / WAF / unclassified) was seen, which may need operator
+  action even if it resolved on its own.
 
 ---
 

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -123,7 +123,11 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 			"status", status, "attempt", attempt, "maxAttempts", total)
 	}
 	rateLimitTracker := NewRateLimitTracker()
+	rlEpisode := &rateLimitEpisodeLogger{logger: logger}
 	rateLimitObs := func(event sqapi.RateLimitEvent) {
+		// Observe feeds the run-wide stats persisted to rate_limit_events.json
+		// for the PDF report; the first event of each kind also carries the
+		// body snippet, which we log once for operator review.
 		if rateLimitTracker.Observe(event) {
 			logger.Warn("rate limiting detected",
 				"kind", event.Kind.String(),
@@ -131,11 +135,18 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 				"waitChosen", event.WaitChosen,
 				"bodySnippet", event.BodySnippet)
 		}
+		// Edge-triggered per-episode "paused" log (deduplicated across
+		// concurrent workers).
+		rlEpisode.onHit(event)
+	}
+	rateLimitRecovery := func(_, _ string, retries int, waited time.Duration) {
+		rlEpisode.onResume(retries, waited)
 	}
 	clientOpts := []sqapi.Option{
 		sqapi.WithTimeout(cfg.Timeout),
 		sqapi.WithRetryLogger(retryLog),
 		sqapi.WithRateLimitObserver(rateLimitObs),
+		sqapi.WithRateLimitRecoveryLogger(rateLimitRecovery),
 	}
 	if cfg.Debug {
 		clientOpts = append(clientOpts, sqapi.WithDebugLogger(common.NewHTTPDebugLogger(logger)))

--- a/go/internal/migrate/ratelimit.go
+++ b/go/internal/migrate/ratelimit.go
@@ -6,12 +6,57 @@ package migrate
 
 import (
 	"encoding/json"
+	"log/slog"
 	"os"
 	"sync"
 	"time"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
 )
+
+// rateLimitEpisodeLogger emits exactly one "paused" / "resuming" log pair per
+// rate-limit episode. It is edge-triggered: onHit logs only on the
+// not-throttled → throttled transition and onResume only on the reverse, so a
+// burst of concurrent workers all parking on the same rate-limit window
+// produces a single readable pair rather than one log line per request. A
+// migration that hits rate limiting several times over its lifetime produces
+// one pair per distinct episode.
+type rateLimitEpisodeLogger struct {
+	mu        sync.Mutex
+	logger    *slog.Logger
+	throttled bool
+}
+
+// onHit records a 429 observation. On the rising edge (first hit of a fresh
+// episode) it logs a single warning; subsequent hits while still throttled are
+// silent so the log is not flooded.
+func (l *rateLimitEpisodeLogger) onHit(event sqapi.RateLimitEvent) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.throttled {
+		return
+	}
+	l.throttled = true
+	l.logger.Warn("API rate limiting hit — pausing requests and retrying with backoff",
+		"kind", event.Kind.String(),
+		"retryAfter", event.RetryAfter,
+		"waitChosen", event.WaitChosen)
+}
+
+// onResume records that a previously throttled request got through. On the
+// falling edge it logs that the migration has resumed; calls while not
+// throttled are no-ops.
+func (l *rateLimitEpisodeLogger) onResume(retries int, waited time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.throttled {
+		return
+	}
+	l.throttled = false
+	l.logger.Info("API rate limiting cleared — migration resuming",
+		"pausedFor", waited,
+		"retries", retries)
+}
 
 // RateLimitEventsFile is the filename written under the run directory
 // when one or more 429 responses were observed during the run. The PDF

--- a/go/internal/report/summary/ratelimit.go
+++ b/go/internal/report/summary/ratelimit.go
@@ -7,7 +7,6 @@ package summary
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -19,23 +18,18 @@ import (
 	sqapi "github.com/sonar-solutions/sq-api-go"
 )
 
-// rateLimitImpactPauseThreshold is the cumulative pause time (in
-// seconds) above which the orange warning is rendered even when the
-// migration completed cleanly. A short blip that recovered in under
-// half a minute is not worth a callout — operators see the JSON in the
-// run dir if they want details.
-const rateLimitImpactPauseThreshold = 30.0
-
 // collectRateLimitReport reads rate_limit_events.json from runDir and
 // returns a *RateLimitReport only when rate limiting materially
-// impacted the run. Returns nil for clean runs, missing files, or
-// recoverable single-blip runs.
+// impacted the run. Returns nil for clean runs and missing files, and —
+// crucially — for runs where rate limiting was hit but the tool paused
+// and resumed gracefully without failing any task. A migration that
+// slowed down but still completed needs no callout.
 //
 // The "materially impacted" predicate is satisfied when ANY of the
 // following hold:
 //   - one or more tasks failed with HTTP 429 as the terminal status,
-//   - cumulative pause time exceeded rateLimitImpactPauseThreshold,
-//   - any non-SQC-classified 429 was observed (Cloudflare or unknown).
+//   - any non-SQC-classified 429 was observed (Cloudflare or unknown),
+//     since those may signal an upstream proxy/WAF needing operator action.
 func collectRateLimitReport(runDir string, failuresByType map[string][]analysis.ReportRow) *RateLimitReport {
 	state, ok := readRateLimitState(runDir)
 	if !ok {
@@ -100,16 +94,13 @@ var nonSQCKindsInPDFOrder = []sqapi.RateLimitKind{
 }
 
 // rateLimitImpacted is the "Only on impact" predicate gating the PDF
-// warning. See the package-level constant for the cumulative-pause
-// cutoff; the other branches are unconditional.
+// warning. A graceful SQC rate-limit episode — hit, paused, resumed,
+// no task failed — is deliberately NOT surfaced: the tool handled it,
+// so the report stays quiet. The warning shows only when rate limiting
+// failed a task, or when a non-SQC 429 (Cloudflare/WAF/unknown) was
+// seen, which may need operator action even if it resolved.
 func rateLimitImpacted(r *RateLimitReport) bool {
-	if r.CloudflareHits > 0 || r.UnknownHits > 0 {
-		return true
-	}
-	if r.CausedTaskFailure {
-		return true
-	}
-	return r.CumulativePauseSeconds > rateLimitImpactPauseThreshold
+	return r.CloudflareHits > 0 || r.UnknownHits > 0 || r.CausedTaskFailure
 }
 
 // anyFailureWas429 reports whether any failed request recorded in the
@@ -147,30 +138,19 @@ func formatHeaders(headers map[string]string) string {
 }
 
 // rateLimitMessage assembles the body text shown inside the orange
-// callout box. The three variants correspond to the impact branches in
-// rateLimitImpacted: clean-but-slow SQC throttling, SQC throttling that
-// killed at least one task, and any non-SQC 429 observation.
+// callout box. The two variants correspond to the impact branches in
+// rateLimitImpacted: any non-SQC 429 observation (preferred when present,
+// as it is more diagnostic), and SQC throttling that killed at least one
+// task. Graceful SQC throttling that recovered is never surfaced, so it
+// has no message variant.
 //
 // The function is pure so it can be unit-tested without touching fpdf
 // or the disk.
 func rateLimitMessage(r *RateLimitReport) string {
-	hasNonSQC := r.CloudflareHits > 0 || r.UnknownHits > 0
-	switch {
-	case hasNonSQC:
+	if r.CloudflareHits > 0 || r.UnknownHits > 0 {
 		return nonSQCMessage(r)
-	case r.CausedTaskFailure:
-		return sqcFailureMessage(r)
-	default:
-		return sqcRecoveredMessage(r)
 	}
-}
-
-func sqcRecoveredMessage(r *RateLimitReport) string {
-	return fmt.Sprintf(
-		"SonarQube Cloud's API rate limit was reached %s during this run. "+
-			"The tool paused and resumed automatically; total pause time was %s. "+
-			"The migration completed successfully but ran slower than usual.",
-		pluralHits(r.SQCHits), formatSeconds(r.CumulativePauseSeconds))
+	return sqcFailureMessage(r)
 }
 
 func sqcFailureMessage(r *RateLimitReport) string {
@@ -198,20 +178,6 @@ func pluralHits(n int) string {
 		return "1 time"
 	}
 	return fmt.Sprintf("%d times", n)
-}
-
-// formatSeconds prints a duration count as a human-friendly string.
-// Sub-minute durations stay in seconds with one decimal; minute+ values
-// round to whole minutes so the callout doesn't read like a stopwatch.
-func formatSeconds(secs float64) string {
-	if secs < 60 {
-		return fmt.Sprintf("%.1f seconds", secs)
-	}
-	mins := int(math.Round(secs / 60))
-	if mins == 1 {
-		return "about 1 minute"
-	}
-	return fmt.Sprintf("about %d minutes", mins)
 }
 
 func snippetForMessage(snippet string) string {

--- a/go/internal/report/summary/ratelimit_test.go
+++ b/go/internal/report/summary/ratelimit_test.go
@@ -35,7 +35,7 @@ func TestCollectRateLimitReport_NoFileReturnsNil(t *testing.T) {
 	assert.Nil(t, got)
 }
 
-func TestCollectRateLimitReport_SingleBlipBelowThreshold(t *testing.T) {
+func TestCollectRateLimitReport_GracefulResumeReturnsNil(t *testing.T) {
 	dir := t.TempDir()
 	writeRateLimitArtefact(t, dir, migrate.RateLimitState{
 		Total:                  1,
@@ -46,10 +46,10 @@ func TestCollectRateLimitReport_SingleBlipBelowThreshold(t *testing.T) {
 		},
 	})
 	got := collectRateLimitReport(dir, nil)
-	assert.Nil(t, got, "single 5s SQC blip below 30s threshold should not surface")
+	assert.Nil(t, got, "an SQC rate limit that paused and resumed without failing a task must not surface")
 }
 
-func TestCollectRateLimitReport_CumulativeAboveThreshold(t *testing.T) {
+func TestCollectRateLimitReport_LongGracefulPauseReturnsNil(t *testing.T) {
 	dir := t.TempDir()
 	writeRateLimitArtefact(t, dir, migrate.RateLimitState{
 		Total:                  3,
@@ -60,10 +60,7 @@ func TestCollectRateLimitReport_CumulativeAboveThreshold(t *testing.T) {
 		},
 	})
 	got := collectRateLimitReport(dir, nil)
-	require.NotNil(t, got)
-	assert.Equal(t, 3, got.SQCHits)
-	assert.InDelta(t, 65.0, got.CumulativePauseSeconds, 0.001)
-	assert.False(t, got.CausedTaskFailure)
+	assert.Nil(t, got, "pause duration no longer matters — a graceful SQC resume never surfaces, however long it paused")
 }
 
 func TestCollectRateLimitReport_TaskFailureWith429(t *testing.T) {
@@ -115,14 +112,6 @@ func TestRateLimitMessageVariants(t *testing.T) {
 		contains []string
 	}{
 		{
-			name: "sqc recovered slow",
-			report: &RateLimitReport{
-				TotalHits: 4, SQCHits: 4,
-				CumulativePauseSeconds: 95,
-			},
-			contains: []string{"SonarQube Cloud", "4 times", "paused and resumed", "minute"},
-		},
-		{
 			name: "sqc task failure",
 			report: &RateLimitReport{
 				TotalHits: 2, SQCHits: 2,
@@ -165,14 +154,6 @@ func TestFormatHeaders(t *testing.T) {
 	assert.Equal(t, "CF-Ray: abc; Server: cloudflare", got)
 	assert.Empty(t, formatHeaders(nil))
 	assert.Empty(t, formatHeaders(map[string]string{}))
-}
-
-func TestFormatSeconds(t *testing.T) {
-	assert.Equal(t, "5.0 seconds", formatSeconds(5))
-	assert.Equal(t, "29.5 seconds", formatSeconds(29.5))
-	assert.Equal(t, "55.0 seconds", formatSeconds(55))   // still under the 60s threshold
-	assert.Equal(t, "about 1 minute", formatSeconds(70)) // rounds to 1 min
-	assert.Equal(t, "about 5 minutes", formatSeconds(300))
 }
 
 func TestSnippetForMessage(t *testing.T) {

--- a/lib/sq-api-go/client.go
+++ b/lib/sq-api-go/client.go
@@ -133,6 +133,7 @@ func buildTransport(cfg *clientConfig, token string, version float64) http.Round
 		sqcBackoff:    sqc429Backoff,
 		nonSQCBackoff: nonSQC429Backoff,
 		logFn:         cfg.retryLogFn,
+		recoveryFn:    cfg.recoveryLogFn,
 		observer:      cfg.rateLimitObsFn,
 		gate:          &rateLimitGate{},
 	}

--- a/lib/sq-api-go/export_test.go
+++ b/lib/sq-api-go/export_test.go
@@ -73,6 +73,7 @@ type RetryTransportConfig struct {
 	SQCBackoff    []time.Duration
 	NonSQCBackoff []time.Duration
 	Logger        RetryLogFunc
+	Recovery      RecoveryLogFunc
 	Observer      RateLimitObserver
 }
 
@@ -84,6 +85,7 @@ func NewRetryTransportFull(cfg RetryTransportConfig) http.RoundTripper {
 		sqcBackoff:    cfg.SQCBackoff,
 		nonSQCBackoff: cfg.NonSQCBackoff,
 		logFn:         cfg.Logger,
+		recoveryFn:    cfg.Recovery,
 		observer:      cfg.Observer,
 		gate:          &rateLimitGate{},
 	}

--- a/lib/sq-api-go/options.go
+++ b/lib/sq-api-go/options.go
@@ -20,6 +20,7 @@ type clientConfig struct {
 	maxConns       int
 	timeoutSecs    int
 	retryLogFn     RetryLogFunc
+	recoveryLogFn  RecoveryLogFunc
 	debugLogFn     DebugLogFunc
 	rateLimitObsFn RateLimitObserver
 }
@@ -90,6 +91,17 @@ func WithTimeout(seconds int) Option {
 func WithRetryLogger(fn RetryLogFunc) Option {
 	return func(cfg *clientConfig) {
 		cfg.retryLogFn = fn
+	}
+}
+
+// WithRateLimitRecoveryLogger sets a callback that fires once per request
+// that was paused by one or more 429 rate-limit responses and then completed
+// successfully — letting the caller log that throttling has cleared and work
+// is flowing again. It is not called for 5xx/network retries, nor when a
+// request exhausts its retry schedule still seeing 429.
+func WithRateLimitRecoveryLogger(fn RecoveryLogFunc) Option {
+	return func(cfg *clientConfig) {
+		cfg.recoveryLogFn = fn
 	}
 }
 

--- a/lib/sq-api-go/ratelimit_test.go
+++ b/lib/sq-api-go/ratelimit_test.go
@@ -212,6 +212,131 @@ func TestRetryTransportRetryAfterHonored(t *testing.T) {
 		"Retry-After: 1 should produce at least one second of wall-clock pause")
 }
 
+// recoveryCall captures one invocation of the RecoveryLogFunc.
+type recoveryCall struct {
+	retries int
+	waited  time.Duration
+}
+
+func TestRetryTransportRecoveryFiresAfter429(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"errors":[{"msg":"rate limit exceeded"}]}`))
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var (
+		mu    sync.Mutex
+		calls []recoveryCall
+	)
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:      http.DefaultTransport,
+		Backoff:    []time.Duration{0},
+		SQCBackoff: []time.Duration{5 * time.Millisecond, 5 * time.Millisecond},
+		Recovery: func(_, _ string, retries int, waited time.Duration) {
+			mu.Lock()
+			defer mu.Unlock()
+			calls = append(calls, recoveryCall{retries: retries, waited: waited})
+		},
+	})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, calls, 1, "recovery must fire exactly once when a 429 clears")
+	assert.Equal(t, 1, calls[0].retries, "one retry preceded the recovery")
+	assert.Greater(t, calls[0].waited, time.Duration(0), "recovery must report the time spent paused")
+}
+
+func TestRetryTransportRecoveryNotFiredFor5xx(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var fired atomic.Int32
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:   http.DefaultTransport,
+		Backoff: []time.Duration{0},
+		Recovery: func(_, _ string, _ int, _ time.Duration) {
+			fired.Add(1)
+		},
+	})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(0), fired.Load(), "5xx retries are not rate limiting — recovery must not fire")
+}
+
+func TestRetryTransportRecoveryNotFiredWhenScheduleExhausted(t *testing.T) {
+	var attempts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"errors":[{"msg":"still limited"}]}`))
+	}))
+	defer ts.Close()
+
+	var fired atomic.Int32
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:      http.DefaultTransport,
+		Backoff:    []time.Duration{0},
+		SQCBackoff: []time.Duration{0, 0},
+		Recovery: func(_, _ string, _ int, _ time.Duration) {
+			fired.Add(1)
+		},
+	})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	assert.Equal(t, int32(0), fired.Load(), "a request that never clears the 429 has not recovered")
+}
+
+func TestRetryTransportRecoveryNotFiredOnImmediateSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var fired atomic.Int32
+	transport := sqapi.NewRetryTransportFull(sqapi.RetryTransportConfig{
+		Inner:   http.DefaultTransport,
+		Backoff: []time.Duration{0},
+		Recovery: func(_, _ string, _ int, _ time.Duration) {
+			fired.Add(1)
+		},
+	})
+
+	client := &http.Client{Transport: transport}
+	resp, err := client.Get(ts.URL)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, int32(0), fired.Load(), "a request that was never throttled has not recovered")
+}
+
 func TestRateLimitGateExtend(t *testing.T) {
 	gate := sqapi.NewRateLimitGate()
 	gate.Extend(time.Now().Add(50 * time.Millisecond))

--- a/lib/sq-api-go/retry.go
+++ b/lib/sq-api-go/retry.go
@@ -66,6 +66,15 @@ var retryableStatusCodes = map[int]bool{
 // current attempt number (1-based), and total attempts.
 type RetryLogFunc func(method, url string, status, attempt, total int)
 
+// RecoveryLogFunc is called once when a request that was paused by one or
+// more 429 rate-limit responses finally completes with a non-429 outcome —
+// i.e. the throttling cleared and this request got through. It receives the
+// HTTP method, URL path, the number of retries that preceded the recovery,
+// and the cumulative time this request spent waiting on rate-limit backoff.
+// It is NOT called when a request exhausts its retry schedule still seeing
+// 429 (that is a failure, not a resume), nor for 5xx/network-error retries.
+type RecoveryLogFunc func(method, url string, retries int, waited time.Duration)
+
 // rateLimitGate is a shared barrier that holds new requests when an
 // SQC-classified 429 has been observed, until the chosen backoff has
 // elapsed. Concurrent workers all park on the same deadline instead of
@@ -132,6 +141,7 @@ type retryTransport struct {
 	sqcBackoff    []time.Duration
 	nonSQCBackoff []time.Duration
 	logFn         RetryLogFunc
+	recoveryFn    RecoveryLogFunc
 	observer      RateLimitObserver
 	gate          *rateLimitGate
 }
@@ -142,11 +152,23 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		err  error
 	)
 
+	// pausedForRateLimit records whether this request slept for at least one
+	// 429 backoff; totalWaited accumulates that backoff. They drive the
+	// recovery callback so we log a resume only for requests that were
+	// genuinely throttled (not 5xx/network retries) and then got through.
+	var (
+		pausedForRateLimit bool
+		totalWaited        time.Duration
+	)
+
 	for attempt := 0; ; attempt++ {
 		t.waitOnGate(req.Context())
 
 		resp, err = t.inner.RoundTrip(req)
 		if !shouldRetry(resp, err) {
+			if pausedForRateLimit {
+				t.fireRecovery(req, attempt, totalWaited)
+			}
 			return resp, err
 		}
 
@@ -166,6 +188,10 @@ func (t *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		t.fireObserver(rl, chosenWait, wallClockAdded)
 		if !more {
 			return resp, err
+		}
+		if rl.is429 {
+			pausedForRateLimit = true
+			totalWaited += chosenWait
 		}
 
 		t.logAttempt(req, resp, attempt, total)
@@ -303,6 +329,17 @@ func (t *retryTransport) extendGate(until time.Time) time.Duration {
 		return 0
 	}
 	return t.gate.extend(until)
+}
+
+// fireRecovery delivers a one-shot "throttling cleared, request got through"
+// signal to the configured RecoveryLogFunc. retries is the number of failed
+// attempts that preceded the successful one; waited is the cumulative
+// rate-limit backoff this request slept through.
+func (t *retryTransport) fireRecovery(req *http.Request, retries int, waited time.Duration) {
+	if t.recoveryFn == nil {
+		return
+	}
+	t.recoveryFn(req.Method, req.URL.Path, retries, waited)
 }
 
 func (t *retryTransport) logAttempt(req *http.Request, resp *http.Response, attempt, total int) {


### PR DESCRIPTION
## Summary

Closes part of #203. The retry/backoff/gate machinery for SonarQube Cloud API rate limiting already existed and is unchanged; this PR fills two gaps:

1. **Resume logging** — there was no log when rate limiting cleared and the migration resumed (the retry transport returned recovered responses silently).
2. **PDF banner** — it fired even for a graceful pause that resumed cleanly; per request, it should only warn when rate limiting was *not* worked around.
3. **Docs** — the behavior was undocumented.

## Changes

**`lib/sq-api-go` (SDK)**
- New `RecoveryLogFunc` + `WithRateLimitRecoveryLogger` option. The retry transport fires a one-shot recovery signal when a request that paused for a `429` finally completes with a non-429 outcome. It does **not** fire for 5xx/network retries, nor when retries exhaust still seeing `429` (that is a failure, not a resume).

**`go/internal/migrate`**
- Edge-triggered, per-episode logging deduplicated across concurrent workers:
  - `WARN  API rate limiting hit — pausing requests and retrying with backoff`
  - `INFO  API rate limiting cleared — migration resuming`

**`go/internal/report/summary` (PDF report)**
- The amber banner no longer fires for a graceful SQC pause that resumed without failing a task — regardless of pause duration. Dropped the `CumulativePauseSeconds > 30` trigger and the now-dead `sqcRecoveredMessage` / `formatSeconds` helper.
- It still fires when a task failed with a `429` terminal status, or a non-standard (Cloudflare/WAF/unknown) `429` was observed.

**`docs/ADVANCED-CONFIG.md`**
- New "SonarQube Cloud API rate limiting handling" section (retryable statuses, backoff schedules, classification, gate, the new log lines, and when the banner appears).

## Out of scope (other #203 checklist items)
- Multi-token round-robin distribution.

## Verification
- `go build ./...` (both modules): clean
- `go vet`: clean
- `go test ./lib/sq-api-go/...`, `./go/internal/migrate/...`, `./go/internal/report/summary/...`: pass (incl. new recovery tests + updated banner tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
