### PR TITLE
fix: migrated main branch renders LOC + real SCM blame in Code view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ lib/sq-api-go/coverage.out
 
 # Logs
 *.log
+# Transfer run output (runtime log artifact; may contain hosts/data)
+transfer-run.out
+transfer-*.out
 
 # Temporary working directory
 tmp/

--- a/docs/EMPTY-MAIN-BRANCH-REPORT-DIFF.md
+++ b/docs/EMPTY-MAIN-BRANCH-REPORT-DIFF.md
@@ -1,0 +1,94 @@
+# Empty Main Branch — Scanner Report Diff (our tool vs `@sonar/scan`)
+<!-- updated: 2026-06-19_17:30:00 -->
+
+## Symptom
+
+After `transfer`, the SonarCloud project list shows **"The main branch of this project is empty"**, even though the project, quality gate, issues, and hotspots all migrate. A native `npx @sonar/scan` of the same project renders correctly (non-empty).
+
+## How this was verified
+<!-- updated: 2026-06-19_17:30:00 -->
+
+A literal, evidence-backed comparison of the two scanner reports for `okorach-oss_sonar-tools-test`:
+
+1. **Real report** — captured by re-running `npx @sonar/scan` against the source server (`localhost:9000`) with `-Dsonar.scanner.keepReport=true`, which retains `.scannerwork/scanner-report/` instead of deleting it post-upload. (The flag IS honored by `@sonar/scan` despite being undocumented.)
+2. **Our report** — reproduced **offline and faithfully** by calling the production `buildBranchReport` for the main branch with the already-extracted data (white-box test `internal/migrate/zz_dumpreport_test.go`, gated on `SMT_DUMP_OUT`). The main-branch path makes no network calls (`buildSCProfileMap` is nil-safe; no create-analysis handshake for main), so the packaged bytes equal what the tool would submit — except `metadata.pb` qprofiles are empty when `e.Cloud == nil`.
+
+## File-inventory diff
+<!-- updated: 2026-06-19_17:30:00 -->
+
+| File type | Our report | Real `@sonar/scan` |
+|---|---:|---:|
+| component-N.pb | 124 (1 PROJECT + 123 FILE) | 124 (1 PROJECT + 123 FILE) |
+| source-N.txt | 123 | 123 |
+| issues-N.pb | 46 | 46 |
+| external-issues-N.pb | 82 | 82 |
+| metadata.pb | 1 | 1 |
+| context-props.pb | 1 (empty) | 1 |
+| activerules.pb | 1 | 1 |
+| adhocrules.pb | 1 | 1 |
+| **measures-N.pb** | **0** | **123** |
+| syntax-highlightings-N.pb | 0 | 123 |
+| symbols-N.pb | 0 | 108 |
+| duplications-N.pb | 0 | 95 |
+| coverages-N.pb | 0 | 93 |
+| telemetry-entries.pb / analysis-cache2.pb / analysis-warnings.pb / sca / analysis.log | 0 | present |
+| changesets-N.pb | 123 | 0 (SCM disabled in this scan) |
+| **Total entries** | **502** | **926** |
+
+Component structure matches exactly (flat PROJECT → 123 FILE, no DIRECTORY tree — the modern scanner does not emit DIRECTORY components, so our PROJECT+FILE shape is correct). Our FILE components correctly carry `lines` and `language` (e.g. `ref=2 type=FILE lines=33 lang="py"`).
+
+No file is byte-identical, and none can be: timestamps, `analysis_uuid`, random `scm_revision_id`, Deflate framing, and entry ordering all differ by construction. Even where the *type* matches, content volume differs (real `metadata.pb` 3608 B vs ours 184 B; real `activerules.pb` 425 KB activating the full ruleset vs ours 17 KB activating only the extracted subset). A raw byte diff is therefore neither achievable nor meaningful — the structural + semantic diff above is the correct comparison.
+
+## Root cause
+<!-- updated: 2026-06-19_17:30:00 -->
+
+`go/internal/migrate/tasks_projectdata.go:449` builds the report with `Measures: make(map[int32][]*pb.Measure)` — an empty map that is never populated. `PackageReport` → `addMeasures` (`go/internal/scanreport/packager.go:119`) therefore writes **zero** `measures-N.pb` files, so the report carries no `ncloc`.
+
+A real file-level `measures-N.pb` contains (decoded from the real report):
+
+```
+ncloc                 int=481
+ncloc_data            string="23=1;24=1;26=1;..."   (per-line bitmap)
+comment_lines         int=73
+complexity            int=103
+cognitive_complexity  int=129
+functions             int=21
+statements            int=398
+classes               int=0
+executable_lines_data string="512=1;513=1;..."
+```
+
+There is **no `measures-1.pb`** (the project root) — SonarCloud's Compute Engine **aggregates project `ncloc` from the per-file measures**. We send none, so project `ncloc` computes to null → the "main branch is empty" overlay fires.
+
+The data is already on hand: `loadExtractedComponents` reads each file's `ncloc` via `extractMeasureInt32(item.Data, "ncloc")` but uses it only for the component `Lines` field. The extract phase requests only `ncloc` (`internal/extract/tasks_projectdata.go:249` → `"metricKeys": {"ncloc"}`); other metrics are not extracted.
+
+## Why this is the right fix (CloudVoyager precedent)
+<!-- updated: 2026-06-19_17:30:00 -->
+
+CloudVoyager (the predecessor this tool harvests from) **did** populate measures and shipped working, non-empty branches:
+
+- `src/pipelines/sq-2025/sonarcloud/report-packager/helpers/add-core-files.js` and `.../uploader/helpers/add-protobuf-files.js` write `measures-${ref}.pb` from a per-ref measures map.
+- It sourced measures from `/api/measures/component` and computed `linesOfCode` from the scalar `ncloc` measure.
+
+This strongly implies a **scalar `ncloc` measure per file is sufficient** to make the branch non-empty; `ncloc_data` (the per-line bitmap) is needed for line-level decoration and coverage-on-new-code but not for the branch to register lines of code.
+
+## Fix (APPLIED 2026-06-19)
+<!-- updated: 2026-06-19_18:05:00 -->
+
+Implemented in three parts:
+
+1. **Extract** (`internal/extract/tasks_projectdata.go`, `getProjectComponentTree`): the `metricKeys` request was widened from `ncloc` alone to `ncloc,comment_lines,complexity,cognitive_complexity,functions,statements,classes`. These are the scalar measures `api/measures/component_tree` allows. The per-line *data* metrics `ncloc_data` and `executable_lines_data` are **rejected** by `component_tree` (`HTTP 400: "Metrics ncloc_data can't be requested in this web service. Please use api/measures/component"`), so they are intentionally omitted — they would each require one `api/measures/component` call per file.
+
+2. **Migrate load** (`internal/migrate/tasks_projectdata.go`): new `loadComponentMeasures` reads the per-file measures array from the extracted component tree and returns `[]scanreport.MeasureInput`. Helper `extractMeasurePairs` parses `"measures":[{"metric":..,"value":..}]`.
+
+3. **Migrate wire-up** (`buildBranchReport`): `Measures: make(map[int32][]*pb.Measure)` (the empty map at the old line 449) was replaced with `Measures: scanreport.BuildMeasures(componentMeasures, cr)`.
+
+**Offline verification** (white-box `zz_dumpreport_test.go`, regenerating the actual main-branch zip from extracted data): `measures-N.pb` went from **0 → 123**; **116/123** files carry `ncloc`; project total = **17,379 LOC** (non-zero → overlay cleared). No `measures-1.pb` root file (correct — the CE aggregates the project total from per-file measures). Total report entries 502 → 625.
+
+Open follow-up (not needed for the overlay): `ncloc_data`/`executable_lines_data` per-line bitmaps for line-level LOC/coverage decoration would require a separate `api/measures/component` extract pass.
+
+## Diagnostic artifacts (temporary — safe to delete)
+<!-- updated: 2026-06-19_17:30:00 -->
+
+- `go/tmp_pbdump/main.go` — decodes report `.pb` files using the repo's proto bindings (`go run ./tmp_pbdump measures <file>` / `component <file>`).
+- `go/internal/migrate/zz_dumpreport_test.go` — dumps our actual main-branch zip offline; gated on `SMT_DUMP_OUT`, skips in CI.

--- a/docs/SCM-BLAME-MIGRATION.md
+++ b/docs/SCM-BLAME-MIGRATION.md
@@ -1,0 +1,48 @@
+# SCM Blame Migration (Code-view author/date/revision per line)
+
+<!-- updated: 2026-06-19_18:05:00 -->
+
+## Goal
+
+In SonarQube Server's Code view each line shows who changed it, when, and at which revision. Before this change the migrated SonarCloud project showed none of that: every line carried a synthetic stub author and the analysis date. This change ships the **real** per-line SCM blame so the SonarCloud Code view matches the source.
+
+## How blame reaches the report
+
+<!-- updated: 2026-06-19_18:05:00 -->
+
+The scanner report conveys blame through `changesets-{ref}.pb` (`Changesets` proto): a list of `Changeset{revision, author, date}` entries plus `changesetIndexByLine[]` mapping each source line (0-indexed) to one entry. SonarCloud's Code view renders author/date/revision from this, and — because `pb.Issue` carries **no date field** — the CE also derives each issue's creation date from the changeset date of the issue's line.
+
+## What was wrong
+
+<!-- updated: 2026-06-19_18:05:00 -->
+
+The extract already pulled real blame via `getProjectSCMData` (`/api/sources/scm`), but the migrate side **never read it**. `buildChangesetMap` always called `BuildDefaultChangesets`, emitting one synthetic changeset per file (`revision="migration-initial"`, `author="sonar-migration-tool@sonarcloud.io"`, date=now). `BackdateChangesets` then rebuilt those entries entirely, keyed on issue creation dates, with the stub author. Net result: no real author, no real revision, dates only meaningful on issue lines.
+
+## What changed
+
+<!-- updated: 2026-06-19_18:05:00 -->
+
+1. **`/api/sources/scm` is run-length encoded.** Confirmed against the live source: the default response lists a line only when its blame differs from the previous line (968 sparse entries vs 1571 with `commits_by_line=true` for one file; sparse line starts `[1,3,4,20,21,23…]`). Each listed line begins a run that continues until the next listed line. Extract keeps the default (smaller payload); migrate expands the runs.
+
+2. **`loadExtractedSCM` + `parseBlameLines`** (`internal/migrate/tasks_projectdata.go`): read `getProjectSCMData` into `[]blameLine{Line, Author, Date, Revision}` per component, sorted by line.
+
+3. **`scanreport.BuildChangesetsFromBlame`** (`internal/scanreport/builder.go`): builds a `Changesets` from the runs — dedups `(revision, author, date)` into entries and expands runs forward across every one of the file's lines. Lines before the first run inherit it; a run with a zero/unparseable date falls back to the analysis date.
+
+4. **`buildChangesetMap`** now prefers real blame and falls back to the synthetic changeset only when blame is **not meaningful** — i.e. every line has an empty author *and* empty revision (a project analyzed without git history). `blameRunsFor` enforces that guard so we never ship all-empty blame.
+
+5. **Blame-preserving backdating** (`internal/scanreport/backdate.go`): `rebuildChangesetForFile` was rewritten. Instead of discarding entries and rebuilding from issue dates, it now overrides only the **date** on issue lines (so issues keep their original creation date) while **preserving the real author and revision** already on that line. Non-issue lines keep their real blame untouched. Multi-line issues get the same (oldest-wins) date on every line of their range, so the CE's MAX-over-lines collapses to that date — no inflation. All existing `backdate_test.go` cases still pass (they assert on dates and the line-1 index, both preserved).
+
+## Source-data caveat (important for verification)
+
+<!-- updated: 2026-06-19_18:05:00 -->
+
+Blame can only be migrated if the **source** has it. Verified directly against `localhost:9000`:
+
+- `okorach-oss_sonar-tools-test` — **no blame**: every line of all 369 files across all 3 branches has empty author and empty revision (uniform analysis-date only). This is the signature of a project analyzed without git history. For this project the tool correctly falls back to the synthetic changeset; the Code view will show no real authors because there is nothing to migrate.
+- `okorach-oss_sonar-tools` (v3.21) — **real blame**: real authors (e.g. `olivier.korach@gmail.com`), real ISO dates, real 40-char revisions. This is the project to use when verifying the blame fix end-to-end.
+
+## Tests
+
+<!-- updated: 2026-06-19_18:05:00 -->
+
+`TestBuildChangesetsFromBlame` covers run-length expansion (lines 1-3=rA, 4-5=rB, 6-8=rA), `(rev,author,date)` dedup, zero-date fallback, and the nil-on-empty case. `go vet` clean; `internal/scanreport`, `internal/migrate`, `internal/extract` all green.

--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -246,7 +246,16 @@ func projectComponentTreeTask() func(ctx context.Context, e *Executor) error {
 					"component":  {projectKey},
 					"branch":     {branch},
 					"qualifiers": {"FIL,UTS"},
-					"metricKeys": {"ncloc"},
+					// Per-file size/complexity measures. Without measures the
+					// packaged report carries no measures-*.pb, SonarCloud's CE
+					// computes a null project ncloc, and the branch renders as
+					// "main branch is empty". ncloc alone clears the overlay
+					// (CloudVoyager precedent); the rest populate the dashboard.
+					// Data metrics (ncloc_data, executable_lines_data) are NOT
+					// requestable via component_tree — the API requires
+					// api/measures/component (one call per file) — so they are
+					// intentionally omitted here.
+					"metricKeys": {"ncloc,comment_lines,complexity,cognitive_complexity,functions,statements,classes"},
 					"ps":         {"500"},
 				}
 				items, err := e.Raw.GetPaginated(ctx, PaginatedOpts{

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -317,6 +317,11 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	components := loadExtractedComponents(e, input.ServerURL, input.ServerKey, input.Branch)
 	sources := loadExtractedSources(e, input.ServerURL, input.ServerKey, input.Branch)
 	activeRules := loadExtractedActiveRules(e, input.ServerURL, input.ServerKey)
+	// Per-file measures (ncloc et al.) — without these the branch renders as
+	// "main branch is empty". Real per-line SCM blame — without it the Code
+	// view shows no author/date per line.
+	componentMeasures := loadComponentMeasures(e, input.ServerURL, input.ServerKey, input.Branch)
+	scmByComponent := loadExtractedSCM(e, input.ServerURL, input.ServerKey, input.Branch)
 
 	if len(components) == 0 {
 		return nil, &importResult{Status: "skipped"}, nil
@@ -382,7 +387,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 		}
 	}
 
-	changesets := buildChangesetMap(cr, components, pbSources, now)
+	changesets := buildChangesetMap(cr, components, pbSources, scmByComponent, now)
 
 	// Backdate changesets so each issue gets its original SonarQube creation date.
 	// Build a component-key-keyed alias map (same pointers) for BackdateChangesets.
@@ -446,7 +451,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 		FileComponents: fileComps,
 		Issues:         scanreport.BuildIssues(issues, cr),
 		ExternalIssues: scanreport.BuildExternalIssues(extIssues, cr),
-		Measures:       make(map[int32][]*pb.Measure),
+		Measures:       scanreport.BuildMeasures(componentMeasures, cr),
 		Changesets:     changesets,
 		ActiveRules:    scanreport.BuildActiveRules(activeRules, now.UnixMilli()),
 		AdHocRules:     scanreport.BuildAdHocRules(adHocRules),
@@ -907,6 +912,196 @@ func loadExtractedComponents(e *Executor, serverURL, serverKey, branch string) [
 	return components
 }
 
+// loadComponentMeasures reads the per-file measures extracted from
+// /api/measures/component_tree (ncloc, comment_lines, complexity, ...) and
+// returns them as MeasureInputs keyed by component. Without these, the
+// packaged report carries no measures-*.pb, SonarCloud's CE computes a null
+// project ncloc, and the migrated branch renders as "main branch is empty".
+func loadComponentMeasures(e *Executor, serverURL, serverKey, branch string) []scanreport.MeasureInput {
+	items, err := readExtractItems(e, "getProjectComponentTree")
+	if err != nil {
+		return nil
+	}
+	var measures []scanreport.MeasureInput
+	for _, item := range items {
+		if item.ServerURL != serverURL {
+			continue
+		}
+		if extractField(item.Data, "projectKey") != serverKey {
+			continue
+		}
+		if extractField(item.Data, "branch") != branch {
+			continue
+		}
+		key := extractField(item.Data, "key")
+		if key == "" {
+			continue
+		}
+		for _, m := range extractMeasurePairs(item.Data) {
+			measures = append(measures, scanreport.MeasureInput{
+				Component: key,
+				MetricKey: m.metric,
+				Value:     m.value,
+			})
+		}
+	}
+	return measures
+}
+
+type measurePair struct {
+	metric string
+	value  string
+}
+
+// extractMeasurePairs reads the "measures":[{"metric":..,"value":..}] array
+// from a component-tree record. Measures with an empty value are skipped.
+func extractMeasurePairs(data json.RawMessage) []measurePair {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil
+	}
+	raw, ok := obj["measures"]
+	if !ok {
+		return nil
+	}
+	var arr []struct {
+		Metric string `json:"metric"`
+		Value  string `json:"value"`
+	}
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil
+	}
+	out := make([]measurePair, 0, len(arr))
+	for _, m := range arr {
+		if m.Metric == "" || m.Value == "" {
+			continue
+		}
+		out = append(out, measurePair{metric: m.Metric, value: m.Value})
+	}
+	return out
+}
+
+// blameLine is one run-length SCM entry: the source line where a commit run
+// begins, plus its author/date/revision. /api/sources/scm omits lines whose
+// blame matches the previous line, so each entry starts a run that continues
+// until the next listed line (handled by scanreport.BuildChangesetsFromBlame).
+type blameLine struct {
+	Line     int32
+	Author   string
+	Date     time.Time
+	Revision string
+}
+
+// loadExtractedSCM reads getProjectSCMData and returns per-component blame runs
+// (sorted by line) for the given branch. The migrate side previously ignored
+// this data and shipped synthetic changesets; loading it lets the report carry
+// real per-line author/date/revision for the SonarCloud Code view.
+func loadExtractedSCM(e *Executor, serverURL, serverKey, branch string) map[string][]blameLine {
+	items, err := readExtractItems(e, "getProjectSCMData")
+	if err != nil {
+		return nil
+	}
+	result := make(map[string][]blameLine)
+	for _, item := range items {
+		if item.ServerURL != serverURL {
+			continue
+		}
+		if extractField(item.Data, "projectKey") != serverKey {
+			continue
+		}
+		if extractField(item.Data, "branch") != branch {
+			continue
+		}
+		key := extractField(item.Data, "key")
+		if key == "" {
+			continue
+		}
+		if lines := parseBlameLines(item.Data); len(lines) > 0 {
+			result[key] = lines
+		}
+	}
+	return result
+}
+
+// parseBlameLines parses the "scm":[[line,author,datetime,revision],...] array
+// from a getProjectSCMData record into blameLines sorted by line.
+func parseBlameLines(data json.RawMessage) []blameLine {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil
+	}
+	raw, ok := obj["scm"]
+	if !ok {
+		return nil
+	}
+	var rows [][]json.RawMessage
+	if err := json.Unmarshal(raw, &rows); err != nil {
+		return nil
+	}
+	out := make([]blameLine, 0, len(rows))
+	for _, r := range rows {
+		if len(r) < 3 {
+			continue
+		}
+		var line int32
+		json.Unmarshal(r[0], &line) //nolint:errcheck
+		var author, dateStr, rev string
+		json.Unmarshal(r[1], &author)  //nolint:errcheck
+		json.Unmarshal(r[2], &dateStr) //nolint:errcheck
+		if len(r) >= 4 {
+			json.Unmarshal(r[3], &rev) //nolint:errcheck
+		}
+		out = append(out, blameLine{
+			Line:     line,
+			Author:   author,
+			Date:     parseISODate(dateStr),
+			Revision: rev,
+		})
+	}
+	slices.SortFunc(out, func(a, b blameLine) int {
+		switch {
+		case a.Line < b.Line:
+			return -1
+		case a.Line > b.Line:
+			return 1
+		default:
+			return 0
+		}
+	})
+	return out
+}
+
+// blameRunsFor converts extracted blame lines into BlameRuns, but only when the
+// blame is meaningful — at least one line must carry a real author or revision.
+// Projects analyzed without git history return blame with empty author AND
+// revision for every line (only a date); for those we return nil so the caller
+// falls back to a synthetic changeset rather than shipping empty blame.
+func blameRunsFor(lines []blameLine) []scanreport.BlameRun {
+	if len(lines) == 0 {
+		return nil
+	}
+	meaningful := false
+	runs := make([]scanreport.BlameRun, 0, len(lines))
+	for _, l := range lines {
+		if l.Line <= 0 {
+			continue
+		}
+		if l.Author != "" || l.Revision != "" {
+			meaningful = true
+		}
+		runs = append(runs, scanreport.BlameRun{
+			StartLine: l.Line,
+			Author:    l.Author,
+			Date:      l.Date,
+			Revision:  l.Revision,
+		})
+	}
+	if !meaningful {
+		return nil
+	}
+	return runs
+}
+
 // sonarCloudRuleRepos lists rule repositories known to exist in SonarCloud.
 // Rules from external/third-party repos are excluded from the report to
 // prevent CE processing errors.
@@ -1137,7 +1332,7 @@ func dropIssuesWithInactiveRules(issues []scanreport.IssueInput, activeRules []s
 	return kept, dropped
 }
 
-func buildChangesetMap(cr *scanreport.ComponentRef, components []scanreport.ComponentInput, pbSources map[int32]string, date time.Time) map[int32]*pb.Changesets {
+func buildChangesetMap(cr *scanreport.ComponentRef, components []scanreport.ComponentInput, pbSources map[int32]string, scmByComp map[string][]blameLine, date time.Time) map[int32]*pb.Changesets {
 	changesets := make(map[int32]*pb.Changesets)
 	for _, comp := range components {
 		ref, ok := cr.Refs()[comp.Key]
@@ -1151,9 +1346,20 @@ func buildChangesetMap(cr *scanreport.ComponentRef, components []scanreport.Comp
 		if lineCount == 0 {
 			lineCount = int(comp.Lines)
 		}
-		if lineCount > 0 {
-			changesets[ref] = scanreport.BuildDefaultChangesets(ref, lineCount, date)
+		if lineCount <= 0 {
+			continue
 		}
+		// Prefer real per-line SCM blame so the SonarCloud Code view shows who
+		// changed each line and when (matching SonarQube Server). Fall back to
+		// a synthetic changeset when the source has no usable blame for the file
+		// (e.g. a project analyzed without git history — every line empty).
+		if runs := blameRunsFor(scmByComp[comp.Key]); len(runs) > 0 {
+			if cs := scanreport.BuildChangesetsFromBlame(ref, runs, lineCount, date); cs != nil {
+				changesets[ref] = cs
+				continue
+			}
+		}
+		changesets[ref] = scanreport.BuildDefaultChangesets(ref, lineCount, date)
 	}
 	return changesets
 }

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -232,7 +232,7 @@ func TestBuildChangesetMap(t *testing.T) {
 	cr.Get("p1:src/Empty.java")
 
 	now := time.Now()
-	result := buildChangesetMap(cr, components, nil, now)
+	result := buildChangesetMap(cr, components, nil, nil, now)
 
 	// Lines > 0 should produce changesets.
 	mainRef, _ := cr.Refs()["p1:src/Main.java"]

--- a/go/internal/migrate/zz_dumpreport_test.go
+++ b/go/internal/migrate/zz_dumpreport_test.go
@@ -1,0 +1,91 @@
+package migrate
+
+// Diagnostic-only: reproduces the EXACT scanner-report zip the tool would submit
+// for the main branch, fully offline, by calling the production buildBranchReport
+// with already-extracted data. Gated on SMT_DUMP_OUT so it never runs in CI.
+//
+//   SMT_DUMP_OUT=/tmp/our-report/our-scanner-report.zip \
+//   SMT_EXPORT_DIR=/abs/path/to/migration-files \
+//   go test ./internal/migrate -run TestDumpOurReport -count=1 -v
+//
+// Delete this file after the investigation.
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+)
+
+func TestDumpOurReport(t *testing.T) {
+	out := os.Getenv("SMT_DUMP_OUT")
+	if out == "" {
+		t.Skip("set SMT_DUMP_OUT to run the report dump")
+	}
+	exportDir := os.Getenv("SMT_EXPORT_DIR")
+	if exportDir == "" {
+		t.Fatal("set SMT_EXPORT_DIR to the migration-files root")
+	}
+
+	mapping, err := structure.GetUniqueExtracts(exportDir)
+	if err != nil {
+		t.Fatalf("GetUniqueExtracts: %v", err)
+	}
+	t.Logf("extract mapping: %#v", mapping)
+
+	e := &Executor{
+		ExportDir: exportDir,
+		Mapping:   mapping,
+		Logger:    slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn})),
+		// Cloud / RawAPI deliberately nil: main-branch path is offline
+		// (buildSCProfileMap is nil-safe; no create-analysis handshake for main).
+	}
+
+	const (
+		serverURL = "http://localhost:9000/"
+		serverKey = "okorach-oss_sonar-tools-test"
+		cloudKey  = "open-digital-society-1_okorach-oss_sonar-tools-test"
+		orgKey    = "open-digital-society-1"
+	)
+
+	branches := collectBranchInfo(e, serverURL, serverKey)
+	t.Logf("collected %d branches", len(branches))
+	var mainName string
+	for _, b := range branches {
+		t.Logf("  branch %q isMain=%v", b.Name, b.IsMain)
+		if b.IsMain {
+			mainName = b.Name
+		}
+	}
+	if mainName == "" {
+		mainName = "main"
+	}
+
+	input := importBranchInput{
+		CloudKey:     cloudKey,
+		OrgKey:       orgKey,
+		ServerURL:    serverURL,
+		ServerKey:    serverKey,
+		Branch:       mainName,
+		TargetBranch: mainName,
+		IsMain:       true,
+	}
+
+	report, skip, err := buildBranchReport(context.Background(), e, input, mainName)
+	if err != nil {
+		t.Fatalf("buildBranchReport: %v", err)
+	}
+	if skip != nil {
+		t.Fatalf("branch was skipped: status=%q err=%q", skip.Status, skip.Error)
+	}
+	if report == nil || len(report.ZIP) == 0 {
+		t.Fatal("empty report zip")
+	}
+
+	if err := os.WriteFile(out, report.ZIP, 0o644); err != nil {
+		t.Fatalf("write zip: %v", err)
+	}
+	t.Logf("wrote %d bytes to %s", len(report.ZIP), out)
+}

--- a/go/internal/scanreport/backdate.go
+++ b/go/internal/scanreport/backdate.go
@@ -48,39 +48,63 @@ func BackdateChangesets(issues []ExtractedIssue, changesets map[string]*pb.Chang
 		if !ok {
 			continue
 		}
-		lineCount := len(cs.ChangesetIndexByLine)
-		if lineCount == 0 {
+		if len(cs.ChangesetIndexByLine) == 0 {
 			continue
 		}
-		rebuildChangesetForFile(cs, lineDateMap, lineCount)
+		rebuildChangesetForFile(cs, lineDateMap)
 	}
 }
 
-// rebuildChangesetForFile replaces the changeset entries and line index for a
-// single file based on the per-line date map.
-func rebuildChangesetForFile(cs *pb.Changesets, lineDateMap map[int32]int64, lineCount int) {
-	uniqueDates := collectSortedDates(lineDateMap)
-	dateToIdx := make(map[int64]int32, len(uniqueDates))
-	entries := make([]*pb.Changesets_Changeset, len(uniqueDates))
-	for i, dateMs := range uniqueDates {
-		dateToIdx[dateMs] = int32(i)
-		entries[i] = &pb.Changesets_Changeset{
-			Revision: "migration-date-" + time.UnixMilli(dateMs).Format("20060102"),
-			Author:   stubAuthor,
-			Date:     dateMs,
+// rebuildChangesetForFile overrides the changeset DATE for each line that
+// carries an issue, so SonarCloud's CE assigns each issue its original
+// SonarQube creation date — while PRESERVING the real SCM author and revision
+// already attributed to that line (from BuildChangesetsFromBlame). Lines
+// without issues keep their real blame untouched, so the Code view still shows
+// the true author/date for the rest of the file.
+//
+// Because buildFileLineDates fills every line of a multi-line issue's range
+// with the same (oldest-wins) date, all of an issue's lines share one date and
+// the CE's MAX-over-lines collapses to that date — no inflation.
+func rebuildChangesetForFile(cs *pb.Changesets, lineDateMap map[int32]int64) {
+	type csKey struct {
+		rev, author string
+		date        int64
+	}
+	index := make(map[csKey]int32, len(cs.Changeset))
+	for i, e := range cs.Changeset {
+		index[csKey{e.Revision, e.Author, e.Date}] = int32(i)
+	}
+	findOrAppend := func(rev, author string, date int64) int32 {
+		k := csKey{rev, author, date}
+		if i, ok := index[k]; ok {
+			return i
 		}
+		i := int32(len(cs.Changeset))
+		cs.Changeset = append(cs.Changeset, &pb.Changesets_Changeset{
+			Revision: rev,
+			Author:   author,
+			Date:     date,
+		})
+		index[k] = i
+		return i
 	}
 
-	newIdx := make([]int32, lineCount)
-	for i := range lineCount {
-		if dateMs, ok := lineDateMap[int32(i+1)]; ok {
-			newIdx[i] = dateToIdx[dateMs]
+	n := len(cs.ChangesetIndexByLine)
+	for ln, dateMs := range lineDateMap {
+		i := int(ln) - 1
+		if i < 0 || i >= n {
+			continue
 		}
-		// else 0 — oldest date, prevents MAX inflation
+		// Carry over the real author/revision on this line; only the date
+		// changes to the issue's creation date. Falls back to the synthetic
+		// stub author when the line had no blame entry.
+		rev, author := "", stubAuthor
+		if base := cs.ChangesetIndexByLine[i]; int(base) >= 0 && int(base) < len(cs.Changeset) {
+			rev = cs.Changeset[base].Revision
+			author = cs.Changeset[base].Author
+		}
+		cs.ChangesetIndexByLine[i] = findOrAppend(rev, author, dateMs)
 	}
-
-	cs.Changeset = entries
-	cs.ChangesetIndexByLine = newIdx
 }
 
 // collectSortedDates returns sorted unique date values from a line-date map.

--- a/go/internal/scanreport/builder.go
+++ b/go/internal/scanreport/builder.go
@@ -381,6 +381,75 @@ func BuildActiveRules(rules []ActiveRuleInput, defaultTSMillis int64) []*pb.Acti
 	return result
 }
 
+// BlameRun is one run-length SCM blame entry from /api/sources/scm. The API
+// lists a line only when its blame differs from the previous line, so each run
+// begins at StartLine and continues until the next run's StartLine.
+type BlameRun struct {
+	StartLine int32
+	Author    string
+	Date      time.Time
+	Revision  string
+}
+
+// BuildChangesetsFromBlame builds a Changesets message for a component from
+// run-length SCM blame, expanding each run forward so every one of lineCount
+// source lines is attributed to a real (revision, author, date). This makes
+// the SonarCloud Code view show who changed each line and when, matching
+// SonarQube Server. Lines before the first run inherit the first run; a run
+// with a zero date falls back to the provided date. Returns nil if there are
+// no runs or lineCount is non-positive.
+func BuildChangesetsFromBlame(compRef int32, runs []BlameRun, lineCount int, fallback time.Time) *pb.Changesets {
+	if len(runs) == 0 || lineCount <= 0 {
+		return nil
+	}
+	fallbackMs := fallback.UnixMilli()
+
+	// Deduplicate (revision, author, date) tuples into changeset entries and
+	// record which entry each run maps to.
+	type key struct {
+		rev, author string
+		date        int64
+	}
+	idxByKey := make(map[key]int32)
+	var entries []*pb.Changesets_Changeset
+	runIdx := make([]int32, len(runs))
+	for i, r := range runs {
+		dateMs := fallbackMs
+		if !r.Date.IsZero() {
+			dateMs = r.Date.UnixMilli()
+		}
+		k := key{r.Revision, r.Author, dateMs}
+		if j, ok := idxByKey[k]; ok {
+			runIdx[i] = j
+			continue
+		}
+		j := int32(len(entries))
+		entries = append(entries, &pb.Changesets_Changeset{
+			Revision: r.Revision,
+			Author:   r.Author,
+			Date:     dateMs,
+		})
+		idxByKey[k] = j
+		runIdx[i] = j
+	}
+
+	// Expand runs across every line. runs are assumed sorted by StartLine.
+	indexByLine := make([]int32, lineCount)
+	pos := 0
+	for line := 1; line <= lineCount; line++ {
+		for pos+1 < len(runs) && int(runs[pos+1].StartLine) <= line {
+			pos++
+		}
+		indexByLine[line-1] = runIdx[pos]
+	}
+
+	return &pb.Changesets{
+		ComponentRef:         compRef,
+		Changeset:            entries,
+		ChangesetIndexByLine: indexByLine,
+	}
+}
+
 // BuildDefaultChangesets creates a Changesets message for a component with
 // lineCount lines, all attributed to a single date. Use BackdateChangesets
 // to rewrite these with per-issue dates afterward.

--- a/go/internal/scanreport/builder_test.go
+++ b/go/internal/scanreport/builder_test.go
@@ -250,6 +250,51 @@ func TestBuildDefaultChangesets(t *testing.T) {
 	}
 }
 
+func TestBuildChangesetsFromBlame(t *testing.T) {
+	fallback := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	dA := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	dB := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	// Run-length blame: line 1 (commit A), line 4 (commit B), line 6 (commit A
+	// again). Total 8 source lines.
+	runs := []BlameRun{
+		{StartLine: 1, Author: "a@co.com", Date: dA, Revision: "rA"},
+		{StartLine: 4, Author: "b@co.com", Date: dB, Revision: "rB"},
+		{StartLine: 6, Author: "a@co.com", Date: dA, Revision: "rA"},
+	}
+	cs := BuildChangesetsFromBlame(2, runs, 8, fallback)
+	if cs == nil {
+		t.Fatal("expected changesets, got nil")
+	}
+	if cs.ComponentRef != 2 {
+		t.Errorf("expected ref 2, got %d", cs.ComponentRef)
+	}
+	// rA appears twice but must dedup to a single entry → 2 unique entries.
+	if len(cs.Changeset) != 2 {
+		t.Fatalf("expected 2 unique changeset entries, got %d", len(cs.Changeset))
+	}
+	if len(cs.ChangesetIndexByLine) != 8 {
+		t.Fatalf("expected 8 line indices, got %d", len(cs.ChangesetIndexByLine))
+	}
+	// Expand the runs: lines 1-3 = rA, 4-5 = rB, 6-8 = rA.
+	want := map[int]string{1: "rA", 2: "rA", 3: "rA", 4: "rB", 5: "rB", 6: "rA", 7: "rA", 8: "rA"}
+	for ln, rev := range want {
+		entry := cs.Changeset[cs.ChangesetIndexByLine[ln-1]]
+		if entry.Revision != rev {
+			t.Errorf("line %d: expected revision %q, got %q", ln, rev, entry.Revision)
+		}
+	}
+	// A run with a zero date falls back to the provided date.
+	csZero := BuildChangesetsFromBlame(3, []BlameRun{{StartLine: 1, Author: "x", Revision: "rX"}}, 3, fallback)
+	if csZero.Changeset[0].Date != fallback.UnixMilli() {
+		t.Errorf("expected zero-date run to use fallback %d, got %d", fallback.UnixMilli(), csZero.Changeset[0].Date)
+	}
+	// No runs → nil.
+	if BuildChangesetsFromBlame(4, nil, 5, fallback) != nil {
+		t.Error("expected nil for empty runs")
+	}
+}
+
 func TestMapSeverity(t *testing.T) {
 	cases := []struct {
 		input    string

--- a/go/tmp_pbdump/main.go
+++ b/go/tmp_pbdump/main.go
@@ -1,0 +1,96 @@
+// Temporary diagnostic: decode real scanner-report .pb files using the repo's
+// own proto bindings. Delete after use.
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"sort"
+
+	pb "github.com/sonar-solutions/sonar-migration-tool/internal/scanreport/proto"
+	"google.golang.org/protobuf/proto"
+)
+
+func readDelimited(b []byte) [][]byte {
+	var out [][]byte
+	for len(b) > 0 {
+		n, adv := binary.Uvarint(b)
+		if adv <= 0 {
+			break
+		}
+		b = b[adv:]
+		if uint64(len(b)) < n {
+			break
+		}
+		out = append(out, b[:n])
+		b = b[n:]
+	}
+	return out
+}
+
+func truncate(s string) string {
+	if len(s) > 50 {
+		return fmt.Sprintf("%s...(%d chars)", s[:50], len(s))
+	}
+	return s
+}
+
+func measVal(m *pb.Measure) string {
+	if v := m.GetIntValue(); v != nil {
+		return fmt.Sprintf("int=%d data=%q", v.GetValue(), truncate(v.GetData()))
+	}
+	if v := m.GetLongValue(); v != nil {
+		return fmt.Sprintf("long=%d data=%q", v.GetValue(), truncate(v.GetData()))
+	}
+	if v := m.GetDoubleValue(); v != nil {
+		return fmt.Sprintf("double=%v data=%q", v.GetValue(), truncate(v.GetData()))
+	}
+	if v := m.GetStringValue(); v != nil {
+		return fmt.Sprintf("string=%q", truncate(v.GetValue()))
+	}
+	if v := m.GetBooleanValue(); v != nil {
+		return fmt.Sprintf("bool=%v data=%q", v.GetValue(), truncate(v.GetData()))
+	}
+	return "(empty)"
+}
+
+func main() {
+	mode := os.Args[1]
+	path := os.Args[2]
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	switch mode {
+	case "measures":
+		msgs := readDelimited(raw)
+		fmt.Printf("%d measure messages in %s\n", len(msgs), path)
+		keys := map[string]string{}
+		for _, m := range msgs {
+			var meas pb.Measure
+			if err := proto.Unmarshal(m, &meas); err != nil {
+				continue
+			}
+			keys[meas.GetMetricKey()] = measVal(&meas)
+		}
+		var order []string
+		for k := range keys {
+			order = append(order, k)
+		}
+		sort.Strings(order)
+		for _, k := range order {
+			fmt.Printf("  %-28s %s\n", k, keys[k])
+		}
+	case "component":
+		var c pb.Component
+		if err := proto.Unmarshal(raw, &c); err != nil {
+			panic(err)
+		}
+		fmt.Printf("ref=%d type=%s key=%q name=%q lines=%d lang=%q nChildren=%d childRefs=%v\n",
+			c.GetRef(), c.GetType(), c.GetKey(), c.GetName(), c.GetLines(), c.GetLanguage(), len(c.GetChildRef()), c.GetChildRef())
+	default:
+		fmt.Println("unknown mode")
+	}
+}


### PR DESCRIPTION
## Problem

After a `transfer`, the migrated SonarCloud project rendered incorrectly in two ways:

1. **"The main branch of this project is empty"** — even though the project, quality gate, issues, and hotspots all migrated.
2. **No SCM blame in the Code view** — every line showed a synthetic stub author and the analysis date, instead of who actually changed the line and when (which SonarQube Server shows).

## Root causes

1. **No measures.** `buildBranchReport` handed `PackageReport` an empty `Measures` map, so the report carried zero `measures-*.pb`. SonarCloud's CE aggregates project `ncloc` from per-file measures; with none, project `ncloc` is null and the empty-branch overlay fires.
2. **Blame ignored.** The extract already pulled real per-line blame via `getProjectSCMData` (`/api/sources/scm`), but the migrate side never read it — it always emitted a synthetic single changeset, then overwrote it with issue-date-only entries during backdating.

## Changes

**Measures (empty branch)**
- `extract`: widen component-tree `metricKeys` from `ncloc` alone to `ncloc,comment_lines,complexity,cognitive_complexity,functions,statements,classes` (the scalar metrics the API allows; `ncloc_data`/`executable_lines_data` are rejected by `component_tree` and would require per-file `api/measures/component` calls — documented as a follow-up).
- `migrate`: new `loadComponentMeasures` reads the per-file measures and feeds `scanreport.BuildMeasures` instead of an empty map.

**SCM blame (Code view)**
- `migrate`: new `loadExtractedSCM` reads `getProjectSCMData`; `/api/sources/scm` is run-length encoded, so `scanreport.BuildChangesetsFromBlame` dedups `(revision, author, date)` and expands runs forward across every line.
- Backdating is now **blame-preserving**: it overrides only the *date* on issue lines (so issue creation dates stay accurate) while keeping each line's real author/revision. Falls back to the synthetic changeset only when the source has no blame.

## Verification (live, against sc-staging)

Transferred the full `okorach-oss_sonar-tools` (which has real git history) and queried the target API:

- **Main branch measures:** `ncloc = 17,379` plus statements 15,702, comment_lines 5,216, complexity 4,663, cognitive_complexity 4,433, functions 1,451, classes 68 — branch is no longer empty.
- **Blame:** `/api/sources/scm` on the target returns real authors / dates / 40-char revisions, matching the source line-for-line.

Note: the `-test` project clone has no blame at the source (analyzed without git history), so it can only ever show synthetic authors — the full project is the correct fixture for the blame fix.

## Tests
- New `TestBuildChangesetsFromBlame` (run-length expansion, commit dedup, zero-date fallback, nil-on-empty).
- Existing `backdate_test.go` cases still pass (the blame-preserving refactor keeps the asserted dates/indices).
- `go build ./...`, `go vet`, and `internal/{migrate,scanreport,extract}` tests all green after rebasing onto latest `main`.

## Notes
- Docs: `docs/EMPTY-MAIN-BRANCH-REPORT-DIFF.md` (updated) + `docs/SCM-BLAME-MIGRATION.md` (new).
- The final `chore` commit adds throwaway report diagnostics (`tmp_pbdump/`, `zz_dumpreport_test.go`, gated/CI-skipped) and gitignores `transfer-run.out`; drop that commit if you'd rather not carry the diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
