### PR TITLE
Issue #138: configurable project-key renaming strategy

### DIFF
--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -9,6 +9,7 @@ This page lists **every** option `sonar-migration-tool` accepts — JSON config 
 - [Top-level fields](#top-level-fields)
 - [`source` block — consumed by `extract`](#source-block--consumed-by-extract)
 - [`target` block — consumed by `migrate` / `reset`](#target-block--consumed-by-migrate--reset)
+- [Project key renaming strategy](#project-key-renaming-strategy)
 - [Per-command CLI flags](#per-command-cli-flags)
 - [SonarQube Cloud API rate limiting handling](#sonarqube-cloud-api-rate-limiting-handling)
 - [Legacy config shapes](#legacy-config-shapes)
@@ -77,6 +78,7 @@ Only `source.url` / `source.token` (for `extract`) and `target.url` / `target.to
 | `target.run_id` | `--run_id` | `null` | No | Resume an in-progress migrate run by ID. |
 | `target.target_task` | `--target_task` | `null` | No | Stop migrate at a specific task (dependencies still run). |
 | `target.default_organization` | `--default_organization` | `null` | No | SonarQube Cloud org applied to every project when `organizations.csv` has no per-row mapping. Ignored (with a WARN) when any row carries a `sonarcloud_org_key` (#281). |
+| `target.project_key_pattern` | `--project_key_pattern` | `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>` | No | Template for target project keys (#138). See [Project key renaming strategy](#project-key-renaming-strategy). |
 | `target.skip_profiles` | `--skip_profiles` | `false` | No | Skip quality profile migration / provisioning. |
 | `target.exclude_branches` | `--exclude_branches` | `[]` | No | Glob patterns (Go `filepath.Match`) for non-main branches to skip. The main branch is never excluded. Repeatable on the CLI. |
 | `target.organization_key` | — | `null` | No | Provisional — accepted but ignored today. |
@@ -144,9 +146,71 @@ The CLI flags `--skip_issue_sync` and `--skip_project_data_migration` on `migrat
 | `run_id` | | Resume an in-progress migrate run by ID. |
 | `target_task` | | Stop migrate at a specific task. |
 | `default_organization` | | SonarCloud org applied to every project when `organizations.csv` has no per-row mapping. Ignored (with a WARN) when any row already carries a `sonarcloud_org_key`. CLI `--default_organization` wins. |
+| `project_key_pattern` | | Template for target project keys, built from `<ORIGINAL_PROJECT_KEY>` and `<ORGANIZATION_KEY>`. Default `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>`. CLI `--project_key_pattern` wins. See [Project key renaming strategy](#project-key-renaming-strategy). |
 | `skip_profiles` | | Skip quality profile migration. |
 | `exclude_branches` | | Array of glob patterns (Go `filepath.Match` syntax) for non-main branches to skip during project data import. The main branch is never excluded regardless of patterns. Example: `["feature/*", "release/*"]`. |
 | `organization_key` | | Provisional — accepted but ignored today. |
+
+---
+
+## Project key renaming strategy
+
+When a project is migrated to SonarQube Cloud its key is rewritten according to
+`target.project_key_pattern` (CLI: `--project_key_pattern`). The pattern is a template built from
+two placeholders:
+
+| Placeholder | Replaced with |
+|---|---|
+| `<ORIGINAL_PROJECT_KEY>` | the source project key (mandatory; `<PROJECT_KEY>` is accepted as an alias) |
+| `<ORGANIZATION_KEY>` | the target SonarQube Cloud organization key |
+
+**Default:** `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>` — SonarQube Cloud's own convention, and the tool's
+historical behavior. Leaving the field unset reproduces exactly what previous versions did.
+
+### Examples
+
+```text
+<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>            →  myorg_my-project
+ACME_CORP_<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>  →  ACME_CORP_myorg_my-project
+<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>_migrated   →  myorg_my-project_migrated
+ACME_CORP_<ORIGINAL_PROJECT_KEY>                     →  ACME_CORP_my-project
+sqs_<ORIGINAL_PROJECT_KEY>_migrated                  →  sqs_my-project_migrated
+<ORIGINAL_PROJECT_KEY>                               →  my-project          (keep unchanged)
+```
+
+### Validation rules
+
+The pattern is validated before the migration starts; an invalid pattern aborts the run with a
+clear error:
+
+- It must contain `<ORIGINAL_PROJECT_KEY>` (a pattern with no placeholder is rejected).
+- Only the two documented placeholders are allowed; any other `<…>` token is rejected.
+- A pattern whose **only** placeholder is `<ORIGINAL_PROJECT_KEY>` is allowed in two forms: bare
+  (`<ORIGINAL_PROJECT_KEY>`, i.e. keep the key unchanged) or with a **static prefix and/or postfix
+  totalling at least 5 characters** (`acme_<ORIGINAL_PROJECT_KEY>` ✅,
+  `MYCORP_<ORIGINAL_PROJECT_KEY>` ✅, `sqs_<ORIGINAL_PROJECT_KEY>_migrated` ✅,
+  `AAA_<ORIGINAL_PROJECT_KEY>` ❌). A short generic affix is too collision-prone to allow.
+
+### Organization-prefix collision guard
+
+If the pattern does **not** include `<ORGANIZATION_KEY>` (so every project gets the same static prefix),
+the tool checks that the prefix does not match an existing SonarQube Cloud organization key. A
+match would make the renamed keys look organization-scoped while not being mapped through one, so
+`migrate` aborts and asks you to disambiguate (for example by adding `<ORGANIZATION_KEY>`).
+
+### Conflict & length reporting
+
+Before keys are created the tool renders every target key and reports, in both the markdown and
+PDF migration reports (an amber callout):
+
+- **Collisions** — the same target key produced by more than one source project. Because SonarQube
+  Cloud project keys are globally unique, colliding projects cannot all be created. This typically
+  happens when a pattern without `<ORGANIZATION_KEY>` maps the same source key from two organizations.
+- **Over-length keys** — any rendered key longer than the SonarQube limit of 400 characters, which
+  the API would reject.
+
+Permission-template and portfolio selection regexes are adapted automatically to whatever prefix
+the chosen pattern produces, so they keep matching the renamed keys.
 
 ---
 
@@ -212,6 +276,7 @@ sonar-migration-tool migrate --target_token <token> --enterprise_key <key> [flag
 | `--skip_project_data_migration` | Skip the entire project-data migration: `importProjectData` plus the trailing sync pair. Implies `--skip_issue_sync`. One-way override of the `skip_project_data_migration` config field. Issue #303. |
 | `--exclude_branches <pattern>` | Glob pattern for non-main branches to skip during project data import. Repeatable. Main branch is never excluded. |
 | `--default_organization <key>` | SonarCloud org applied to every project when `organizations.csv` has no mapping defined. |
+| `--project_key_pattern <pattern>` | Template for target project keys (`<ORIGINAL_PROJECT_KEY>` / `<ORGANIZATION_KEY>`). Default `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>`. See [Project key renaming strategy](#project-key-renaming-strategy). |
 | `--concurrency <n>` | Max concurrent requests. |
 
 ### `reset`
@@ -252,6 +317,7 @@ file.
 | `--target_url <url>` | `target.url` | SonarQube Cloud URL. |
 | `--target_token <token>` | `target.token` | SonarQube Cloud token. |
 | `--default_organization <key>` | `target.default_organization` | SonarQube Cloud organization key. |
+| `--project_key_pattern <pattern>` | `target.project_key_pattern` | Template for target project keys. See [Project key renaming strategy](#project-key-renaming-strategy). |
 | `--enterprise_key <key>` | `target.enterprise_key` | SonarQube Cloud enterprise key (defaults to `--default_organization`). |
 | `--export_dir <dir>` | `export_directory` | Working directory (default `./migration-files/`). |
 | `--concurrency <n>` | `concurrency` | Max concurrent HTTP requests. |

--- a/examples/config.unified.example.json
+++ b/examples/config.unified.example.json
@@ -28,6 +28,7 @@
     "timeout": 60,
     "run_id": null,
     "target_task": null,
-    "organization_key": null
+    "organization_key": null,
+    "project_key_pattern": "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>"
   }
 }

--- a/go/cmd/migrate.go
+++ b/go/cmd/migrate.go
@@ -68,6 +68,7 @@ func init() {
 	f.Bool(flagSkipIssueSync, false, "Skip the final per-issue and per-hotspot metadata sync (#299). Same semantics as the skip_issue_sync config-file field — defaults to false (sync happens); pass the flag to skip.")
 	f.Bool(flagSkipProjectDataMigration, false, "Skip the entire project-data migration: importProjectData and the trailing per-issue/per-hotspot sync (#303). Defaults to false (data is migrated); pass the flag to skip.")
 	f.String("default_organization", "", "SonarQube Cloud organization to migrate every project into when organizations.csv has no mapping defined. Ignored if any mapping is present.")
+	f.String("project_key_pattern", "", "Template for target project keys, built from <ORIGINAL_PROJECT_KEY> and <ORGANIZATION_KEY> (default: <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>). #138")
 	f.StringSlice("exclude_branches", nil, "Glob patterns for non-main branches to skip during project data import (e.g. feature/*,bugfix/*)")
 }
 
@@ -98,6 +99,7 @@ func buildMigrateConfig(cmd *cobra.Command, args []string) (migrate.MigrateConfi
 	overrideString(cmd, "export_directory", &cfg.ExportDirectory)
 	overrideString(cmd, "target_task", &cfg.TargetTask)
 	overrideString(cmd, "default_organization", &cfg.DefaultOrganization)
+	overrideString(cmd, "project_key_pattern", &cfg.ProjectKeyPattern)
 	overrideInt(cmd, "concurrency", &cfg.Concurrency)
 	overrideInt(cmd, "timeout", &cfg.Timeout)
 	if cmd.Flags().Changed("skip_profiles") {

--- a/go/cmd/reset_test.go
+++ b/go/cmd/reset_test.go
@@ -188,9 +188,21 @@ func TestBuildResetConfig_NewURLWinsOverDeprecated(t *testing.T) {
 }
 
 func TestBuildResetConfigShape3FromExampleFile(t *testing.T) {
-	// Round-trip the documented side-sectioned example via buildResetConfig.
-	path, err := filepath.Abs("../../examples/migration-config.example.json")
-	if err != nil {
+	// Round-trip a side-sectioned config via buildResetConfig. The shape is
+	// no longer shipped as an example file (examples/ was consolidated in
+	// #408), so the fixture is inline; the parser still supports the shape.
+	const sideSectioned = `{
+  "sonarqube": { "url": "http://localhost:9000", "token": "x" },
+  "sonarcloud": {
+    "url": "https://sonarcloud.io/",
+    "token": "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE",
+    "enterprise_key": "YOUR_ENTERPRISE_KEY_HERE",
+    "org_key": "YOUR_TARGET_ORGANIZATION_KEY_HERE"
+  },
+  "settings": { "export_directory": "./files", "concurrency": 10, "timeout": 60 }
+}`
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(sideSectioned), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -28,25 +28,26 @@ const (
 	sqServerName = "SonarQube Server"
 	scCloudName  = "SonarQube Cloud"
 
-	flagConfig             = "config"
-	flagSourceURL          = "source_url"
-	flagSourceToken        = "source_token"
-	flagProjectKey         = "project_key"
-	flagTargetURL          = "target_url"
-	flagTargetToken        = "target_token"
-	flagEnterpriseKey      = "enterprise_key"
-	flagDefaultOrg         = "default_organization"
-	flagEdition            = "edition"
+	flagConfig                   = "config"
+	flagSourceURL                = "source_url"
+	flagSourceToken              = "source_token"
+	flagProjectKey               = "project_key"
+	flagTargetURL                = "target_url"
+	flagTargetToken              = "target_token"
+	flagEnterpriseKey            = "enterprise_key"
+	flagDefaultOrg               = "default_organization"
+	flagProjectKeyPattern        = "project_key_pattern"
+	flagEdition                  = "edition"
 	flagExportDir                = "export_dir"
 	flagSkipIssueSync            = "skip_issue_sync"
 	flagSkipProjectDataMigration = "skip_project_data_migration"
 	flagConcurrency              = "concurrency"
-	flagTimeout            = "timeout"
-	flagPEMFilePath        = "pem_file_path"
-	flagKeyFilePath        = "key_file_path"
-	flagCertPassword       = "cert_password"
-	flagDebug              = "debug"
-	flagExcludeBranches    = "exclude_branches"
+	flagTimeout                  = "timeout"
+	flagPEMFilePath              = "pem_file_path"
+	flagKeyFilePath              = "key_file_path"
+	flagCertPassword             = "cert_password"
+	flagDebug                    = "debug"
+	flagExcludeBranches          = "exclude_branches"
 )
 
 // transferTargetTasks is the explicit set of project-scoped "leaf" migrate
@@ -155,6 +156,7 @@ func init() {
 	f.String(flagTargetURL, "", scCloudName+" URL (maps to target.url, default: https://sonarcloud.io/)")
 	f.String(flagTargetToken, "", scCloudName+" token (maps to target.token)")
 	f.String(flagDefaultOrg, "", scCloudName+" organization key (maps to target.default_organization)")
+	f.String(flagProjectKeyPattern, "", "Template for target project keys, built from <ORIGINAL_PROJECT_KEY> and <ORGANIZATION_KEY> (maps to target.project_key_pattern; default: <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>)")
 	f.String(flagEnterpriseKey, "", scCloudName+" enterprise key (maps to target.enterprise_key, defaults to --"+flagDefaultOrg+")")
 	f.String(flagEdition, "", scCloudName+" license edition (maps to target.edition; defaults to enterprise)")
 	f.String(flagExportDir, "./migration-files/", "Working directory for intermediate files (maps to export_directory)")
@@ -171,15 +173,16 @@ func init() {
 
 // transferConfig holds the resolved configuration after merging file and flag values.
 type transferConfig struct {
-	sourceURL           string
-	sourceToken         string
-	projectKey          string
-	targetURL           string
-	targetToken         string
-	defaultOrganization string
-	enterpriseKey       string
-	edition             string
-	exportDir           string
+	sourceURL                string
+	sourceToken              string
+	projectKey               string
+	targetURL                string
+	targetToken              string
+	defaultOrganization      string
+	projectKeyPattern        string
+	enterpriseKey            string
+	edition                  string
+	exportDir                string
 	concurrency              int
 	timeout                  int
 	pemFilePath              string
@@ -255,6 +258,7 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 	cfg.enterpriseKey = migrateCfg.EnterpriseKey
 	cfg.edition = migrateCfg.Edition
 	cfg.defaultOrganization = migrateCfg.DefaultOrganization
+	cfg.projectKeyPattern = migrateCfg.ProjectKeyPattern
 
 	cfg.exportDir = extractCfg.ExportDirectory
 	if cfg.exportDir == "" {
@@ -298,6 +302,7 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 	applyFlagString(cmd, flagTargetURL, &cfg.targetURL)
 	applyFlagString(cmd, flagTargetToken, &cfg.targetToken)
 	applyFlagString(cmd, flagDefaultOrg, &cfg.defaultOrganization)
+	applyFlagString(cmd, flagProjectKeyPattern, &cfg.projectKeyPattern)
 	applyFlagString(cmd, flagEnterpriseKey, &cfg.enterpriseKey)
 	applyFlagString(cmd, flagEdition, &cfg.edition)
 	applyFlagString(cmd, flagExportDir, &cfg.exportDir)
@@ -522,6 +527,7 @@ func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error)
 		SkipProjectDataMigration: cfg.skipProjectDataMigration,
 		Debug:                    cfg.debug,
 		ExcludeBranches:          cfg.excludeBranches,
+		ProjectKeyPattern:        cfg.projectKeyPattern,
 	})
 	if err != nil {
 		return "", fmt.Errorf("migrate failed: %w", err)

--- a/go/internal/extract/config_file_test.go
+++ b/go/internal/extract/config_file_test.go
@@ -11,17 +11,45 @@ import (
 	"testing"
 )
 
-const examplesDir = "../../../examples"
+// The legacy config shapes are no longer shipped as example files (the
+// examples/ directory was consolidated in #408), but the parser still
+// supports them. These fixtures keep one representative document per shape
+// inline so the parser is exercised independently of the docs examples.
+const (
+	flatExtractJSON = `{
+  "url": "http://localhost:9000",
+  "token": "YOUR_SONARQUBE_TOKEN_HERE",
+  "export_directory": "./files",
+  "concurrency": 10,
+  "timeout": 60
+}`
+	commandSectionedExtractJSON = `{
+  "extract": {
+    "url": "http://localhost:9000",
+    "token": "YOUR_SONARQUBE_TOKEN_HERE",
+    "export_directory": "./files",
+    "extract_type": "all",
+    "concurrency": 10,
+    "timeout": 60
+  },
+  "migrate": { "url": "https://sonarcloud.io/", "token": "y" }
+}`
+	sideSectionedExtractJSON = `{
+  "sonarqube": { "url": "http://localhost:9000", "token": "YOUR_SONARQUBE_ADMIN_TOKEN_HERE" },
+  "sonarcloud": { "url": "https://sonarcloud.io/", "token": "y" },
+  "settings": { "export_directory": "./files", "concurrency": 10, "timeout": 60 }
+}`
+)
 
 func TestLoadExtractConfigFileShapes(t *testing.T) {
 	cases := []struct {
-		name string
-		file string
-		want ExtractConfig
+		name    string
+		content string
+		want    ExtractConfig
 	}{
 		{
-			name: "shape 1 - flat",
-			file: "config-extract.example.json",
+			name:    "shape 1 - flat",
+			content: flatExtractJSON,
 			want: ExtractConfig{
 				URL:             "http://localhost:9000",
 				Token:           "YOUR_SONARQUBE_TOKEN_HERE",
@@ -31,8 +59,8 @@ func TestLoadExtractConfigFileShapes(t *testing.T) {
 			},
 		},
 		{
-			name: "shape 2 - command-sectioned",
-			file: "config.example.json",
+			name:    "shape 2 - command-sectioned",
+			content: commandSectionedExtractJSON,
 			want: ExtractConfig{
 				URL:             "http://localhost:9000",
 				Token:           "YOUR_SONARQUBE_TOKEN_HERE",
@@ -43,8 +71,8 @@ func TestLoadExtractConfigFileShapes(t *testing.T) {
 			},
 		},
 		{
-			name: "shape 3 - side-sectioned",
-			file: "migration-config.example.json",
+			name:    "shape 3 - side-sectioned",
+			content: sideSectionedExtractJSON,
 			want: ExtractConfig{
 				URL:             "http://localhost:9000",
 				Token:           "YOUR_SONARQUBE_ADMIN_TOKEN_HERE",
@@ -57,9 +85,13 @@ func TestLoadExtractConfigFileShapes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := LoadExtractConfigFile(filepath.Join(examplesDir, tc.file))
+			path := filepath.Join(t.TempDir(), "config.json")
+			if err := os.WriteFile(path, []byte(tc.content), 0o600); err != nil {
+				t.Fatalf("writing fixture: %v", err)
+			}
+			got, err := LoadExtractConfigFile(path)
 			if err != nil {
-				t.Fatalf("LoadExtractConfigFile(%s): %v", tc.file, err)
+				t.Fatalf("LoadExtractConfigFile(%s): %v", tc.name, err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("ExtractConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -96,6 +96,7 @@ type unifiedTargetBlock struct {
 	TargetTask          string   `json:"target_task"`
 	OrganizationKey     string   `json:"organization_key"`     // provisional, ignored
 	DefaultOrganization string   `json:"default_organization"` // #281
+	ProjectKeyPattern   string   `json:"project_key_pattern"`  // #138
 	ExcludeBranches     []string `json:"exclude_branches"`
 }
 
@@ -162,6 +163,7 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			cfg.Concurrency = s.Target.Concurrency
 			cfg.Timeout = s.Target.Timeout
 			cfg.DefaultOrganization = s.Target.DefaultOrganization
+			cfg.ProjectKeyPattern = s.Target.ProjectKeyPattern
 			cfg.ExcludeBranches = s.Target.ExcludeBranches
 		}
 		if cfg.Concurrency == 0 {

--- a/go/internal/migrate/config_file_test.go
+++ b/go/internal/migrate/config_file_test.go
@@ -11,17 +11,60 @@ import (
 	"testing"
 )
 
-const examplesDir = "../../../examples"
+// The legacy config shapes no longer ship as example files (the examples/
+// directory was consolidated in #408), but the parser still supports them.
+// These fixtures keep one representative document per shape inline so the
+// parser is exercised independently of the docs examples.
+const (
+	flatShapeJSON = `{
+  "token": "YOUR_SONARCLOUD_TOKEN_HERE",
+  "enterprise_key": "YOUR_ENTERPRISE_KEY",
+  "url": "https://sonarcloud.io/",
+  "export_directory": "./files",
+  "concurrency": 10
+}`
+	commandSectionedShapeJSON = `{
+  "extract": { "url": "http://localhost:9000", "token": "x" },
+  "migrate": {
+    "token": "YOUR_SONARCLOUD_TOKEN_HERE",
+    "enterprise_key": "YOUR_ENTERPRISE_KEY",
+    "url": "https://sonarcloud.io/",
+    "edition": "enterprise",
+    "export_directory": "./files",
+    "concurrency": 10
+  }
+}`
+	sideSectionedShapeJSON = `{
+  "sonarqube": { "url": "http://localhost:9000", "token": "x" },
+  "sonarcloud": {
+    "url": "https://sonarcloud.io/",
+    "token": "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE",
+    "enterprise_key": "YOUR_ENTERPRISE_KEY_HERE",
+    "org_key": "YOUR_TARGET_ORGANIZATION_KEY_HERE"
+  },
+  "settings": { "export_directory": "./files", "concurrency": 10, "timeout": 60 }
+}`
+)
+
+// writeConfigFixture writes content to a temp file and returns its path.
+func writeConfigFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing config fixture: %v", err)
+	}
+	return path
+}
 
 func TestLoadMigrateConfigFileShapes(t *testing.T) {
 	cases := []struct {
-		name string
-		file string
-		want MigrateConfig
+		name    string
+		content string
+		want    MigrateConfig
 	}{
 		{
-			name: "shape 1 - flat",
-			file: "config-migrate.example.json",
+			name:    "shape 1 - flat",
+			content: flatShapeJSON,
 			want: MigrateConfig{
 				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
 				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
@@ -31,8 +74,8 @@ func TestLoadMigrateConfigFileShapes(t *testing.T) {
 			},
 		},
 		{
-			name: "shape 2 - command-sectioned",
-			file: "config.example.json",
+			name:    "shape 2 - command-sectioned",
+			content: commandSectionedShapeJSON,
 			want: MigrateConfig{
 				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
 				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
@@ -43,8 +86,8 @@ func TestLoadMigrateConfigFileShapes(t *testing.T) {
 			},
 		},
 		{
-			name: "shape 3 - side-sectioned",
-			file: "migration-config.example.json",
+			name:    "shape 3 - side-sectioned",
+			content: sideSectionedShapeJSON,
 			want: MigrateConfig{
 				Token:           "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE",
 				EnterpriseKey:   "YOUR_ENTERPRISE_KEY_HERE",
@@ -59,9 +102,9 @@ func TestLoadMigrateConfigFileShapes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := LoadMigrateConfigFile(filepath.Join(examplesDir, tc.file))
+			got, err := LoadMigrateConfigFile(writeConfigFixture(t, tc.content))
 			if err != nil {
-				t.Fatalf("LoadMigrateConfigFile(%s): %v", tc.file, err)
+				t.Fatalf("LoadMigrateConfigFile(%s): %v", tc.name, err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("MigrateConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)
@@ -72,13 +115,13 @@ func TestLoadMigrateConfigFileShapes(t *testing.T) {
 
 func TestLoadResetConfigFileShapes(t *testing.T) {
 	cases := []struct {
-		name string
-		file string
-		want ResetConfig
+		name    string
+		content string
+		want    ResetConfig
 	}{
 		{
-			name: "shape 1 - flat",
-			file: "config-migrate.example.json",
+			name:    "shape 1 - flat",
+			content: flatShapeJSON,
 			want: ResetConfig{
 				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
 				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
@@ -88,8 +131,8 @@ func TestLoadResetConfigFileShapes(t *testing.T) {
 			},
 		},
 		{
-			name: "shape 2 - command-sectioned",
-			file: "config.example.json",
+			name:    "shape 2 - command-sectioned",
+			content: commandSectionedShapeJSON,
 			want: ResetConfig{
 				Token:           "YOUR_SONARCLOUD_TOKEN_HERE",
 				EnterpriseKey:   "YOUR_ENTERPRISE_KEY",
@@ -100,8 +143,8 @@ func TestLoadResetConfigFileShapes(t *testing.T) {
 			},
 		},
 		{
-			name: "shape 3 - side-sectioned",
-			file: "migration-config.example.json",
+			name:    "shape 3 - side-sectioned",
+			content: sideSectionedShapeJSON,
 			want: ResetConfig{
 				Token:           "YOUR_SONARCLOUD_ADMIN_TOKEN_HERE",
 				EnterpriseKey:   "YOUR_ENTERPRISE_KEY_HERE",
@@ -114,9 +157,9 @@ func TestLoadResetConfigFileShapes(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := LoadResetConfigFile(filepath.Join(examplesDir, tc.file))
+			got, err := LoadResetConfigFile(writeConfigFixture(t, tc.content))
 			if err != nil {
-				t.Fatalf("LoadResetConfigFile(%s): %v", tc.file, err)
+				t.Fatalf("LoadResetConfigFile(%s): %v", tc.name, err)
 			}
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("ResetConfig mismatch\n got=%+v\nwant=%+v", got, tc.want)

--- a/go/internal/migrate/eventlog.go
+++ b/go/internal/migrate/eventlog.go
@@ -50,6 +50,10 @@ type RunMeta struct {
 	OverallStatus string        `json:"overall_status"`
 	Phases        []PhaseTiming `json:"phases"`
 	Tasks         []TaskTiming  `json:"tasks"`
+	// ProjectKeyPattern records the target-key renaming pattern (issue #138)
+	// so the report can re-derive every project's target key and surface
+	// collisions / over-length keys.
+	ProjectKeyPattern string `json:"project_key_pattern,omitempty"`
 }
 
 // eventCollector accumulates LogEvents from the teeing slog handler. Safe for

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -25,12 +25,12 @@ import (
 
 // MigrateConfig holds all parameters for a migrate run.
 type MigrateConfig struct {
-	Token           string
-	EnterpriseKey   string
-	Edition         string // "enterprise", "developer", etc.
-	URL             string // Cloud URL (default: https://sonarcloud.io/)
-	RunID           string // Resume a prior run
-	Concurrency     int
+	Token         string
+	EnterpriseKey string
+	Edition       string // "enterprise", "developer", etc.
+	URL           string // Cloud URL (default: https://sonarcloud.io/)
+	RunID         string // Resume a prior run
+	Concurrency   int
 	// Timeout is the per-HTTP-request timeout in seconds applied to
 	// every SonarQube Cloud call the migrate phase makes (#383). When
 	// <= 0, applyDefaults sets it to 60 — matching the SDK default
@@ -59,6 +59,11 @@ type MigrateConfig struct {
 	// ExcludeBranches holds glob patterns for non-main branches to skip
 	// during project data import. Main branch is never excluded.
 	ExcludeBranches []string
+
+	// ProjectKeyPattern is the template used to derive each target
+	// SonarQube Cloud project key from the source key, the org key, and
+	// the enterprise key. Defaults to DefaultProjectKeyPattern. Issue #138.
+	ProjectKeyPattern string
 }
 
 // Executor is the runtime context passed to every migrate task function.
@@ -78,6 +83,11 @@ type Executor struct {
 	Sem             chan struct{}
 	Logger          *slog.Logger
 	ExcludeBranches []string
+
+	// ProjectKeyPattern is the resolved target-key template (issue #138),
+	// consumed by every task that derives a SonarQube Cloud project key
+	// (createProjects, matchProjectRepos, permission templates, portfolios).
+	ProjectKeyPattern string
 
 	// ResetConfirmedOrgs is populated only by RunReset after the
 	// operator has interactively confirmed which SonarCloud orgs to
@@ -103,6 +113,14 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	collector := &eventCollector{}
 	base := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})
 	logger := slog.New(newEventHandler(base, collector))
+
+	// Validate the project-key renaming pattern syntax before anything
+	// else — a malformed pattern is a config error the operator must fix
+	// (issue #138). The org-prefix collision guard runs later once the
+	// Cloud client exists.
+	if err := ValidateProjectKeyPattern(cfg.ProjectKeyPattern); err != nil {
+		return "", common.NewExitError(2, fmt.Errorf("invalid project_key_pattern: %w", err))
+	}
 
 	// Validate the SQC org mapping and apply --default_organization
 	// fallback if requested (issues #279 + #281). Done before any API
@@ -163,6 +181,14 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 		return "", err
 	}
 
+	// When the key pattern carries a static prefix instead of <ORGANIZATION_KEY>,
+	// that prefix is shared by every project and could be mistaken for an
+	// organization-scoped key. Abort if it collides with a real SQC org
+	// (issue #138).
+	if err := validatePatternOrgCollision(ctx, cc.Organizations, cfg.ProjectKeyPattern); err != nil {
+		return "", err
+	}
+
 	// Create RawClients for read operations.
 	raw := common.NewRawClient(cloudClient.HTTPClient(), cloudClient.BaseURL())
 	rawAPI := common.NewRawClient(apiClient.HTTPClient(), apiClient.BaseURL())
@@ -193,11 +219,12 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	defer func() {
 		tm.CompletedAt = time.Now()
 		meta := RunMeta{
-			StartedAt:     tm.StartedAt,
-			CompletedAt:   tm.CompletedAt,
-			OverallStatus: computeStatus(retErr, tm),
-			Phases:        tm.phasesSnapshot(),
-			Tasks:         tm.tasksSnapshot(),
+			StartedAt:         tm.StartedAt,
+			CompletedAt:       tm.CompletedAt,
+			OverallStatus:     computeStatus(retErr, tm),
+			Phases:            tm.phasesSnapshot(),
+			Tasks:             tm.tasksSnapshot(),
+			ProjectKeyPattern: cfg.ProjectKeyPattern,
 		}
 		if b, err := json.MarshalIndent(meta, "", "  "); err == nil {
 			_ = os.WriteFile(filepath.Join(runDir, "run_meta.json"), b, 0o644)
@@ -263,21 +290,22 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	plan = filterCompleted(plan, store)
 
 	executor := &Executor{
-		Cloud:           cc,
-		CloudAPI:        apiCC,
-		Raw:             raw,
-		RawAPI:          rawAPI,
-		Extract:         nil, // Will be set per-task based on extract mapping
-		Store:           store,
-		CloudURL:        cloudClient.BaseURL(),
-		APIURL:          apiClient.BaseURL(),
-		EntKey:          cfg.EnterpriseKey,
-		Edition:         edition,
-		ExportDir:       cfg.ExportDirectory,
-		Mapping:         mapping,
-		Sem:             make(chan struct{}, cfg.Concurrency),
-		ExcludeBranches: cfg.ExcludeBranches,
-		Logger:          logger,
+		Cloud:             cc,
+		CloudAPI:          apiCC,
+		Raw:               raw,
+		RawAPI:            rawAPI,
+		Extract:           nil, // Will be set per-task based on extract mapping
+		Store:             store,
+		CloudURL:          cloudClient.BaseURL(),
+		APIURL:            apiClient.BaseURL(),
+		EntKey:            cfg.EnterpriseKey,
+		Edition:           edition,
+		ExportDir:         cfg.ExportDirectory,
+		Mapping:           mapping,
+		Sem:               make(chan struct{}, cfg.Concurrency),
+		ExcludeBranches:   cfg.ExcludeBranches,
+		ProjectKeyPattern: cfg.ProjectKeyPattern,
+		Logger:            logger,
 	}
 
 	// Execute phases.
@@ -346,6 +374,9 @@ func (cfg *MigrateConfig) applyDefaults() {
 	}
 	if cfg.Edition == "" {
 		cfg.Edition = "enterprise"
+	}
+	if strings.TrimSpace(cfg.ProjectKeyPattern) == "" {
+		cfg.ProjectKeyPattern = DefaultProjectKeyPattern
 	}
 	// Ensure trailing slash.
 	if cfg.URL != "" && cfg.URL[len(cfg.URL)-1] != '/' {

--- a/go/internal/migrate/org_existence_test.go
+++ b/go/internal/migrate/org_existence_test.go
@@ -165,3 +165,43 @@ func TestCSVOrgMissingError_MessageShape(t *testing.T) {
 		t.Error("missing enterprise key in message")
 	}
 }
+
+// Issue #138: a static-prefix pattern (no <ORGANIZATION_KEY>) whose prefix matches an
+// existing SonarQube Cloud organization is ambiguous → exit 2.
+func TestValidatePatternOrgCollision(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("static prefix collides with org → abort", func(t *testing.T) {
+		lookup := newFakeOrgs("acme")
+		err := validatePatternOrgCollision(ctx, lookup, "acme_<ORIGINAL_PROJECT_KEY>")
+		var ec *common.ExitCodeError
+		if !errors.As(err, &ec) || ec.Code != 2 {
+			t.Fatalf("expected exit code 2, got %v (%T)", err, err)
+		}
+	})
+
+	t.Run("static prefix with no matching org → ok", func(t *testing.T) {
+		lookup := newFakeOrgs("some-other-org")
+		if err := validatePatternOrgCollision(ctx, lookup, "acme_<ORIGINAL_PROJECT_KEY>"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("pattern using <ORGANIZATION_KEY> skips the check entirely", func(t *testing.T) {
+		lookup := newFakeOrgs("acme")
+		// Even though "acme" exists, an org-scoped pattern is never ambiguous.
+		if err := validatePatternOrgCollision(ctx, lookup, DefaultProjectKeyPattern); err != nil {
+			t.Fatalf("expected no error for org-scoped pattern, got %v", err)
+		}
+		if len(lookup.calls) != 0 {
+			t.Fatalf("org-scoped pattern must not query organizations, got %d calls", len(lookup.calls))
+		}
+	})
+
+	t.Run("bare keep-unchanged pattern has no prefix to collide", func(t *testing.T) {
+		lookup := newFakeOrgs("acme")
+		if err := validatePatternOrgCollision(ctx, lookup, "<ORIGINAL_PROJECT_KEY>"); err != nil {
+			t.Fatalf("expected no error for bare pattern, got %v", err)
+		}
+	})
+}

--- a/go/internal/migrate/org_mapping.go
+++ b/go/internal/migrate/org_mapping.go
@@ -224,6 +224,37 @@ func orgsByKey(ctx context.Context, lookup orgLookup, keys []string) (map[string
 	return out, nil
 }
 
+// validatePatternOrgCollision implements the issue #138 guard: when the
+// project-key pattern does NOT use <ORGANIZATION_KEY>, the static prefix is the same
+// for every migrated project. If that prefix (minus a trailing underscore)
+// matches an existing SonarQube Cloud organization key, the resulting keys
+// would look org-scoped while not being mapped through one — ambiguous
+// enough that we abort and ask the operator to disambiguate the pattern.
+//
+// Patterns that include <ORGANIZATION_KEY> are inherently org-scoped and skip this
+// check. So does a bare <ORIGINAL_PROJECT_KEY> (keep-unchanged), which has
+// no prefix to collide.
+func validatePatternOrgCollision(ctx context.Context, lookup orgLookup, pattern string) error {
+	if PatternUsesOrg(pattern) {
+		return nil
+	}
+	prefix, _ := ProjectKeyAffixes(pattern, "")
+	candidate := strings.TrimRight(prefix, "_")
+	if candidate == "" {
+		return nil
+	}
+	known, err := orgsByKey(ctx, lookup, []string{candidate})
+	if err != nil {
+		return fmt.Errorf("checking project_key_pattern prefix against SonarQube Cloud organizations: %w", err)
+	}
+	if known[candidate] {
+		return common.NewExitError(2, fmt.Errorf(
+			`project_key_pattern prefix %q collides with existing SonarQube Cloud organization %q; use <ORGANIZATION_KEY> in the pattern or choose a prefix that is not an organization key`,
+			prefix, candidate))
+	}
+	return nil
+}
+
 func defaultOrgMissingError(defaultOrg, enterpriseKey string) error {
 	return common.NewExitError(3, fmt.Errorf(
 		`Default organization %q does not exists in SonarQube Cloud, or is not part of Enterprise %q`,

--- a/go/internal/migrate/portfolio_analysis_test.go
+++ b/go/internal/migrate/portfolio_analysis_test.go
@@ -110,7 +110,7 @@ func TestResolveEffectivePortfolioConfig_RegexpAlternationWithOrgPrefix(t *testi
 			{SelectionMode: "REGEXP", Regexp: ".*-INVEST-.*"},
 		},
 	}
-	mode, regex, _ := resolveEffectivePortfolioConfig("", "", "", pc, []string{"acme"})
+	mode, regex, _ := resolveEffectivePortfolioConfig("", "", "", pc, []string{"acme"}, DefaultProjectKeyPattern)
 	if mode != "REGEXP" {
 		t.Fatalf("expected REGEXP, got %q", mode)
 	}
@@ -130,7 +130,7 @@ func TestResolveEffectivePortfolioConfig_TagsUnion(t *testing.T) {
 			{SelectionMode: "TAGS", Tags: []string{"frontend", "python"}}, // dedup
 		},
 	}
-	mode, _, tags := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	mode, _, tags := resolveEffectivePortfolioConfig("", "", "", pc, nil, DefaultProjectKeyPattern)
 	if mode != "TAGS" {
 		t.Fatalf("expected TAGS, got %q", mode)
 	}
@@ -144,7 +144,7 @@ func TestResolveEffectivePortfolioConfig_MixedFlattensToManual(t *testing.T) {
 		HasSubportfolios:    true,
 		MixedSelectionModes: true,
 	}
-	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil, DefaultProjectKeyPattern)
 	if mode != "MANUAL" {
 		t.Errorf("expected MANUAL for mixed, got %q", mode)
 	}
@@ -155,14 +155,14 @@ func TestResolveEffectivePortfolioConfig_DepthGT1FlattensToManual(t *testing.T) 
 		HasSubportfolios: true,
 		DepthGT1:         true,
 	}
-	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil, DefaultProjectKeyPattern)
 	if mode != "MANUAL" {
 		t.Errorf("expected MANUAL for depth>1, got %q", mode)
 	}
 }
 
 func TestResolveEffectivePortfolioConfig_RestModeFlattensToManual(t *testing.T) {
-	mode, _, _ := resolveEffectivePortfolioConfig("REST", "", "", PortfolioComposition{}, nil)
+	mode, _, _ := resolveEffectivePortfolioConfig("REST", "", "", PortfolioComposition{}, nil, DefaultProjectKeyPattern)
 	if mode != "MANUAL" {
 		t.Errorf("REST should flatten to MANUAL, got %q", mode)
 	}
@@ -170,14 +170,14 @@ func TestResolveEffectivePortfolioConfig_RestModeFlattensToManual(t *testing.T) 
 
 func TestResolveEffectivePortfolioConfig_AppsOnlyFlattensToManual(t *testing.T) {
 	pc := PortfolioComposition{HasApps: true}
-	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil)
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", pc, nil, DefaultProjectKeyPattern)
 	if mode != "MANUAL" {
 		t.Errorf("apps-only should flatten to MANUAL, got %q", mode)
 	}
 }
 
 func TestResolveEffectivePortfolioConfig_OwnRegexpUnchanged(t *testing.T) {
-	mode, regex, _ := resolveEffectivePortfolioConfig("REGEXP", "^pre", "", PortfolioComposition{}, []string{"acme"})
+	mode, regex, _ := resolveEffectivePortfolioConfig("REGEXP", "^pre", "", PortfolioComposition{}, []string{"acme"}, DefaultProjectKeyPattern)
 	if mode != "REGEXP" {
 		t.Fatalf("expected REGEXP, got %q", mode)
 	}
@@ -187,7 +187,7 @@ func TestResolveEffectivePortfolioConfig_OwnRegexpUnchanged(t *testing.T) {
 }
 
 func TestResolveEffectivePortfolioConfig_EmptyPlainPortfolio(t *testing.T) {
-	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", PortfolioComposition{}, nil)
+	mode, _, _ := resolveEffectivePortfolioConfig("", "", "", PortfolioComposition{}, nil, DefaultProjectKeyPattern)
 	if mode != "" {
 		t.Errorf("plain empty portfolio: expected no config, got %q", mode)
 	}

--- a/go/internal/migrate/projectkey.go
+++ b/go/internal/migrate/projectkey.go
@@ -1,0 +1,149 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Project-key renaming strategy (issue #138).
+//
+// When a project is migrated from SonarQube Server to SonarQube Cloud its
+// key is rewritten according to a configurable pattern built from two
+// placeholders:
+//
+//	<ORIGINAL_PROJECT_KEY>  the source project key (mandatory)
+//	<ORGANIZATION_KEY>      the target SonarQube Cloud organization key
+//
+// `<PROJECT_KEY>` is accepted as an alias of `<ORIGINAL_PROJECT_KEY>`.
+// Placeholder names are recognised case-insensitively but canonicalised to
+// the uppercase forms above.
+//
+// The default pattern reproduces SonarQube Cloud's own convention and the
+// tool's historical behaviour (orgKey + "_" + sourceKey).
+const (
+	DefaultProjectKeyPattern = "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>"
+
+	// MaxProjectKeyLength is SonarQube's hard limit on a project key. Keys
+	// rendered longer than this are surfaced in the migration report.
+	MaxProjectKeyLength = 400
+
+	// minSinglePlaceholderPrefix is the minimum length of the static text
+	// that must accompany a lone <ORIGINAL_PROJECT_KEY> placeholder. A
+	// short, generic prefix is too collision-prone to allow.
+	minSinglePlaceholderPrefix = 5
+
+	phOriginal = "<ORIGINAL_PROJECT_KEY>"
+	phOrg      = "<ORGANIZATION_KEY>"
+)
+
+// placeholderRe matches any <...> token so unknown placeholders can be rejected.
+var placeholderRe = regexp.MustCompile(`<[^>]*>`)
+
+// canonicalPlaceholders maps the uppercased inner name of a recognised
+// placeholder (including the <PROJECT_KEY> alias) to its canonical token.
+var canonicalPlaceholders = map[string]string{
+	"ORIGINAL_PROJECT_KEY": phOriginal,
+	"PROJECT_KEY":          phOriginal, // alias
+	"ORGANIZATION_KEY":     phOrg,
+}
+
+// normalizeProjectKeyPattern canonicalises every recognised placeholder to
+// its uppercase form (so <organization_key>, <ORGANIZATION_KEY> and the
+// <PROJECT_KEY> alias all collapse onto the same token). Unrecognised
+// <...> tokens are left untouched so ValidateProjectKeyPattern can reject them.
+func normalizeProjectKeyPattern(pattern string) string {
+	return placeholderRe.ReplaceAllStringFunc(pattern, func(tok string) string {
+		inner := strings.ToUpper(tok[1 : len(tok)-1])
+		if canon, ok := canonicalPlaceholders[inner]; ok {
+			return canon
+		}
+		return tok
+	})
+}
+
+// resolveProjectKeyPattern normalizes the pattern and falls back to the
+// default when it is empty. RunMigrate defaults the pattern before use, but
+// the runtime helpers below default defensively too so a caller that forgot
+// to set it still gets SonarQube Cloud's standard behaviour rather than an
+// empty key. Validation deliberately does NOT default — an empty pattern in
+// a config file is an error worth surfacing.
+func resolveProjectKeyPattern(pattern string) string {
+	if strings.TrimSpace(pattern) == "" {
+		return DefaultProjectKeyPattern
+	}
+	return normalizeProjectKeyPattern(pattern)
+}
+
+// ValidateProjectKeyPattern enforces the rules from issue #138:
+//   - only the two documented placeholders are allowed;
+//   - <ORIGINAL_PROJECT_KEY> must appear (which also rules out a pattern
+//     with zero placeholders);
+//   - when the pattern does not use <ORGANIZATION_KEY>, the only placeholder
+//     is <ORIGINAL_PROJECT_KEY>: a bare pattern (no static text) is allowed
+//     (the "keep the key unchanged" mode), but any static prefix/suffix must
+//     total at least minSinglePlaceholderPrefix characters so a short generic
+//     prefix can't produce collision-prone keys.
+func ValidateProjectKeyPattern(pattern string) error {
+	p := normalizeProjectKeyPattern(pattern)
+	if strings.TrimSpace(p) == "" {
+		return fmt.Errorf("project_key_pattern must not be empty")
+	}
+	for _, tok := range placeholderRe.FindAllString(p, -1) {
+		switch tok {
+		case phOriginal, phOrg:
+		default:
+			return fmt.Errorf("project_key_pattern contains unknown placeholder %q; allowed placeholders are %s and %s",
+				tok, phOriginal, phOrg)
+		}
+	}
+	if !strings.Contains(p, phOriginal) {
+		return fmt.Errorf("project_key_pattern %q must include the %s placeholder", pattern, phOriginal)
+	}
+	if !strings.Contains(p, phOrg) {
+		// Lone <ORIGINAL_PROJECT_KEY>. The literal text is everything that
+		// is not the placeholder itself.
+		literal := strings.ReplaceAll(p, phOriginal, "")
+		if n := len(literal); n > 0 && n < minSinglePlaceholderPrefix {
+			return fmt.Errorf(
+				"project_key_pattern %q: a single %s placeholder combined with a static prefix and/or postfix requires at least %d characters of literal text (got %d) — e.g. \"acme_%s\"",
+				pattern, phOriginal, minSinglePlaceholderPrefix, n, phOriginal)
+		}
+	}
+	return nil
+}
+
+// RenderProjectKey substitutes the placeholders in pattern to produce the
+// target SonarQube Cloud project key.
+func RenderProjectKey(pattern, originalKey, orgKey string) string {
+	return strings.NewReplacer(
+		phOrg, orgKey,
+		phOriginal, originalKey,
+	).Replace(resolveProjectKeyPattern(pattern))
+}
+
+// ProjectKeyAffixes returns the literal text that surrounds the
+// <ORIGINAL_PROJECT_KEY> placeholder once <ORGANIZATION_KEY> is substituted.
+// Permission-template and portfolio regexes — which match source project
+// keys — are wrapped with these affixes so they keep matching after renaming.
+func ProjectKeyAffixes(pattern, orgKey string) (prefix, suffix string) {
+	p := resolveProjectKeyPattern(pattern)
+	idx := strings.Index(p, phOriginal)
+	if idx < 0 {
+		return "", ""
+	}
+	rep := strings.NewReplacer(phOrg, orgKey)
+	return rep.Replace(p[:idx]), rep.Replace(p[idx+len(phOriginal):])
+}
+
+// PatternUsesOrg reports whether the pattern includes <ORGANIZATION_KEY>. When
+// it does not, the static prefix is the same for every project and could
+// collide with an existing organization key — the migrate command checks
+// for that before running.
+func PatternUsesOrg(pattern string) bool {
+	return strings.Contains(resolveProjectKeyPattern(pattern), phOrg)
+}

--- a/go/internal/migrate/projectkey_test.go
+++ b/go/internal/migrate/projectkey_test.go
@@ -1,0 +1,112 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import "testing"
+
+func TestValidateProjectKeyPattern(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		wantErr bool
+	}{
+		{"default", DefaultProjectKeyPattern, false},
+		{"org and original", "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>", false},
+		{"static prefix with org", "ACME_CORP_<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>", false},
+		{"org with postfix", "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>_migrated", false},
+		{"static-only prefix 5 chars", "acme_<ORIGINAL_PROJECT_KEY>", false},
+		{"static-only prefix long", "MYCORP_<ORIGINAL_PROJECT_KEY>", false},
+		{"prefix and postfix combined", "sqs_<ORIGINAL_PROJECT_KEY>_migrated", false},
+		{"postfix only ≥5 chars", "<ORIGINAL_PROJECT_KEY>_migrated", false},
+		{"bare original (keep unchanged)", "<ORIGINAL_PROJECT_KEY>", false},
+		{"bare original via alias", "<PROJECT_KEY>", false},
+		{"alias with org", "<ORGANIZATION_KEY>_<PROJECT_KEY>", false},
+		{"lowercase accepted (case-insensitive)", "<organization_key>_<original_project_key>", false},
+
+		{"static prefix too short", "AAA_<ORIGINAL_PROJECT_KEY>", true},
+		{"static prefix 4 chars", "abc_<ORIGINAL_PROJECT_KEY>", true},
+		{"short postfix only", "<ORIGINAL_PROJECT_KEY>_x", true},
+		{"no original placeholder", "<ORGANIZATION_KEY>_static", true},
+		{"zero placeholders", "ACME_CORP", true},
+		{"empty", "", true},
+		{"whitespace", "   ", true},
+		{"unknown placeholder", "<TEAM_KEY>_<ORIGINAL_PROJECT_KEY>", true},
+		{"old org_key name now rejected", "<ORG_KEY>_<ORIGINAL_PROJECT_KEY>", true},
+		{"enterprise placeholder now rejected", "<ENTERPRISE_KEY>_<ORIGINAL_PROJECT_KEY>", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateProjectKeyPattern(tc.pattern)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %q, got nil", tc.pattern)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error for %q, got %v", tc.pattern, err)
+			}
+		})
+	}
+}
+
+func TestRenderProjectKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		pattern  string
+		original string
+		org      string
+		want     string
+	}{
+		{"default reproduces legacy", DefaultProjectKeyPattern, "my-proj", "myorg", "myorg_my-proj"},
+		{"org then original", "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>", "p", "o", "o_p"},
+		{"static prefix", "ACME_CORP_<ORIGINAL_PROJECT_KEY>", "p", "o", "ACME_CORP_p"},
+		{"prefix and postfix", "sqs_<ORIGINAL_PROJECT_KEY>_migrated", "p", "o", "sqs_p_migrated"},
+		{"org with postfix", "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>_migrated", "p", "o", "o_p_migrated"},
+		{"keep unchanged", "<ORIGINAL_PROJECT_KEY>", "p", "o", "p"},
+		{"alias keep unchanged", "<PROJECT_KEY>", "p", "o", "p"},
+		{"lowercase canonicalised", "<organization_key>_<original_project_key>", "p", "o", "o_p"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := RenderProjectKey(tc.pattern, tc.original, tc.org)
+			if got != tc.want {
+				t.Fatalf("RenderProjectKey = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProjectKeyAffixes(t *testing.T) {
+	cases := []struct {
+		name       string
+		pattern    string
+		org        string
+		wantPrefix string
+		wantSuffix string
+	}{
+		{"default", DefaultProjectKeyPattern, "o", "o_", ""},
+		{"static prefix no org", "ACME_CORP_<ORIGINAL_PROJECT_KEY>", "o", "ACME_CORP_", ""},
+		{"keep unchanged", "<ORIGINAL_PROJECT_KEY>", "o", "", ""},
+		{"suffix", "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>_x", "o", "o_", "_x"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix, suffix := ProjectKeyAffixes(tc.pattern, tc.org)
+			if prefix != tc.wantPrefix || suffix != tc.wantSuffix {
+				t.Fatalf("ProjectKeyAffixes = (%q, %q), want (%q, %q)", prefix, suffix, tc.wantPrefix, tc.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestPatternUsesOrg(t *testing.T) {
+	if !PatternUsesOrg("<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>") {
+		t.Fatal("expected PatternUsesOrg true for org pattern")
+	}
+	if !PatternUsesOrg("<organization_key>_<original_project_key>") {
+		t.Fatal("expected PatternUsesOrg true for lowercase org pattern")
+	}
+	if PatternUsesOrg("ACME_CORP_<ORIGINAL_PROJECT_KEY>") {
+		t.Fatal("expected PatternUsesOrg false for static-prefix pattern")
+	}
+}

--- a/go/internal/migrate/tasks_alm.go
+++ b/go/internal/migrate/tasks_alm.go
@@ -50,7 +50,7 @@ func runMatchProjectRepos(ctx context.Context, e *Executor) error {
 	for _, pm := range projMappings {
 		orgKey := extractField(pm, "sonarcloud_org_key")
 		key := extractField(pm, "key")
-		cloudKey := orgKey + "_" + key
+		cloudKey := RenderProjectKey(e.ProjectKeyPattern, key, orgKey)
 		projALMInfo[cloudKey] = projectALMInfo{
 			ALM:        extractField(pm, "alm"),
 			Repository: extractField(pm, "repository"),

--- a/go/internal/migrate/tasks_create.go
+++ b/go/internal/migrate/tasks_create.go
@@ -65,7 +65,7 @@ func runCreateProjects(ctx context.Context, e *Executor) error {
 			ncdType := extractField(item, "new_code_definition_type")
 			ncdValue := extractAnyStr(item, "new_code_definition_value")
 
-			cloudKey := orgKey + "_" + key
+			cloudKey := RenderProjectKey(e.ProjectKeyPattern, key, orgKey)
 			e.Logger.Debug("project api call: POST /api/projects/create",
 				"source_key", key, "cloud_key", cloudKey, "name", name, "org", orgKey,
 				"new_code_type", ncdType, "new_code_value", ncdValue)
@@ -298,9 +298,13 @@ func runCreatePermissionTemplates(ctx context.Context, e *Executor) error {
 			name := extractField(item, "name")
 			desc := extractField(item, "description")
 			pattern := extractField(item, "project_key_pattern")
-			// Prepend org key to pattern if present.
+			// Wrap the source pattern with the same affixes the project
+			// keys get, so the template keeps matching after renaming
+			// (issue #138). For the default <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>
+			// pattern this reduces to the historical orgKey + "_" + pattern.
 			if pattern != "" {
-				pattern = orgKey + "_" + pattern
+				prefix, suffix := ProjectKeyAffixes(e.ProjectKeyPattern, orgKey)
+				pattern = prefix + pattern + suffix
 			}
 
 			var templateID string

--- a/go/internal/migrate/tasks_portfolios.go
+++ b/go/internal/migrate/tasks_portfolios.go
@@ -119,7 +119,7 @@ func runConfigurePortfolios(ctx context.Context, e *Executor) error {
 			// otherwise). Single-mode portfolios are unaffected.
 			effMode, effRegexp, effTags := resolveEffectivePortfolioConfig(selectionMode,
 				extractField(item, "regexp"), extractField(item, "tags"),
-				composition, orgs)
+				composition, orgs, e.ProjectKeyPattern)
 			if effMode == "" {
 				return nil
 			}
@@ -360,18 +360,38 @@ func resolveProjectBranchRefs(ctx context.Context, e *Executor, cache map[string
 // With orgKeys = ["org1","org2"]:
 //
 //	"^foo" → "^(?:org1_|org2_)foo"
-func transformPortfolioRegex(regex string, orgKeys []string) string {
+//
+// The prefix each org contributes is derived from the configured
+// project-key pattern (issue #138) via ProjectKeyAffixes, so the regex
+// adapts to whatever renaming strategy is in effect. For the default
+// <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY> pattern the prefix is "<org>_", matching
+// the historical behaviour. A non-empty affix suffix (rare — only when the
+// pattern places literal text after <ORIGINAL_PROJECT_KEY>) is mirrored onto
+// the regex tail; it is assumed org-independent.
+func transformPortfolioRegex(regex string, orgKeys []string, pattern string) string {
 	if regex == "" {
 		return ""
 	}
 	seen := map[string]bool{}
 	prefixes := make([]string, 0, len(orgKeys))
+	suffix := ""
 	for _, o := range orgKeys {
-		if o == "" || seen[o] {
+		if o == "" {
 			continue
 		}
-		seen[o] = true
-		prefixes = append(prefixes, regexp.QuoteMeta(o+"_"))
+		p, s := ProjectKeyAffixes(pattern, o)
+		quoted := regexp.QuoteMeta(p)
+		// Dedupe on the rendered prefix, not the org key: a pattern with a
+		// static prefix (no <ORGANIZATION_KEY>) produces the same prefix for every
+		// org, so the alternation must collapse to a single branch.
+		if seen[quoted] {
+			continue
+		}
+		seen[quoted] = true
+		prefixes = append(prefixes, quoted)
+		if s != "" {
+			suffix = s
+		}
 	}
 	if len(prefixes) == 0 {
 		return regex
@@ -382,10 +402,21 @@ func transformPortfolioRegex(regex string, orgKeys []string) string {
 	} else {
 		prefix = "(?:" + strings.Join(prefixes, "|") + ")"
 	}
-	if strings.HasPrefix(regex, "^") {
-		return "^" + prefix + regex[1:]
+	out := regex
+	if strings.HasPrefix(out, "^") {
+		out = "^" + prefix + out[1:]
+	} else {
+		out = prefix + out
 	}
-	return prefix + regex
+	if suffix != "" {
+		q := regexp.QuoteMeta(suffix)
+		if strings.HasSuffix(out, "$") {
+			out = out[:len(out)-1] + q + "$"
+		} else {
+			out += q
+		}
+	}
+	return out
 }
 
 // buildEmptyPortfolioSet returns composite serverURL|portfolioKey strings
@@ -468,10 +499,10 @@ func indexPortfolioCompositions(e *Executor) map[string]PortfolioComposition {
 // An empty effMode return means "no configurePortfolios call" (e.g. a
 // truly empty parent with no children).
 func resolveEffectivePortfolioConfig(parentMode, parentRegexp, parentTags string,
-	composition PortfolioComposition, orgs []string) (effMode, effRegexp string, effTags []string) {
+	composition PortfolioComposition, orgs []string, pattern string) (effMode, effRegexp string, effTags []string) {
 
 	if parentMode == "REGEXP" {
-		return "REGEXP", transformPortfolioRegex(parentRegexp, orgs), nil
+		return "REGEXP", transformPortfolioRegex(parentRegexp, orgs, pattern), nil
 	}
 	if parentMode == "TAGS" {
 		if parentTags == "" {
@@ -499,7 +530,7 @@ func resolveEffectivePortfolioConfig(parentMode, parentRegexp, parentTags string
 				if sp.Regexp == "" {
 					continue
 				}
-				parts = append(parts, transformPortfolioRegex(sp.Regexp, orgs))
+				parts = append(parts, transformPortfolioRegex(sp.Regexp, orgs, pattern))
 			}
 			if len(parts) == 0 {
 				return "", "", nil

--- a/go/internal/migrate/tasks_portfolios_test.go
+++ b/go/internal/migrate/tasks_portfolios_test.go
@@ -20,32 +20,37 @@ func TestTransformPortfolioRegex(t *testing.T) {
 		name    string
 		regex   string
 		orgKeys []string
+		pattern string
 		want    string
 	}{
 		{"anchored simple",
-			"^backend-", []string{"org1"}, "^org1_backend-"},
+			"^backend-", []string{"org1"}, DefaultProjectKeyPattern, "^org1_backend-"},
 		{"anchored char class",
-			"^[A-Z].*", []string{"org1"}, "^org1_[A-Z].*"},
+			"^[A-Z].*", []string{"org1"}, DefaultProjectKeyPattern, "^org1_[A-Z].*"},
 		{"unanchored",
-			"backend", []string{"org1"}, "org1_backend"},
+			"backend", []string{"org1"}, DefaultProjectKeyPattern, "org1_backend"},
 		{"two orgs alternation",
-			"^foo", []string{"org1", "org2"},
+			"^foo", []string{"org1", "org2"}, DefaultProjectKeyPattern,
 			"^(?:org1_|org2_)foo"},
 		{"empty regex stays empty",
-			"", []string{"org1"}, ""},
+			"", []string{"org1"}, DefaultProjectKeyPattern, ""},
 		{"no orgs returns original",
-			"^foo", nil, "^foo"},
+			"^foo", nil, DefaultProjectKeyPattern, "^foo"},
 		{"org key with regex metachars is quoted",
-			"^bar", []string{"org-1.x"}, `^org-1\.x_bar`},
+			"^bar", []string{"org-1.x"}, DefaultProjectKeyPattern, `^org-1\.x_bar`},
 		{"duplicate org keys deduplicated",
-			"^foo", []string{"org1", "org1"}, "^org1_foo"},
+			"^foo", []string{"org1", "org1"}, DefaultProjectKeyPattern, "^org1_foo"},
+		{"static-prefix pattern (no org) uses constant prefix",
+			"^foo", []string{"org1", "org2"}, "ACME_CORP_<ORIGINAL_PROJECT_KEY>", "^ACME_CORP_foo"},
+		{"keep-unchanged pattern leaves regex as-is",
+			"^foo", []string{"org1"}, "<ORIGINAL_PROJECT_KEY>", "^foo"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := transformPortfolioRegex(tc.regex, tc.orgKeys)
+			got := transformPortfolioRegex(tc.regex, tc.orgKeys, tc.pattern)
 			if got != tc.want {
-				t.Errorf("transformPortfolioRegex(%q, %v): got %q, want %q",
-					tc.regex, tc.orgKeys, got, tc.want)
+				t.Errorf("transformPortfolioRegex(%q, %v, %q): got %q, want %q",
+					tc.regex, tc.orgKeys, tc.pattern, got, tc.want)
 			}
 		})
 	}
@@ -262,7 +267,6 @@ func TestRunConfigurePortfoliosSkipsNoneAndRest(t *testing.T) {
 		t.Error("PATCH must not be called for NONE/REST portfolios")
 	}
 }
-
 
 func writeJSONLLine(t *testing.T, path string, item map[string]any) {
 	t.Helper()

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -119,9 +119,77 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 		sum.Warnings = rt.Warnings
 		sum.Branches = rt.Branches
 		sum.Throughput = rt.Throughput
+		sum.ProjectKeys = collectProjectKeyReport(store, rt.ProjectKeyPattern)
 	}
 
 	return sum, nil
+}
+
+// collectProjectKeyReport re-derives every project's target SonarQube Cloud
+// key from the generateProjectMappings output and the recorded
+// project_key_pattern, then flags two problems (issue #138): target keys
+// claimed by more than one source project (collisions) and keys longer than
+// migrate.MaxProjectKeyLength. Returns nil when there is nothing to report.
+func collectProjectKeyReport(store *common.DataStore, pattern string) *ProjectKeyReport {
+	rows, err := store.ReadAll("generateProjectMappings")
+	if err != nil || len(rows) == 0 {
+		return nil
+	}
+
+	type bucket struct {
+		sources []ProjectKeySource
+		seen    map[string]bool
+	}
+	byTarget := make(map[string]*bucket)
+	order := make([]string, 0, len(rows))
+	var tooLong []ProjectKeyTooLong
+
+	for _, row := range rows {
+		srcKey := jsonStr(row, "key")
+		orgKey := jsonStr(row, "sonarcloud_org_key")
+		if srcKey == "" || orgKey == "" || orgKey == "SKIPPED" {
+			continue
+		}
+		target := migrate.RenderProjectKey(pattern, srcKey, orgKey)
+		src := ProjectKeySource{SourceKey: srcKey, OrgKey: orgKey}
+
+		b := byTarget[target]
+		if b == nil {
+			b = &bucket{seen: map[string]bool{}}
+			byTarget[target] = b
+			order = append(order, target)
+		}
+		dedupe := srcKey + "\x00" + orgKey
+		if !b.seen[dedupe] {
+			b.seen[dedupe] = true
+			b.sources = append(b.sources, src)
+		}
+
+		if len(target) > migrate.MaxProjectKeyLength {
+			tooLong = append(tooLong, ProjectKeyTooLong{
+				ProjectKeySource: src,
+				TargetKey:        target,
+				Length:           len(target),
+			})
+		}
+	}
+
+	var collisions []ProjectKeyCollision
+	for _, target := range order {
+		b := byTarget[target]
+		if len(b.sources) > 1 {
+			collisions = append(collisions, ProjectKeyCollision{TargetKey: target, Sources: b.sources})
+		}
+	}
+
+	if len(collisions) == 0 && len(tooLong) == 0 {
+		return nil
+	}
+	return &ProjectKeyReport{
+		Pattern:    pattern,
+		Collisions: collisions,
+		TooLong:    tooLong,
+	}
 }
 
 // collectLimitations builds the free-text bullet list rendered in the

--- a/go/internal/report/summary/collect_runtime.go
+++ b/go/internal/report/summary/collect_runtime.go
@@ -77,17 +77,23 @@ type runtimeData struct {
 	Warnings      WarningLedger
 	Branches      []BranchStat
 	Throughput    ThroughputStats
+
+	// ProjectKeyPattern is the target-key renaming pattern recorded in
+	// run_meta.json, used to re-derive project keys for the collision /
+	// over-length report (issue #138).
+	ProjectKeyPattern string
 }
 
 // runMetaFile mirrors the on-disk run_meta.json written by the migrate
 // engine (shared contract A). Decoded locally so the summary package
 // stays free of any migrate-package import.
 type runMetaFile struct {
-	StartedAt     time.Time      `json:"started_at"`
-	CompletedAt   time.Time      `json:"completed_at"`
-	OverallStatus string         `json:"overall_status"`
-	Phases        []runMetaPhase `json:"phases"`
-	Tasks         []runMetaTask  `json:"tasks"`
+	StartedAt         time.Time      `json:"started_at"`
+	CompletedAt       time.Time      `json:"completed_at"`
+	OverallStatus     string         `json:"overall_status"`
+	Phases            []runMetaPhase `json:"phases"`
+	Tasks             []runMetaTask  `json:"tasks"`
+	ProjectKeyPattern string         `json:"project_key_pattern"`
 }
 
 type runMetaPhase struct {
@@ -143,6 +149,7 @@ func collectRunMeta(runDir string, rt *runtimeData) {
 	rt.StartedAt = meta.StartedAt
 	rt.CompletedAt = meta.CompletedAt
 	rt.OverallStatus = meta.OverallStatus
+	rt.ProjectKeyPattern = meta.ProjectKeyPattern
 	if !meta.StartedAt.IsZero() && !meta.CompletedAt.IsZero() {
 		rt.TotalElapsed = meta.CompletedAt.Sub(meta.StartedAt)
 	}

--- a/go/internal/report/summary/markdown.go
+++ b/go/internal/report/summary/markdown.go
@@ -36,6 +36,7 @@ func RenderMarkdown(summary *MigrationSummary) ([]byte, error) {
 
 	renderMarkdownTitle(&sb, summary)
 	renderMarkdownExecutiveSummary(&sb, summary)
+	renderMarkdownProjectKeyConflicts(&sb, summary)
 	renderMarkdownSections(&sb, summary)
 	renderMarkdownBottlenecks(&sb, summary)
 	renderMarkdownFailureLedger(&sb, summary)

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -120,6 +120,10 @@ func RenderPDF(summary *MigrationSummary) ([]byte, error) {
 		renderRateLimitWarning(pdf, summary.RateLimit)
 	}
 
+	if summary.ProjectKeys != nil {
+		renderProjectKeyWarning(pdf, summary.ProjectKeys)
+	}
+
 	for _, section := range summary.Sections {
 		if summary.OmitSections[section.Name] {
 			continue

--- a/go/internal/report/summary/projectkey.go
+++ b/go/internal/report/summary/projectkey.go
@@ -1,0 +1,143 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-pdf/fpdf"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+)
+
+const projectKeyHeading = "Project key conflicts detected"
+
+// projectKeyMessageMaxItems bounds how many individual collisions /
+// over-length keys are spelled out in the callout before it summarises the
+// remainder, so a pathological run can't produce a page-long box.
+const projectKeyMessageMaxItems = 8
+
+// projectKeyMessage builds the body text for both the PDF callout and the
+// markdown section. Pure so it can be unit-tested without fpdf.
+func projectKeyMessage(r *ProjectKeyReport) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Target project keys were derived with the pattern %q. ", r.Pattern)
+	if len(r.Collisions) > 0 {
+		fmt.Fprintf(&b, "%d target key(s) are claimed by more than one source project — "+
+			"SonarQube Cloud keys are globally unique, so colliding projects cannot all be created. ",
+			len(r.Collisions))
+	}
+	if len(r.TooLong) > 0 {
+		fmt.Fprintf(&b, "%d key(s) exceed the %d-character limit and will be rejected. ",
+			len(r.TooLong), migrate.MaxProjectKeyLength)
+	}
+	b.WriteString("Adjust project_key_pattern (e.g. include <ORGANIZATION_KEY>) to disambiguate.")
+
+	for i, c := range r.Collisions {
+		if i >= projectKeyMessageMaxItems {
+			fmt.Fprintf(&b, "\n  … and %d more collision(s)", len(r.Collisions)-projectKeyMessageMaxItems)
+			break
+		}
+		parts := make([]string, 0, len(c.Sources))
+		for _, s := range c.Sources {
+			parts = append(parts, fmt.Sprintf("%q in %q", s.SourceKey, s.OrgKey))
+		}
+		fmt.Fprintf(&b, "\n  collision %q ← %s", c.TargetKey, strings.Join(parts, ", "))
+	}
+	for i, tl := range r.TooLong {
+		if i >= projectKeyMessageMaxItems {
+			fmt.Fprintf(&b, "\n  … and %d more over-length key(s)", len(r.TooLong)-projectKeyMessageMaxItems)
+			break
+		}
+		fmt.Fprintf(&b, "\n  too long (%d chars): %q ← %q in %q", tl.Length, tl.TargetKey, tl.SourceKey, tl.OrgKey)
+	}
+	return b.String()
+}
+
+// renderProjectKeyWarning draws the amber callout for project-key problems,
+// mirroring renderRateLimitWarning. Renders only when CollectSummary
+// produced a non-nil report; nil is a programmer error.
+func renderProjectKeyWarning(pdf *fpdf.Fpdf, r *ProjectKeyReport) {
+	pdf.Ln(4)
+	pageW, _ := pdf.GetPageSize()
+	left, _, right, _ := pdf.GetMargins()
+	boxW := pageW - left - right
+	innerW := boxW - 2*rateLimitBoxPadding
+
+	body := sanitizeForPDF(projectKeyMessage(r))
+
+	pdf.SetFont(pdfFontFamilyBody, "", rateLimitBodyFontPt)
+	bodyLines := pdf.SplitLines([]byte(body), innerW)
+	bodyLineCount := len(bodyLines)
+	if bodyLineCount < 1 {
+		bodyLineCount = 1
+	}
+	boxHeight := rateLimitHeadingLineH + rateLimitBodyLineH*float64(bodyLineCount) + rateLimitBoxPadding*2
+	checkPageBreak(pdf, boxHeight)
+
+	startY := pdf.GetY()
+	innerX := left + rateLimitBoxPadding
+
+	pdf.SetXY(innerX, startY+rateLimitBoxPadding)
+	setColor(pdf, colorAmber)
+	pdf.SetFont(pdfFontFamilyHeading, "B", rateLimitHeadingFontPt)
+	pdf.CellFormat(innerW, rateLimitHeadingLineH, projectKeyHeading, "", 1, "L", false, 0, "")
+
+	pdf.SetX(innerX)
+	setColor(pdf, colorBlack)
+	pdf.SetFont(pdfFontFamilyBody, "", rateLimitBodyFontPt)
+	pdf.MultiCell(innerW, rateLimitBodyLineH, body, "", "L", false)
+
+	endY := pdf.GetY() + rateLimitBoxPadding
+
+	prevLineWidth := pdf.GetLineWidth()
+	pdf.SetLineWidth(rateLimitBoxBorderWidth)
+	prevDraw := setDrawColorAmber(pdf)
+	pdf.Rect(left, startY, boxW, endY-startY, "D")
+	restoreDrawColor(pdf, prevDraw)
+	pdf.SetLineWidth(prevLineWidth)
+
+	pdf.SetY(endY + 2)
+}
+
+// renderMarkdownProjectKeyConflicts writes the project-key conflict section
+// to the markdown report. No-op when there is nothing to report.
+func renderMarkdownProjectKeyConflicts(sb *strings.Builder, summary *MigrationSummary) {
+	r := summary.ProjectKeys
+	if r == nil {
+		return
+	}
+	sb.WriteString("## ⚠️ Project key conflicts\n\n")
+	fmt.Fprintf(sb, "Target project keys were derived with the pattern `%s`.\n\n", r.Pattern)
+
+	if len(r.Collisions) > 0 {
+		fmt.Fprintf(sb, "**%d colliding target key(s)** — claimed by more than one source project. "+
+			"SonarQube Cloud project keys are globally unique, so these cannot all be created; "+
+			"adjust `project_key_pattern` (for example include `<ORGANIZATION_KEY>`) to disambiguate.\n\n",
+			len(r.Collisions))
+		sb.WriteString("| Target key | Source projects (key in organization) |\n")
+		sb.WriteString("|---|---|\n")
+		for _, c := range r.Collisions {
+			parts := make([]string, 0, len(c.Sources))
+			for _, s := range c.Sources {
+				parts = append(parts, fmt.Sprintf("`%s` in `%s`", s.SourceKey, s.OrgKey))
+			}
+			fmt.Fprintf(sb, "| `%s` | %s |\n", mdCell(c.TargetKey), mdCell(strings.Join(parts, "; ")))
+		}
+		sb.WriteString("\n")
+	}
+
+	if len(r.TooLong) > 0 {
+		fmt.Fprintf(sb, "**%d over-length key(s)** — longer than the %d-character SonarQube limit and will be rejected.\n\n",
+			len(r.TooLong), migrate.MaxProjectKeyLength)
+		sb.WriteString("| Target key | Length | Source key | Organization |\n")
+		sb.WriteString("|---|---|---|---|\n")
+		for _, tl := range r.TooLong {
+			fmt.Fprintf(sb, "| `%s` | %d | `%s` | `%s` |\n",
+				mdCell(tl.TargetKey), tl.Length, mdCell(tl.SourceKey), mdCell(tl.OrgKey))
+		}
+		sb.WriteString("\n")
+	}
+}

--- a/go/internal/report/summary/projectkey_test.go
+++ b/go/internal/report/summary/projectkey_test.go
@@ -1,0 +1,90 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/migrate"
+)
+
+func TestCollectProjectKeyReport(t *testing.T) {
+	t.Run("default pattern, unique keys → nil", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTaskJSONL(t, dir, "generateProjectMappings", []map[string]any{
+			{"key": "proj-a", "sonarcloud_org_key": "org1"},
+			{"key": "proj-b", "sonarcloud_org_key": "org2"},
+		})
+		got := collectProjectKeyReport(common.NewDataStore(dir), migrate.DefaultProjectKeyPattern)
+		if got != nil {
+			t.Fatalf("expected nil report, got %+v", got)
+		}
+	})
+
+	t.Run("static-prefix pattern collides same key across orgs", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTaskJSONL(t, dir, "generateProjectMappings", []map[string]any{
+			{"key": "shared", "sonarcloud_org_key": "org1"},
+			{"key": "shared", "sonarcloud_org_key": "org2"},
+			{"key": "unique", "sonarcloud_org_key": "org1"},
+		})
+		got := collectProjectKeyReport(common.NewDataStore(dir), "ACME_CORP_<ORIGINAL_PROJECT_KEY>")
+		if got == nil {
+			t.Fatal("expected a report, got nil")
+		}
+		if len(got.Collisions) != 1 {
+			t.Fatalf("expected 1 collision, got %d", len(got.Collisions))
+		}
+		c := got.Collisions[0]
+		if c.TargetKey != "ACME_CORP_shared" {
+			t.Errorf("collision target key = %q", c.TargetKey)
+		}
+		if len(c.Sources) != 2 {
+			t.Errorf("expected 2 colliding sources, got %d", len(c.Sources))
+		}
+	})
+
+	t.Run("default pattern keeps same key in different orgs distinct", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTaskJSONL(t, dir, "generateProjectMappings", []map[string]any{
+			{"key": "shared", "sonarcloud_org_key": "org1"},
+			{"key": "shared", "sonarcloud_org_key": "org2"},
+		})
+		// org1_shared vs org2_shared — no collision under the default pattern.
+		got := collectProjectKeyReport(common.NewDataStore(dir), migrate.DefaultProjectKeyPattern)
+		if got != nil {
+			t.Fatalf("expected nil report (org prefix disambiguates), got %+v", got)
+		}
+	})
+
+	t.Run("over-length key is flagged", func(t *testing.T) {
+		dir := t.TempDir()
+		longKey := strings.Repeat("x", migrate.MaxProjectKeyLength)
+		writeTaskJSONL(t, dir, "generateProjectMappings", []map[string]any{
+			{"key": longKey, "sonarcloud_org_key": "org1"}, // org1_ + 400 x's > 400
+		})
+		got := collectProjectKeyReport(common.NewDataStore(dir), migrate.DefaultProjectKeyPattern)
+		if got == nil || len(got.TooLong) != 1 {
+			t.Fatalf("expected 1 over-length key, got %+v", got)
+		}
+		if got.TooLong[0].Length <= migrate.MaxProjectKeyLength {
+			t.Errorf("over-length entry length = %d, want > %d", got.TooLong[0].Length, migrate.MaxProjectKeyLength)
+		}
+	})
+
+	t.Run("SKIPPED and empty orgs are ignored", func(t *testing.T) {
+		dir := t.TempDir()
+		writeTaskJSONL(t, dir, "generateProjectMappings", []map[string]any{
+			{"key": "shared", "sonarcloud_org_key": "SKIPPED"},
+			{"key": "shared", "sonarcloud_org_key": ""},
+		})
+		got := collectProjectKeyReport(common.NewDataStore(dir), "ACME_CORP_<ORIGINAL_PROJECT_KEY>")
+		if got != nil {
+			t.Fatalf("expected nil (all rows skipped), got %+v", got)
+		}
+	})
+}

--- a/go/internal/report/summary/types.go
+++ b/go/internal/report/summary/types.go
@@ -54,6 +54,45 @@ type MigrationSummary struct {
 	// exceeded the impact threshold, or any non-SQC 429 was observed).
 	// Nil for clean runs, which renders the report unchanged.
 	RateLimit *RateLimitReport
+
+	// ProjectKeys is populated only when the configured project-key
+	// renaming strategy produces a target-key collision (the same key in
+	// more than one organization) or a key over the SonarQube length
+	// limit. Nil when every rendered key is unique and within limits.
+	// Issue #138.
+	ProjectKeys *ProjectKeyReport
+}
+
+// ProjectKeyReport surfaces problems with the renamed target project keys
+// in the orange callout box and a markdown section. Issue #138.
+type ProjectKeyReport struct {
+	// Pattern is the project_key_pattern in effect for the run.
+	Pattern string
+	// Collisions lists target keys produced by more than one distinct
+	// source project (typically the same source key landing in different
+	// organizations under a pattern that omits <ORGANIZATION_KEY>).
+	Collisions []ProjectKeyCollision
+	// TooLong lists rendered keys that exceed migrate.MaxProjectKeyLength.
+	TooLong []ProjectKeyTooLong
+}
+
+// ProjectKeySource identifies a source project by its key and target org.
+type ProjectKeySource struct {
+	SourceKey string
+	OrgKey    string
+}
+
+// ProjectKeyCollision is one target key claimed by multiple source projects.
+type ProjectKeyCollision struct {
+	TargetKey string
+	Sources   []ProjectKeySource
+}
+
+// ProjectKeyTooLong is one rendered key that exceeds the length limit.
+type ProjectKeyTooLong struct {
+	ProjectKeySource
+	TargetKey string
+	Length    int
 }
 
 // RateLimitReport summarises 429 hits seen during the run for inclusion

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -176,6 +176,11 @@
         "default_organization": {
           "type": ["string", "null"],
           "description": "SonarQube Cloud organization key applied to every project when organizations.csv has no mapping defined. Ignored (with a WARN) when at least one row in organizations.csv carries a sonarcloud_org_key. CLI --default_organization overrides this. Issue #281."
+        },
+        "project_key_pattern": {
+          "type": ["string", "null"],
+          "default": "<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>",
+          "description": "Template for target SonarQube Cloud project keys, built from the placeholders <ORIGINAL_PROJECT_KEY> (mandatory) and <ORGANIZATION_KEY>. Defaults to <ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>. A single <ORIGINAL_PROJECT_KEY> with a static prefix requires a prefix of at least 5 characters; a bare <ORIGINAL_PROJECT_KEY> keeps the key unchanged. CLI --project_key_pattern overrides this. Issue #138."
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes #138. Makes the SonarQube Server → SonarQube Cloud project-key renaming strategy configurable via `target.project_key_pattern` (CLI: `--project_key_pattern`), instead of the hard-coded `orgKey + "_" + sourceKey`.

The pattern is built from **two placeholders** (case-insensitive, canonicalised to uppercase):

- `<ORIGINAL_PROJECT_KEY>` — the source key (mandatory; `<PROJECT_KEY>` accepted as an alias)
- `<ORGANIZATION_KEY>` — the target SonarQube Cloud organization key

Default: `<ORGANIZATION_KEY>_<ORIGINAL_PROJECT_KEY>` — SonarQube Cloud's convention and the tool's prior behavior, so existing migrations are unaffected.

## What's implemented (matches the revised issue spec)

- **Pattern engine** (`projectkey.go`): validate / render / affix-extraction / org-usage helpers, reused at every key-derivation site.
- **Validation** (aborts early on error): must include `<ORIGINAL_PROJECT_KEY>`; only the two placeholders allowed; a lone `<ORIGINAL_PROJECT_KEY>` is allowed **bare** (keep unchanged) or with a **prefix and/or postfix totalling ≥ 5 characters** (`acme_<…>` ✅, `sqs_<…>_migrated` ✅, `AAA_<…>` ❌).
- **Org-prefix collision guard**: a pattern without `<ORGANIZATION_KEY>` aborts `migrate` if its static prefix matches an existing SQC organization key.
- **Applied everywhere a key is derived**: `createProjects`, `matchProjectRepos`, and — affix-adapted so they keep matching after renaming — permission-template and portfolio selection regexes.
- **Reporting**: markdown + PDF amber callout for target-key **collisions** (same key in more than one org) and keys over the **400-char** limit.
- **Docs / schema / example** updated with the "Project key renaming strategy" section.

## Note
Also decouples three config-shape tests (`migrate`, `reset`, `extract`) from the example files removed in #408 — they now use inline fixtures. Those tests referenced deleted files, so `main` was red; this un-breaks it.

## Verification
- `go build ./...`, `go vet`, and `go test ./...` all pass (new engine, collision-abort, portfolio-regex, and report collision/over-length tests included).
- Example config validates against the JSON schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
