### PR TITLE
fix(#417): retrieve and migrate source code for branches with available source

### DIFF
--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -8,11 +8,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"html"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 )
+
+var htmlTagRe = regexp.MustCompile(`<[^>]+>`)
 
 // issueStatusesRename is the SonarQube Server release where the issue
 // search swapped its statuses parameter to issueStatuses + the new
@@ -314,6 +318,16 @@ func fetchSourceCode(ctx context.Context, e *Executor, item json.RawMessage, w *
 			return err
 		}
 	}
+	if len(raw) == 0 {
+		// api/sources/raw returned empty — SonarQube housekeeping may have purged the
+		// raw_source_data column while the data column (used by the Code view UI) remains.
+		// Try api/sources/lines as a fallback to recover the source text.
+		if fallback, fErr := fetchSourceFromLines(ctx, e, fileKey, branch); fErr == nil && len(fallback) > 0 {
+			e.Logger.Info("getProjectSourceCode: recovered source via sources/lines fallback",
+				"file", fileKey, "branch", branch, "bytes", len(fallback))
+			raw = []byte(fallback)
+		}
+	}
 	record := map[string]any{
 		"key":        fileKey,
 		"branch":     branch,
@@ -326,6 +340,31 @@ func fetchSourceCode(ctx context.Context, e *Executor, item json.RawMessage, w *
 		return err
 	}
 	return w.WriteOne(b)
+}
+
+// fetchSourceFromLines retrieves plain source text via api/sources/lines when
+// api/sources/raw returns empty. The lines endpoint reads the 'data' column
+// (used by the SonarQube Code view UI), which housekeeping leaves intact even
+// after purging raw_source_data. HTML tags are stripped and HTML entities are
+// unescaped from the code field to reconstruct plain source text.
+func fetchSourceFromLines(ctx context.Context, e *Executor, fileKey, branch string) (string, error) {
+	resp, err := e.Raw.Get(ctx, "api/sources/lines", fileParams(fileKey, branch))
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Sources []struct {
+			Code string `json:"code"`
+		} `json:"sources"`
+	}
+	if err := json.Unmarshal(resp, &result); err != nil {
+		return "", fmt.Errorf("parsing sources/lines response: %w", err)
+	}
+	lines := make([]string, 0, len(result.Sources))
+	for _, s := range result.Sources {
+		lines = append(lines, html.UnescapeString(htmlTagRe.ReplaceAllString(s.Code, "")))
+	}
+	return strings.Join(lines, "\n"), nil
 }
 
 // projectSCMDataTask extracts SCM blame data for each file component.

--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -297,10 +297,22 @@ func fetchSourceCode(ctx context.Context, e *Executor, item json.RawMessage, w *
 	if fileKey == "" {
 		return nil
 	}
+	if branch == "" {
+		e.Logger.Warn("getProjectSourceCode skipped: component has no branch field", "file", fileKey)
+		return nil
+	}
 	params := fileParams(fileKey, branch)
 	raw, err := e.Raw.GetRaw(ctx, "api/sources/raw", params)
 	if err != nil {
-		return handleNonFatal(e, "getProjectSourceCode", fileKey, err)
+		if isNonFatalHTTPErr(err) {
+			e.Logger.Warn("getProjectSourceCode skipped", "file", fileKey, "branch", branch, "err", err)
+			// Write an empty source record so the branch×file is tracked even when source
+			// is absent (purged or restricted). Without this, zero records in a branch make
+			// totalSourceLen indistinguishable from "source never attempted".
+			raw = []byte{}
+		} else {
+			return err
+		}
 	}
 	record := map[string]any{
 		"key":        fileKey,
@@ -330,6 +342,10 @@ func fetchSCMData(ctx context.Context, e *Executor, item json.RawMessage, w *Chu
 	fileKey := extractField(item, "key")
 	branch := extractField(item, "branch")
 	if fileKey == "" {
+		return nil
+	}
+	if branch == "" {
+		e.Logger.Warn("getProjectSCMData skipped: component has no branch field", "file", fileKey)
 		return nil
 	}
 	raw, err := e.Raw.Get(ctx, "api/sources/scm", fileParams(fileKey, branch))
@@ -469,7 +485,9 @@ func buildBranchMap(branches []json.RawMessage) map[string][]string {
 	return result
 }
 
-// fileParams builds url.Values for a file key with optional branch.
+// fileParams builds url.Values for a file key and its branch.
+// Both fetchSourceCode and fetchSCMData guard against empty branch before
+// calling this, so branch is always non-empty here.
 func fileParams(fileKey, branch string) url.Values {
 	params := url.Values{"key": {fileKey}}
 	if branch != "" {

--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -663,6 +663,56 @@ func TestProjectSourceCodeTaskNonFatal(t *testing.T) {
 	}
 }
 
+func TestProjectSourceCodeTaskLinesFallback(t *testing.T) {
+	// api/sources/raw returns empty (housekeeping purged raw_source_data).
+	// api/sources/lines should be called as a fallback and its HTML-highlighted
+	// source stripped to plain text.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/sources/raw":
+			// 200 OK but empty body — source purged from raw_source_data column
+			w.WriteHeader(200)
+		case "/api/sources/lines":
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"sources":[{"line":1,"code":"<span class=\"k\">public</span> class Foo {}"},{"line":2,"code":"  int x = 1 &amp; 2;"}]}`))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
+
+	w, _ := e.Store.Writer("getProjectComponentTree")
+	b, _ := json.Marshal(map[string]any{
+		"key":        "p1:src/Foo.java",
+		"branch":     "main",
+		"projectKey": "p1",
+	})
+	w.WriteOne(b)
+
+	fn := projectSourceCodeTask()
+	if err := fn(ctx(t), e); err != nil {
+		t.Fatalf("projectSourceCodeTask: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("getProjectSourceCode")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 source record, got %d", len(items))
+	}
+	got := extractField(items[0], "source")
+	// HTML tags stripped, &amp; unescaped, lines joined with \n
+	want := "public class Foo {}\n  int x = 1 & 2;"
+	if got != want {
+		t.Errorf("unexpected source from fallback:\n got:  %q\n want: %q", got, want)
+	}
+	if extractField(items[0], "branch") != "main" {
+		t.Errorf("expected branch 'main' in source record")
+	}
+}
+
 func TestProjectSourceCodeTaskEmptyBranch(t *testing.T) {
 	e := newTestExecutor(t)
 	e.ServerURL = "http://test/"

--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -502,8 +502,10 @@ func TestProjectComponentTreeTask(t *testing.T) {
 }
 
 func TestProjectSourceCodeTask(t *testing.T) {
+	var capturedURL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/sources/raw" {
+			capturedURL = r.URL.RawQuery
 			w.Write([]byte("public class Main {}"))
 			return
 		}
@@ -537,6 +539,14 @@ func TestProjectSourceCodeTask(t *testing.T) {
 	src := extractField(items[0], "source")
 	if src != "public class Main {}" {
 		t.Errorf("unexpected source: %q", src)
+	}
+	// Branch must always be passed as a URL parameter.
+	if !strings.Contains(capturedURL, "branch=main") {
+		t.Errorf("expected branch=main in request URL, got %q", capturedURL)
+	}
+	// Branch must be preserved in the stored record.
+	if extractField(items[0], "branch") != "main" {
+		t.Errorf("expected branch 'main' in source record")
 	}
 }
 
@@ -638,6 +648,39 @@ func TestProjectSourceCodeTaskNonFatal(t *testing.T) {
 	err := fn(ctx(t), e)
 	if err != nil {
 		t.Fatalf("expected non-fatal skip, got error: %v", err)
+	}
+	// A source record must be written even on 404 (empty source, branch preserved)
+	// so migration can distinguish "checked but purged" from "never attempted".
+	items, _ := e.Store.ReadAll("getProjectSourceCode")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 empty source record for 404, got %d", len(items))
+	}
+	if extractField(items[0], "source") != "" {
+		t.Errorf("expected empty source for 404, got %q", extractField(items[0], "source"))
+	}
+	if extractField(items[0], "branch") != "main" {
+		t.Errorf("expected branch preserved in record, got %q", extractField(items[0], "branch"))
+	}
+}
+
+func TestProjectSourceCodeTaskEmptyBranch(t *testing.T) {
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+
+	// Component tree item with no branch field — should be skipped with a warning.
+	w, _ := e.Store.Writer("getProjectComponentTree")
+	b, _ := json.Marshal(map[string]any{"key": "p1:src/File.java", "projectKey": "p1"})
+	w.WriteOne(b)
+
+	fn := projectSourceCodeTask()
+	err := fn(ctx(t), e)
+	if err != nil {
+		t.Fatalf("projectSourceCodeTask: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("getProjectSourceCode")
+	if len(items) != 0 {
+		t.Errorf("expected 0 items for missing branch, got %d", len(items))
 	}
 }
 

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -461,6 +462,16 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	zipBytes, err := scanreport.PackageReport(reportData)
 	if err != nil {
 		return nil, nil, fmt.Errorf("packaging report: %w", err)
+	}
+
+	if dumpDir := os.Getenv("SMT_DUMP_REPORT_DIR"); dumpDir != "" {
+		safe := strings.NewReplacer("/", "_", ":", "_", ",", "_").Replace(input.CloudKey + "-" + input.Branch)
+		dumpPath := filepath.Join(dumpDir, safe+".zip")
+		if werr := os.WriteFile(dumpPath, zipBytes, 0o644); werr != nil {
+			e.Logger.Warn("failed to dump report zip", "path", dumpPath, "err", werr)
+		} else {
+			e.Logger.Info("dumped report zip", "path", dumpPath)
+		}
 	}
 
 	e.Logger.Info("report packaged",

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -382,7 +382,7 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	root, fileComps, cr := scanreport.BuildComponents(input.CloudKey, components)
 	pbSources := make(map[int32]string)
 	for _, s := range sources {
-		if ref, ok := cr.Refs()[s.Component]; ok {
+		if ref, ok := cr.Refs()[s.Component]; ok && s.Source != "" {
 			pbSources[ref] = s.Source
 		}
 	}

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -485,6 +485,41 @@ func TestLoadExtractedSourcesWrongBranch(t *testing.T) {
 	}
 }
 
+// TestEmptySourcesNotIncludedInPbSources verifies that components with empty
+// extracted source are NOT added to pbSources, which prevents writing empty
+// source-N.txt files into the ZIP that would cause the CE to reject the report
+// (a 0-byte source file with a component claiming N lines is inconsistent).
+func TestEmptySourcesNotIncludedInPbSources(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "proj:A.java", Path: "A.java", Language: "java", Lines: 10},
+		{Key: "proj:B.java", Path: "B.java", Language: "java", Lines: 20},
+	}
+	sources := []sourceRecord{
+		{Component: "proj:A.java", Source: "class A {}"},
+		{Component: "proj:B.java", Source: ""},
+	}
+
+	_, _, cr := scanreport.BuildComponents("proj", components)
+	pbSources := make(map[int32]string)
+	for _, s := range sources {
+		if ref, ok := cr.Refs()[s.Component]; ok && s.Source != "" {
+			pbSources[ref] = s.Source
+		}
+	}
+
+	if len(pbSources) != 1 {
+		t.Fatalf("expected 1 source in pbSources (only non-empty), got %d", len(pbSources))
+	}
+	refA := cr.Refs()["proj:A.java"]
+	if pbSources[refA] != "class A {}" {
+		t.Errorf("expected source for A.java, got %q", pbSources[refA])
+	}
+	refB := cr.Refs()["proj:B.java"]
+	if _, present := pbSources[refB]; present {
+		t.Error("B.java has empty source and should NOT be in pbSources")
+	}
+}
+
 func TestLoadExtractedIssues(t *testing.T) {
 	dir := t.TempDir()
 	setupProjectDataExtract(t, dir)


### PR DESCRIPTION
## Issue #417

Some projects were migrated without their source code even though the source is available on the SonarQube Server side, leaving the SonarCloud Code view empty.

## Root causes addressed

1. **Empty/purged branches poisoned the report.** When SonarQube housekeeping purges source text for an inactive branch (line measures may remain, but `api/sources/{raw,lines}` return empty), the migration would build a report declaring N-line files with empty source. Submitting such a report makes the SonarCloud CE reject the whole analysis — so *all* files lose source.
   - Skip a branch entirely when it has findings but no retrievable source text (`tasks_projectdata.go`), and never write a `source-N.txt` for an empty source string (`pbSources` now filters `s.Source != ""`), which previously produced 0-byte source files that the CE rejected.

2. **Empty branch on source fetch / 404 handling** — guard the empty-branch case and still write a record on 404 so downstream filtering is correct.

3. **Fallback** to `api/sources/lines` when `api/sources/raw` returns empty.

## Diagnostics

- Added an env-gated scanner-report ZIP dump (`SMT_DUMP_REPORT_DIR`): when set, each branch's packaged report ZIP is written to disk before submission. No-op (zero overhead) when unset. Used to verify `source-N.txt` / `component-N.pb` contents while diagnosing this issue.

## Verification

- The packaged main-branch report contains the correct `source-2/3/4.txt` (named by component ref; root project is ref 1) with matching `component-N.pb`, measures, changesets and issues.
- Reproduced the canonical case (BANKING-PORTAL: main has source; `release-3.2` and `comma,branch` are purged): main migrates with source, the two purged branches are cleanly skipped, and source is retrievable on the target via `api/sources/raw` after the run.
- Also surfaced a SonarCloud CE constraint worth noting: the CE rejects a report whose `analysisDate` is older than the last processed analysis ("a newer report has already been processed"); a rejected re-analysis preserves existing source. Normal tool runs use a monotonic wall-clock `analysisDate`, so they are accepted.
- `go build ./...` and `go test ./internal/migrate/ ./internal/scanreport/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
