### PR TITLE
Issue #321: source-link comment back to original SQ issue/hotspot

### DIFF
--- a/go/internal/migrate/sourcelink_test.go
+++ b/go/internal/migrate/sourcelink_test.go
@@ -1,0 +1,115 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import "testing"
+
+func TestIssueSourceLinkURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		serverURL  string
+		projectKey string
+		issueKey   string
+		branch     string
+		want       string
+	}{
+		{
+			name: "basic (no branch)", serverURL: "https://sq.example.com", projectKey: "my-proj", issueKey: "AYx1",
+			want: "https://sq.example.com/project/issues?id=my-proj&issues=AYx1&open=AYx1",
+		},
+		{
+			name: "with branch", serverURL: "https://sq.example.com", projectKey: "p", issueKey: "k", branch: "feature/x",
+			want: "https://sq.example.com/project/issues?id=p&issues=k&open=k&branch=feature%2Fx",
+		},
+		{
+			name: "trailing slash trimmed", serverURL: "https://sq.example.com/", projectKey: "p", issueKey: "k",
+			want: "https://sq.example.com/project/issues?id=p&issues=k&open=k",
+		},
+		{
+			name: "special chars escaped", serverURL: "https://sq.example.com", projectKey: "org:proj", issueKey: "a b",
+			want: "https://sq.example.com/project/issues?id=org%3Aproj&issues=a+b&open=a+b",
+		},
+		{name: "missing serverURL", serverURL: "", projectKey: "p", issueKey: "k", want: ""},
+		{name: "missing projectKey", serverURL: "https://sq", projectKey: "", issueKey: "k", want: ""},
+		{name: "missing issueKey", serverURL: "https://sq", projectKey: "p", issueKey: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := issueSourceLinkURL(tc.serverURL, tc.projectKey, tc.issueKey, tc.branch); got != tc.want {
+				t.Fatalf("issueSourceLinkURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHotspotSourceLinkURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		serverURL  string
+		projectKey string
+		hotspotKey string
+		branch     string
+		want       string
+	}{
+		{
+			name: "basic (no branch)", serverURL: "https://sq.example.com", projectKey: "my-proj", hotspotKey: "HS-9",
+			want: "https://sq.example.com/security_hotspots?id=my-proj&hotspots=HS-9",
+		},
+		{
+			name: "with branch", serverURL: "https://sq.example.com", projectKey: "p", hotspotKey: "k", branch: "release/2.0",
+			want: "https://sq.example.com/security_hotspots?id=p&hotspots=k&branch=release%2F2.0",
+		},
+		{
+			name: "trailing slash trimmed", serverURL: "https://sq.example.com/", projectKey: "p", hotspotKey: "k",
+			want: "https://sq.example.com/security_hotspots?id=p&hotspots=k",
+		},
+		{name: "missing serverURL", serverURL: "", projectKey: "p", hotspotKey: "k", want: ""},
+		{name: "missing projectKey", serverURL: "https://sq", projectKey: "", hotspotKey: "k", want: ""},
+		{name: "missing hotspotKey", serverURL: "https://sq", projectKey: "p", hotspotKey: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hotspotSourceLinkURL(tc.serverURL, tc.projectKey, tc.hotspotKey, tc.branch); got != tc.want {
+				t.Fatalf("hotspotSourceLinkURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSourceLinkIdempotencyHelpers(t *testing.T) {
+	link := issueSourceLinkURL("https://sq.example.com", "p", "k", "")
+
+	t.Run("issue: marker detected even when URL is HTML-escaped", func(t *testing.T) {
+		// Simulates the cloud API returning the comment with the URL's "&"
+		// escaped — the marker still matches, preventing a duplicate link.
+		cloud := []issueComment{
+			{Markdown: "[Migrated from alice] some text"},
+			{HTMLText: issueSourceLinkMarker + "(https://sq.example.com/project/issues?id=p&amp;issues=k&amp;open=k)"},
+		}
+		if !issueCommentsContain(cloud, issueSourceLinkMarker) {
+			t.Fatal("expected the existing source link to be detected via marker")
+		}
+	})
+	t.Run("issue: absent when no link", func(t *testing.T) {
+		cloud := []issueComment{{HTMLText: "just a migrated comment"}}
+		if issueCommentsContain(cloud, issueSourceLinkMarker) {
+			t.Fatal("did not expect a source link to be detected")
+		}
+	})
+	_ = link
+
+	t.Run("hotspot: marker detected", func(t *testing.T) {
+		cloud := []hotspotComment{{Markdown: hotspotSourceLinkMarker + "(https://sq.example.com/security_hotspots?id=p&hotspots=k)"}}
+		if !hotspotCommentsContain(cloud, hotspotSourceLinkMarker) {
+			t.Fatal("expected the existing hotspot source link to be detected via marker")
+		}
+	})
+	t.Run("hotspot: absent when no link", func(t *testing.T) {
+		cloud := []hotspotComment{{HTMLText: "unrelated"}}
+		if hotspotCommentsContain(cloud, hotspotSourceLinkMarker) {
+			t.Fatal("did not expect a hotspot source link to be detected")
+		}
+	})
+}

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -55,6 +55,10 @@ type matchableHotspot struct {
 	Status     string
 	Resolution string
 	Comments   []hotspotComment
+	// Branch is the source SonarQube Server branch the hotspot was
+	// extracted from (enriched into the extract record). Used to build a
+	// branch-correct back-link to the original hotspot (#321).
+	Branch string
 }
 
 // hotspotComment captures a single comment attached to a hotspot.
@@ -336,11 +340,15 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 	// (ruleKey, line). Race-safety: actionable is read-only, each
 	// goroutine takes one hotspot by value, stats counters are
 	// atomic.
+	// Public base URL for back-links — prefer the SQS sonar.core.serverBaseURL
+	// setting over the (often localhost) connection URL (#321).
+	baseURL := resolveSourceBaseURL(e, input.ServerURL)
+
 	var a, b, c, ack atomic.Int64
 	label := "Project key " + input.CloudKey + " hotspot sync:"
 	runProjectSyncLoop(ctx, e, actionable, label, 10,
 		func(gctx context.Context, src matchableHotspot) {
-			outcome := resolveAndSyncHotspot(gctx, e, input.CloudKey, input.OrgKey, input.ServerKey, src, counter)
+			outcome := resolveAndSyncHotspot(gctx, e, input.CloudKey, input.OrgKey, baseURL, input.ServerKey, src, counter)
 			switch outcome {
 			case syncOutcomeSynced:
 				a.Add(1)
@@ -362,7 +370,7 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 // resolveAndSyncHotspot searches Cloud for hotspots in the source
 // hotspot's file, then resolves by (ruleKey, line). Returns the case
 // a/b/c/lookup outcome.
-func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, sourceKey string, src matchableHotspot, counter *TaskCounter) syncOutcome {
+func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, baseURL, sourceKey string, src matchableHotspot, counter *TaskCounter) syncOutcome {
 	filePath := src.Component
 	prefix := sourceKey + ":"
 	if strings.HasPrefix(filePath, prefix) {
@@ -382,7 +390,7 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, s
 	switch outcome {
 	case syncOutcomeSynced:
 		pair := hotspotPair{source: src, cloud: target}
-		if err := syncOneHotspot(ctx, e, pair); err != nil {
+		if err := syncOneHotspot(ctx, e, pair, baseURL, sourceKey); err != nil {
 			counter.Fail()
 			logAPIWarn(e.Logger, "syncHotspotMetadata: hotspot sync failed", err,
 				"source_key", src.Key, "cloud_key", target.Key)
@@ -560,9 +568,11 @@ func findCloudHotspotCandidates(ctx context.Context, e *Executor, cloudKey, orgK
 // Per-hotspot sync
 // ---------------------------------------------------------------------------
 
-// syncOneHotspot synchronises a single hotspot's status and comments.
-// Operations are sequential within each hotspot: status first, then comments.
-func syncOneHotspot(ctx context.Context, e *Executor, pair hotspotPair) error {
+// syncOneHotspot synchronises a single hotspot's status and comments, then
+// appends a back-link to the original SonarQube Server hotspot (#321).
+// Operations are sequential within each hotspot: status first, then comments,
+// then the source-link comment.
+func syncOneHotspot(ctx context.Context, e *Executor, pair hotspotPair, baseURL, projectKey string) error {
 	// 1. Sync status. Three branches when the source is REVIEWED:
 	//   - SAFE/FIXED → mapHotspotResolution returns the SQC resolution;
 	//     post change_status REVIEWED+<resolution>.
@@ -572,25 +582,30 @@ func syncOneHotspot(ctx context.Context, e *Executor, pair hotspotPair) error {
 	//     may have left on SQC. Idempotent — TO_REVIEW is also the
 	//     cloud default for a never-touched hotspot. #323.
 	//   - Unknown resolution → no API call (defensive).
+	// A status-sync failure is recorded but does NOT short-circuit the
+	// rest of the function — the comment and source-link steps must still
+	// run. Returning early here was why already-synced hotspots (whose
+	// change_status is rejected because they're already REVIEWED on a
+	// re-run) never got a back-link (#321).
+	var statusErr error
 	if strings.ToUpper(pair.source.Status) == "REVIEWED" {
 		resolution := mapHotspotResolution(pair.source.Resolution)
 		switch {
 		case resolution != "":
 			if err := e.Cloud.Hotspots.ChangeStatus(ctx, pair.cloud.Key, "REVIEWED", resolution); err != nil {
-				return fmt.Errorf("change status: %w", err)
+				statusErr = fmt.Errorf("change status: %w", err)
 			}
 		case IsAcknowledgedResolution(pair.source.Resolution):
 			if err := e.Cloud.Hotspots.ChangeStatus(ctx, pair.cloud.Key, "TO_REVIEW", ""); err != nil {
-				return fmt.Errorf("reset ACKNOWLEDGED to TO_REVIEW: %w", err)
+				statusErr = fmt.Errorf("reset ACKNOWLEDGED to TO_REVIEW: %w", err)
 			}
 		}
 	}
 
-	// 2. Sync comments: fetch Cloud detail first for idempotency check.
-	if len(pair.source.Comments) == 0 {
-		return nil
-	}
-
+	// 2. Sync comments + the source-link comment. Cloud detail is fetched
+	// once up front for the idempotency checks of both. Unlike before, we
+	// fetch even when the source has no comments, because the source-link
+	// comment (#321) is always appended for a matched hotspot.
 	cloudComments := fetchCloudHotspotComments(ctx, e, pair.cloud.Key)
 	for _, comment := range pair.source.Comments {
 		if isAlreadyMigratedComment(comment, cloudComments) {
@@ -617,7 +632,65 @@ func syncOneHotspot(ctx context.Context, e *Executor, pair hotspotPair) error {
 		}
 	}
 
-	return nil
+	// 3. Append a back-link to the original SonarQube Server hotspot so
+	// engineers can click through to its origin (#321). Best-effort and
+	// idempotent — consistent with the migrated-comment handling above.
+	// Always attempted, even if the status sync above failed.
+	addHotspotSourceLink(ctx, e, pair.cloud.Key, baseURL, projectKey, pair.source.Key, pair.source.Branch, cloudComments)
+
+	return statusErr
+}
+
+// hotspotSourceLinkURL builds the SonarQube Server deep link back to the
+// original hotspot, or "" when any component is missing. #321.
+func hotspotSourceLinkURL(baseURL, projectKey, hotspotKey, branch string) string {
+	if baseURL == "" || projectKey == "" || hotspotKey == "" {
+		return ""
+	}
+	base := strings.TrimRight(baseURL, "/")
+	u := fmt.Sprintf("%s/security_hotspots?id=%s&hotspots=%s",
+		base, url.QueryEscape(projectKey), url.QueryEscape(hotspotKey))
+	if branch != "" {
+		u += "&branch=" + url.QueryEscape(branch)
+	}
+	return u
+}
+
+// hotspotSourceLinkMarker is the stable, per-hotspot-unique prefix used to
+// detect an already-added source-link comment (see issueSourceLinkMarker for
+// why we match on the marker rather than the full URL).
+const hotspotSourceLinkMarker = "Link to [Original hotspot]"
+
+// addHotspotSourceLink posts a one-line "Link to [Original hotspot](…)"
+// comment pointing back to the source hotspot (#321). Best-effort and
+// idempotent: skipped when a cloud comment already carries the marker.
+func addHotspotSourceLink(ctx context.Context, e *Executor, cloudKey, baseURL, projectKey, sourceHotspotKey, branch string, cloudComments []hotspotComment) {
+	link := hotspotSourceLinkURL(baseURL, projectKey, sourceHotspotKey, branch)
+	if link == "" {
+		return
+	}
+	if hotspotCommentsContain(cloudComments, hotspotSourceLinkMarker) {
+		return
+	}
+	text := hotspotSourceLinkMarker + "(" + link + ")"
+	if err := e.Cloud.Hotspots.AddComment(ctx, cloudKey, text); err != nil {
+		e.Logger.Warn("syncHotspotMetadata: could not add source-link comment (non-fatal)",
+			"cloud_key", cloudKey, "reason", sourceLinkErrSummary(err))
+	}
+}
+
+// hotspotCommentsContain reports whether any cloud comment's text contains substr.
+func hotspotCommentsContain(cloudComments []hotspotComment, substr string) bool {
+	for _, cc := range cloudComments {
+		t := cc.Markdown
+		if t == "" {
+			t = cc.HTMLText
+		}
+		if strings.Contains(t, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 // fetchCloudHotspotComments retrieves comments for a Cloud hotspot via the
@@ -757,6 +830,9 @@ func parseMatchableHotspot(data json.RawMessage) matchableHotspot {
 		Status:     status,
 		Resolution: resolution,
 		Comments:   comments,
+		// Present on source-side records (enriched at extract time);
+		// absent/empty on cloud candidates, which don't need it.
+		Branch: extractField(data, "branch"),
 	}
 }
 

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -250,6 +250,61 @@ func TestMapHotspotResolution(t *testing.T) {
 	}
 }
 
+// #321: syncOneHotspot appends a back-link comment to the original
+// SonarQube Server hotspot, using the provided base URL. The link is added
+// even when the hotspot has no source comments, and is idempotent.
+func TestSyncOneHotspotAddsSourceLink(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		comments []string
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/hotspots/change_status", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	mux.HandleFunc("GET /api/hotspots/show", func(w http.ResponseWriter, _ *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"comment": []map[string]any{}})
+	})
+	mux.HandleFunc("POST /api/hotspots/add_comment", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		// api/hotspots/add_comment names the body parameter "comment".
+		comments = append(comments, r.FormValue("comment"))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	dir := t.TempDir()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	// A REVIEWED/SAFE hotspot on a feature branch with NO source comments —
+	// the link must still be added and carry the branch.
+	pair := hotspotPair{
+		source: matchableHotspot{Key: "HS-7", Status: "REVIEWED", Resolution: "SAFE", Branch: "feature/x"},
+		cloud:  matchableHotspot{Key: "cloud-1"},
+	}
+	if err := syncOneHotspot(context.Background(), e, pair, "https://sqs.example.com", "my-proj"); err != nil {
+		t.Fatalf("syncOneHotspot: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := "Link to [Original hotspot](https://sqs.example.com/security_hotspots?id=my-proj&hotspots=HS-7&branch=feature%2Fx)"
+	found := false
+	for _, c := range comments {
+		if c == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected source-link comment %q, got %v", want, comments)
+	}
+}
+
 // #323: when the source hotspot is REVIEWED/ACKNOWLEDGED, syncOneHotspot
 // must call /api/hotspots/change_status with status=TO_REVIEW and no
 // resolution — this resets a cloud hotspot left in SAFE by a previous
@@ -298,7 +353,7 @@ func TestSyncOneHotspotAcknowledgedResetsToToReview(t *testing.T) {
 			Comments: []hotspotComment{{Login: "alice", Markdown: "needs review"}}},
 		cloud: matchableHotspot{Key: "cloud-1"},
 	}
-	if err := syncOneHotspot(context.Background(), e, pair); err != nil {
+	if err := syncOneHotspot(context.Background(), e, pair, "", ""); err != nil {
 		t.Fatalf("syncOneHotspot: %v", err)
 	}
 
@@ -577,7 +632,7 @@ func TestSyncOneHotspotSafeCallsChangeStatus(t *testing.T) {
 		source: matchableHotspot{Key: "src-1", Status: "REVIEWED", Resolution: "SAFE"},
 		cloud:  matchableHotspot{Key: "cloud-1"},
 	}
-	if err := syncOneHotspot(context.Background(), e, pair); err != nil {
+	if err := syncOneHotspot(context.Background(), e, pair, "", ""); err != nil {
 		t.Fatalf("syncOneHotspot: %v", err)
 	}
 

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -513,11 +513,15 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 	// dispatch. Counted via atomics on the shared stats. Race-safety:
 	// the actionable slice is read-only, each goroutine receives one
 	// source by value, and stats.{A,B,C} use atomic adds.
+	// Public base URL for back-links — prefer the SQS sonar.core.serverBaseURL
+	// setting over the (often localhost) connection URL (#321).
+	baseURL := resolveSourceBaseURL(e, serverURL)
+
 	var a, b, c atomic.Int64
 	label := "Project key " + cloudKey + " issue sync:"
 	runProjectSyncLoop(ctx, e, actionable, label, 20,
 		func(gctx context.Context, src matchableIssue) {
-			outcome := resolveAndSyncIssue(gctx, e, cloudKey, orgKey, src, counter)
+			outcome := resolveAndSyncIssue(gctx, e, cloudKey, orgKey, baseURL, serverKey, src, counter)
 			switch outcome {
 			case syncOutcomeSynced:
 				a.Add(1)
@@ -563,7 +567,7 @@ const (
 // resolveAndSyncIssue searches Cloud for counterparts of src, resolves
 // to one by line, and dispatches the sync. Returns the case-a/b/c/lookup
 // outcome.
-func resolveAndSyncIssue(ctx context.Context, e *Executor, cloudKey, orgKey string, src matchableIssue, counter *TaskCounter) syncOutcome {
+func resolveAndSyncIssue(ctx context.Context, e *Executor, cloudKey, orgKey, baseURL, projectKey string, src matchableIssue, counter *TaskCounter) syncOutcome {
 	filePath := stripProjectKeyPrefix(src.Component)
 	if filePath == "" || src.Rule == "" || src.Line <= 0 {
 		e.Logger.Debug("syncIssueMetadata: source issue not matchable", "key", src.Key, "rule", src.Rule, "component", src.Component, "line", src.Line)
@@ -578,7 +582,7 @@ func resolveAndSyncIssue(ctx context.Context, e *Executor, cloudKey, orgKey stri
 	target, outcome := classifyIssueCandidatesByLine(candidates, src.Line)
 	switch outcome {
 	case syncOutcomeSynced:
-		syncOnePair(ctx, e, issuePair{source: src, cloud: target}, counter)
+		syncOnePair(ctx, e, issuePair{source: src, cloud: target}, baseURL, projectKey, counter)
 	case syncOutcomeNotFound:
 		e.Logger.Debug("syncIssueMetadata: no cloud counterpart on source line", "source_key", src.Key, "rule", src.Rule, "file", filePath, "line", src.Line)
 	case syncOutcomeLineMismatch:
@@ -634,8 +638,11 @@ func findCloudIssueCandidates(ctx context.Context, e *Executor, cloudKey, orgKey
 	// state already).
 	params.Set("issueStatuses", "OPEN,CONFIRMED,FALSE_POSITIVE,ACCEPTED")
 	// Ask for the per-issue available-transition list so we can verify
-	// the "accept" transition is offered before applying it (#322).
-	params.Set("additionalFields", "transitions")
+	// the "accept" transition is offered before applying it (#322), and
+	// the comment list so the source-link comment can be added
+	// idempotently — including on issues already carrying the
+	// metadata-synchronized tag from an earlier run (#321).
+	params.Set("additionalFields", "transitions,comments")
 	apiIssues, err := e.Cloud.Issues.SearchAll(ctx, params)
 	if err != nil {
 		return nil, err
@@ -657,14 +664,27 @@ func findCloudIssueCandidates(ctx context.Context, e *Executor, cloudKey, orgKey
 //
 // Idempotency: if the cloud issue already carries the metadataSyncTag
 // the pair is skipped entirely.
-func syncOnePair(ctx context.Context, e *Executor, pair issuePair, counter *TaskCounter) {
+func syncOnePair(ctx context.Context, e *Executor, pair issuePair, baseURL, projectKey string, counter *TaskCounter) {
+	cloudKey := pair.cloud.Key
+
+	// The metadata-synchronized tag means the expensive metadata sync
+	// (transition, comments, tags) already ran in a previous run. We still
+	// ensure the source-link comment exists, because issues synced by an
+	// earlier tool version carry the tag but no back-link (#321). The link
+	// is idempotent — skipped when a cloud comment already contains it.
 	if slices.Contains(pair.cloud.Tags, metadataSyncTag) {
+		syncIssueSourceLink(ctx, e, cloudKey, baseURL, projectKey, pair.source.Key, pair.source.Branch, pair.cloud.Comments)
 		return
 	}
 
-	cloudKey := pair.cloud.Key
 	transFailed := syncIssueTransition(ctx, e, cloudKey, pair.source, pair.cloud.Transitions)
 	commentFailed := syncIssueComments(ctx, e, cloudKey, pair.source.Comments, pair.cloud.Comments)
+	// Source-link back to the original SonarQube Server issue, added as
+	// the final comment so traceability survives the migration (#321).
+	// Best-effort: a failure here (e.g. an upstream CDN/WAF rejecting the
+	// URL-bearing comment body) must NOT fail the pair — the status,
+	// comments and tags have already synced successfully.
+	syncIssueSourceLink(ctx, e, cloudKey, baseURL, projectKey, pair.source.Key, pair.source.Branch, pair.cloud.Comments)
 	tagsFailed := syncIssueTags(ctx, e, cloudKey, pair.source.Tags)
 
 	if transFailed || commentFailed || tagsFailed {
@@ -672,6 +692,107 @@ func syncOnePair(ctx context.Context, e *Executor, pair issuePair, counter *Task
 	} else {
 		counter.Success()
 	}
+}
+
+// resolveSourceBaseURL returns the public base URL of the source SonarQube
+// Server, used to build issue/hotspot back-links (#321). Preference order:
+//
+//  1. the SQS `sonar.core.serverBaseURL` global setting captured at extract
+//     time (the operator-configured public URL), when non-empty;
+//  2. the URL the tool connected to (source_url / --source_url).
+//
+// The connection URL is frequently http://localhost:9000 — useless as a
+// click-through for engineers and liable to trip an upstream WAF's SSRF
+// rules — so the configured public base URL is preferred. Trailing slash is
+// trimmed. Safe for concurrent use (read-only extract access).
+func resolveSourceBaseURL(e *Executor, serverURL string) string {
+	if items, err := readExtractItems(e, "getServerSettings"); err == nil {
+		for _, it := range items {
+			if it.ServerURL != serverURL {
+				continue
+			}
+			if extractField(it.Data, "key") != "sonar.core.serverBaseURL" {
+				continue
+			}
+			if v := strings.TrimSpace(extractField(it.Data, "value")); v != "" {
+				return strings.TrimRight(v, "/")
+			}
+		}
+	}
+	return strings.TrimRight(serverURL, "/")
+}
+
+// issueSourceLinkURL builds the SonarQube Server deep link back to the
+// original issue, or "" when any component is missing. baseURL is the
+// resolved public server base (see resolveSourceBaseURL); branch, when
+// non-empty, scopes the link to the issue's source branch. #321.
+func issueSourceLinkURL(baseURL, projectKey, issueKey, branch string) string {
+	if baseURL == "" || projectKey == "" || issueKey == "" {
+		return ""
+	}
+	base := strings.TrimRight(baseURL, "/")
+	u := fmt.Sprintf("%s/project/issues?id=%s&issues=%s&open=%s",
+		base, url.QueryEscape(projectKey), url.QueryEscape(issueKey), url.QueryEscape(issueKey))
+	if branch != "" {
+		u += "&branch=" + url.QueryEscape(branch)
+	}
+	return u
+}
+
+// issueSourceLinkMarker is the stable, per-issue-unique prefix used to
+// detect an already-added source-link comment. Matching on this rather than
+// the full URL avoids false negatives when the cloud API returns the comment
+// with the URL's "&" HTML-escaped (which would duplicate the link on re-run).
+const issueSourceLinkMarker = "Link to [Original issue]"
+
+// syncIssueSourceLink posts a one-line "Link to [Original issue](…)" comment
+// pointing back to the source SonarQube Server issue (#321). Idempotent:
+// skipped when a comment already carries the marker. Best-effort — a failure
+// (e.g. an upstream CDN/WAF rejecting the URL-bearing body) is logged
+// concisely and never fails the issue sync.
+func syncIssueSourceLink(ctx context.Context, e *Executor, cloudKey, baseURL, projectKey, sourceIssueKey, branch string, cloudComments []issueComment) {
+	link := issueSourceLinkURL(baseURL, projectKey, sourceIssueKey, branch)
+	if link == "" {
+		return
+	}
+	if issueCommentsContain(cloudComments, issueSourceLinkMarker) {
+		return
+	}
+	text := issueSourceLinkMarker + "(" + link + ")"
+	if err := e.Cloud.Issues.AddComment(ctx, cloudKey, text); err != nil {
+		e.Logger.Warn("syncIssueMetadata: could not add source-link comment (non-fatal)",
+			"issue", cloudKey, "reason", sourceLinkErrSummary(err))
+	}
+}
+
+// sourceLinkErrSummary collapses the verbose HTML body an upstream CDN/WAF
+// (e.g. AWS CloudFront) returns on a 403 block into a short, actionable
+// note, so the log isn't flooded with an HTML error page per issue.
+func sourceLinkErrSummary(err error) string {
+	s := err.Error()
+	low := strings.ToLower(s)
+	if strings.Contains(low, "<html") || strings.Contains(low, "cloudfront") ||
+		strings.Contains(low, "request blocked") || strings.Contains(low, "403 error") {
+		return "blocked by an upstream CDN/WAF (the comment body contains a URL the WAF rejected)"
+	}
+	if len(s) > 200 {
+		s = s[:200] + "…"
+	}
+	return s
+}
+
+// issueCommentsContain reports whether any cloud comment's text contains substr.
+func issueCommentsContain(cloudComments []issueComment, substr string) bool {
+	for _, cc := range cloudComments {
+		t := cc.Markdown
+		if t == "" {
+			t = cc.HTMLText
+		}
+		if strings.Contains(t, substr) {
+			return true
+		}
+	}
+	return false
 }
 
 // syncIssueTransition applies the status transition on the Cloud issue.

--- a/lib/sq-api-go/cloud/cloud_test.go
+++ b/lib/sq-api-go/cloud/cloud_test.go
@@ -1534,3 +1534,48 @@ func TestBaseClientHTTPError(t *testing.T) {
 	require.ErrorAs(t, err, &apiErr)
 	assert.Equal(t, 500, apiErr.StatusCode)
 }
+
+// #321 regression: api/hotspots/add_comment names the body parameter
+// "comment" (not "text" as api/issues/add_comment does). Sending the wrong
+// name yields a 400 "The 'comment' parameter is missing".
+func TestHotspotsAddCommentUsesCommentParam(t *testing.T) {
+	var gotHotspot, gotComment, gotText string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/hotspots/add_comment", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotHotspot = r.FormValue("hotspot")
+		gotComment = r.FormValue("comment")
+		gotText = r.FormValue("text")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cc := newTestCloud(t, mux)
+	if err := cc.Hotspots.AddComment(context.Background(), "HS-1", "hello"); err != nil {
+		t.Fatalf("AddComment: %v", err)
+	}
+	assert.Equal(t, "HS-1", gotHotspot)
+	assert.Equal(t, "hello", gotComment, "body must be sent as the 'comment' parameter")
+	assert.Empty(t, gotText, "the 'text' parameter must not be used for hotspots")
+}
+
+// #321 regression: /api/hotspots/show returns component and project as
+// nested objects; HotspotDetail must unmarshal them (as json.RawMessage)
+// rather than failing the whole response, so Comment is recovered.
+func TestHotspotsShowParsesObjectComponent(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/hotspots/show", func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"key":       "HS-1",
+			"component": map[string]any{"key": "proj:src/Foo.java", "qualifier": "FIL", "path": "src/Foo.java"},
+			"project":   map[string]any{"key": "proj", "qualifier": "TRK", "name": "Proj"},
+			"status":    "REVIEWED",
+			"comment": []map[string]any{
+				{"key": "c1", "login": "alice", "markdown": "looks safe"},
+			},
+		})
+	})
+	cc := newTestCloud(t, mux)
+	detail, err := cc.Hotspots.Show(context.Background(), "HS-1")
+	require.NoError(t, err)
+	require.Len(t, detail.Comment, 1)
+	assert.Equal(t, "looks safe", detail.Comment[0].Markdown)
+}

--- a/lib/sq-api-go/cloud/hotspots.go
+++ b/lib/sq-api-go/cloud/hotspots.go
@@ -77,10 +77,13 @@ func (c *HotspotsClient) ChangeStatus(ctx context.Context, hotspotKey, status, r
 	return c.postForm(ctx, "api/hotspots/change_status", form, nil)
 }
 
-// AddComment adds a comment to a hotspot.
+// AddComment adds a comment to a hotspot. Note the text parameter is named
+// "comment" for api/hotspots/add_comment (unlike api/issues/add_comment,
+// which uses "text") — sending "text" yields a 400 "The 'comment' parameter
+// is missing".
 func (c *HotspotsClient) AddComment(ctx context.Context, hotspotKey, text string) error {
 	form := url.Values{}
 	form.Set("hotspot", hotspotKey)
-	form.Set("text", text)
+	form.Set("comment", text)
 	return c.postForm(ctx, "api/hotspots/add_comment", form, nil)
 }

--- a/lib/sq-api-go/types/hotspots.go
+++ b/lib/sq-api-go/types/hotspots.go
@@ -4,6 +4,8 @@
 
 package types
 
+import "encoding/json"
+
 // Hotspot represents a single security hotspot returned by /api/hotspots/search.
 type Hotspot struct {
 	Key                      string `json:"key"`
@@ -22,10 +24,15 @@ type Hotspot struct {
 }
 
 // HotspotDetail is the full detail returned by /api/hotspots/show.
+//
+// Unlike /api/hotspots/search (where component and project are plain key
+// strings), /api/hotspots/show returns them as nested objects. They are kept
+// as json.RawMessage so the response unmarshals regardless of shape — the
+// migrate-side hotspot sync only consumes Comment and Rule from this type.
 type HotspotDetail struct {
 	Key                      string           `json:"key"`
-	Component                string           `json:"component"`
-	Project                  string           `json:"project"`
+	Component                json.RawMessage  `json:"component"`
+	Project                  json.RawMessage  `json:"project"`
 	SecurityCategory         string           `json:"securityCategory"`
 	VulnerabilityProbability string           `json:"vulnerabilityProbability"`
 	Status                   string           `json:"status"`


### PR DESCRIPTION
## Summary

Closes #321 (CLOUDVOYAGER-DELTA BUG-06). After migration, every synced issue and hotspot now carries a comment linking back to its **original** SonarQube Server issue/hotspot, restoring traceability from the Cloud finding to its origin.

- **Issues:** a `Link to [Original issue](…)` comment is posted after the migrated comments (and also added to issues already carrying the `metadata-synchronized` tag, so findings synced by an earlier run get back-linked too).
- **Hotspots:** a `Link to [Original hotspot](…)` comment is posted for every matched hotspot — even with no source comments, and even when the status sync fails (a `change_status` error no longer short-circuits before the link).

## Link construction

- **Base URL** prefers the source server's `sonar.core.serverBaseURL` setting (from the `getServerSettings` extract), falling back to `source_url` / `--source_url`. This avoids useless `localhost` links — and the SSRF WAF block they trigger.
- **Branch** is included (`&branch=<encoded>`) when the finding carries one, matching SonarQube's deep-link format (per `sonar-tools`).
- **Idempotent** via a stable per-finding marker (`Link to [Original issue]` / `Link to [Original hotspot]`), so re-runs don't duplicate it.
- **Best-effort** with concise logging — an upstream CDN/WAF block is reported in one line and never fails the sync.

## SDK fixes surfaced along the way (`lib/sq-api-go`)

1. `Hotspots.AddComment` sent `text=`, but `api/hotspots/add_comment` requires `comment=` (issues use `text`). This had been breaking **all** hotspot comment writes, not just the source-link.
2. `HotspotDetail.Component`/`Project` were typed `string` but `/api/hotspots/show` returns objects → the whole response failed to unmarshal, blinding the comment-idempotency check. Now `json.RawMessage`.

## Tests
- New pure-function tests for the issue/hotspot URL builders (incl. branch + escaping) and marker-based idempotency.
- Integration test asserting `syncOneHotspot` posts the branch-bearing link even with no source comments.
- SDK regression tests: `add_comment` uses the `comment` param; `Show` parses object-shaped `component`/`project` and recovers comments.
- `go build ./...` and `go test ./...` pass in both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
