### PR TITLE
Issue #420: migrate source-code syntax highlighting

### DIFF
--- a/docs/MIGRATION-CAPABILITIES.md
+++ b/docs/MIGRATION-CAPABILITIES.md
@@ -73,6 +73,9 @@ Migration of source code snapshots and version control blame data.
 **What it migrates:**
 - Source code file contents (as they existed at analysis time)
 - SCM blame/changeset data (author, revision, date per line)
+- Syntax highlighting (token colors in the Code view), reconstructed from
+  `/api/sources/lines` into `syntax-highlightings-<ref>.pb` — see
+  [SYNTAX-HIGHLIGHTING-MIGRATION.md](SYNTAX-HIGHLIGHTING-MIGRATION.md) (issue #420)
 - Line hashes for duplicate detection
 - File-level metadata (language, encoding)
 - Changeset backdating to preserve accurate issue creation dates within SonarQube Cloud
@@ -315,7 +318,7 @@ Electron-based desktop application wrapping the CLI and browser GUI.
 ---
 
 ## Migration Summary Table
-<!-- updated: 2026-06-04_12:00:00 -->
+<!-- updated: 2026-06-26_18:52:18 -->
 
 | Data Type | Current Status | Target Status |
 |-----------|---------------|---------------|
@@ -329,6 +332,7 @@ Electron-based desktop application wrapping the CLI and browser GUI.
 | **Issues** | **Not migrated** | **Full migration with metadata sync** |
 | **Security Hotspots** | **Not migrated** | **Full migration with metadata sync** |
 | **Source Code** | **Not migrated** | **Migrated via scanner protocol** |
+| **Syntax Highlighting** | **Not migrated** | **Migrated (token colors in Code view, #420)** |
 | **SCM/Blame Data** | **Not migrated** | **Full changeset migration** |
 | **Measures/Metrics** | **Not migrated** | **Full metric preservation** |
 | **Clean Code Attributes** | **Not migrated** | **Mapped across versions** |
@@ -409,7 +413,7 @@ Each version has a dedicated extraction/encoding pipeline to handle API differen
 ---
 
 ## API Endpoints Used
-<!-- updated: 2026-06-04_12:00:00 -->
+<!-- updated: 2026-06-26_18:52:18 -->
 
 ### SonarQube Server (Source -- Read Only)
 
@@ -419,6 +423,7 @@ Each version has a dedicated extraction/encoding pipeline to handle API differen
 | `/api/issues/changelog` | Fetch issue changelogs for pre-filtering |
 | `/api/hotspots/search` | Extract security hotspots |
 | `/api/sources/raw` | Extract source code |
+| `/api/sources/lines` | Extract syntax highlighting (and source-text fallback) |
 | `/api/sources/scm` | Extract SCM blame data |
 | `/api/measures/component` | Extract project measures |
 | `/api/measures/search_history` | Extract measure history |

--- a/docs/SYNTAX-HIGHLIGHTING-MIGRATION.md
+++ b/docs/SYNTAX-HIGHLIGHTING-MIGRATION.md
@@ -1,0 +1,112 @@
+# Syntax Highlighting Migration (issue #420)
+<!-- updated: 2026-06-26_18:49:04 -->
+
+## Problem
+<!-- updated: 2026-06-26_18:49:04 -->
+
+Migrated projects rendered source code as **raw, uncolored text** in the
+SonarQube Cloud Code view, while a native scanner analysis of the same code is
+syntax-highlighted (GitHub issue #420).
+
+Root cause: the scanner-report ZIP that the tool submits to the CE *Submit*
+endpoint never contained the `syntax-highlightings-<ref>.pb` protobuf streams.
+The packager wrote `metadata`, `component-*`, `issues-*`, `external-issues-*`,
+`measures-*`, `changesets-*`, `activerules`, `adhocrules`, and `source-*.txt`,
+but had no notion of syntax highlighting at all. The source text was fetched
+from `/api/sources/raw` (plain text), and the highlighting available from
+`/api/sources/lines` was discarded (only used, stripped of markup, as a
+source-text fallback). CloudVoyager never implemented this either — its
+`syntax-highlighting.js` extractor was an empty stub.
+
+## Where highlighting survives on the source
+<!-- updated: 2026-06-26_18:49:04 -->
+
+SonarQube does **not** expose the raw scanner highlighting protobuf over the web
+API. The only place the highlighting survives is the per-line `code` field of
+`/api/sources/lines`, where each highlighted token is wrapped in a
+`<span class="<cssClass>">`. The CSS class is SonarQube's `TypeOfText`
+abbreviation:
+
+| CSS class      | HighlightingType (protobuf)        |
+|----------------|------------------------------------|
+| `a`            | `ANNOTATION` (1)                   |
+| `c`            | `CONSTANT` (2)                     |
+| `cd`, `cppd`   | `COMMENT` (3)                      |
+| `j`            | `STRUCTURED_COMMENT` (5)           |
+| `k`            | `KEYWORD` (6)                      |
+| `s`            | `HIGHLIGHTING_STRING` (7)          |
+| `h`            | `KEYWORD_LIGHT` (8)                |
+| `p`            | `PREPROCESS_DIRECTIVE` (9)         |
+| `sym`, `sym-N` | symbol references — *not* a syntax type (ignored) |
+
+Symbol-reference spans (`sym`, `sym-N`) are a different feature (click-to-
+highlight-occurrences) and **nest** with syntax spans, so the HTML must be
+parsed with a stack rather than a flat regex.
+
+## Solution
+<!-- updated: 2026-06-26_18:49:04 -->
+
+1. **Extract** (`internal/extract/tasks_projectdata.go`) — `fetchSourceCode`
+   now always calls `/api/sources/lines` (via `fetchHighlightedLines`) and
+   stores the per-line `code` HTML under a new `highlightedLines` field in the
+   `getProjectSourceCode` record. The same response still backs the
+   plain-text fallback (`plainTextFromHighlighted`) for purged `raw`.
+2. **Parse + build** (`internal/scanreport/syntax.go`) — `BuildSyntaxHighlighting`
+   parses each line's HTML into `SyntaxHighlightingRule{Range, Type}` messages.
+   `parseHighlightedLine` walks the HTML with an open-span stack; the active
+   type for any text run is the innermost span class that maps to a real type
+   (so nested `sym` spans are seen through). Offsets are **0-based UTF-16 column
+   offsets of the HTML-unescaped text** (`utf16Len`), and every rule is a
+   single-line range (`StartLine == EndLine`) — matching exactly what a native
+   `sonar-scanner` writes (verified against a real `.scannerwork` report).
+3. **Package** (`internal/scanreport/packager.go`) — `addSyntaxHighlighting`
+   writes one `syntax-highlightings-<ref>.pb` per component, each a
+   length-delimited stream of `SyntaxHighlightingRule` (same framing as
+   `issues-*`/`measures-*`). Refs with no rules are skipped.
+4. **Wire-in** (`internal/migrate/tasks_projectdata.go`) —
+   `loadExtractedSyntaxHighlighting` reads the `highlightedLines` back per
+   branch, and `buildBranchReport` builds the rules with the **same**
+   `ComponentRef`, so `syntax-highlightings-<ref>.pb` keys off the same ref as
+   `component-<ref>.pb` / `source-<ref>.txt`.
+
+### Offset-vs-source clamping (robustness)
+<!-- updated: 2026-06-26_18:49:04 -->
+
+The highlighting offsets come from `/api/sources/lines` while the source text
+written to `source-<ref>.txt` comes from `/api/sources/raw`. If a line's length
+diverges between the two (CRLF vs LF, BOM, trailing-whitespace handling), the CE
+`RangeOffsetConverter` throws and **silently drops ALL highlighting for that
+file** (logged only at DEBUG; the analysis still succeeds). To prevent a whole
+file losing its colors over a one-character mismatch, `BuildSyntaxHighlighting`
+clamps each range to the UTF-16 length of the matching `source-<ref>.txt` line
+(trailing `\r` excluded), dropping rules that start past end-of-line and
+truncating rules that end past it. At worst a single token is trimmed.
+
+## Verification
+<!-- updated: 2026-06-26_18:49:04 -->
+
+Live clean-slate transfer of `okorach-oss_sonar-tools`
+(`localhost:9000` → `sc-staging.io`, org `open-digital-society-1`):
+
+- **Before fix** — target `sonar/cli/__init__.py`: 0 / 22 lines highlighted.
+- **After fix** — 20 / 22 lines highlighted (2 blank lines correctly skipped).
+- **Parity** — `sonar/projects.py`: source and target both emit **1835**
+  syntax spans, with **0 of 1571 lines differing** (offsets, text, and type
+  all match). Target class histogram: `k`=978, `s`=471, `j`=267, `c`=86,
+  `cd`=33 — all classes migrate, not just comments.
+- **All branches** — highlighting present on `master`, `my-test`, `release-3.x`,
+  `reduce-tech-debt` (non-main branches too).
+- **No regression** — issues 1292, hotspots 31/31, 4 LONG branches, `develop`
+  correctly skipped (source purged), `ncloc`=17,379, SCM blame 1572/1572 lines.
+
+Unit tests: `internal/scanreport/syntax_test.go` covers class mapping, UTF-16
+offsets, HTML entities, nested symbol spans, malformed tags, the build/ref
+mapping, and source-line clamping (incl. CRLF).
+
+## Out of scope
+<!-- updated: 2026-06-26_18:49:04 -->
+
+Symbol references (`symbols-<ref>.pb`, the click-to-highlight-occurrences
+feature) are **not** migrated. `/api/sources/lines` exposes only `sym-N`
+grouping classes, not the declaration/reference metadata the `symbols` protobuf
+requires. This is a separate feature from issue #420.

--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -318,22 +318,33 @@ func fetchSourceCode(ctx context.Context, e *Executor, item json.RawMessage, w *
 			return err
 		}
 	}
-	if len(raw) == 0 {
+	// Always fetch the per-line highlighted HTML from api/sources/lines. Its
+	// "code" field carries the syntax highlighting that api/sources/raw lacks
+	// (issue #420), and it doubles as a source-text fallback when raw has been
+	// purged. Highlighting failures are non-fatal — source still migrates.
+	highlightedLines, hErr := fetchHighlightedLines(ctx, e, fileKey, branch)
+	if hErr != nil {
+		e.Logger.Warn("getProjectSourceCode: syntax highlighting unavailable",
+			"file", fileKey, "branch", branch, "err", hErr)
+	}
+
+	if len(raw) == 0 && len(highlightedLines) > 0 {
 		// api/sources/raw returned empty — SonarQube housekeeping may have purged the
 		// raw_source_data column while the data column (used by the Code view UI) remains.
-		// Try api/sources/lines as a fallback to recover the source text.
-		if fallback, fErr := fetchSourceFromLines(ctx, e, fileKey, branch); fErr == nil && len(fallback) > 0 {
+		// Reconstruct plain source text from the highlighted lines we just fetched.
+		if fallback := plainTextFromHighlighted(highlightedLines); fallback != "" {
 			e.Logger.Info("getProjectSourceCode: recovered source via sources/lines fallback",
 				"file", fileKey, "branch", branch, "bytes", len(fallback))
 			raw = []byte(fallback)
 		}
 	}
 	record := map[string]any{
-		"key":        fileKey,
-		"branch":     branch,
-		"projectKey": extractField(item, "projectKey"),
-		"source":     string(raw),
-		"serverUrl":  e.ServerURL,
+		"key":              fileKey,
+		"branch":           branch,
+		"projectKey":       extractField(item, "projectKey"),
+		"source":           string(raw),
+		"highlightedLines": highlightedLines,
+		"serverUrl":        e.ServerURL,
 	}
 	b, err := json.Marshal(record)
 	if err != nil {
@@ -342,29 +353,53 @@ func fetchSourceCode(ctx context.Context, e *Executor, item json.RawMessage, w *
 	return w.WriteOne(b)
 }
 
-// fetchSourceFromLines retrieves plain source text via api/sources/lines when
-// api/sources/raw returns empty. The lines endpoint reads the 'data' column
-// (used by the SonarQube Code view UI), which housekeeping leaves intact even
-// after purging raw_source_data. HTML tags are stripped and HTML entities are
-// unescaped from the code field to reconstruct plain source text.
-func fetchSourceFromLines(ctx context.Context, e *Executor, fileKey, branch string) (string, error) {
+// fetchHighlightedLines retrieves the per-line highlighted HTML ("code" field)
+// from api/sources/lines. The returned slice is indexed by line-1; any line the
+// API omits is left as an empty string so indices keep matching line numbers.
+// The lines endpoint reads the 'data' column (behind the SonarQube Code view),
+// which housekeeping leaves intact even after purging raw_source_data. This HTML
+// is the only place the source server still exposes syntax highlighting.
+func fetchHighlightedLines(ctx context.Context, e *Executor, fileKey, branch string) ([]string, error) {
 	resp, err := e.Raw.Get(ctx, "api/sources/lines", fileParams(fileKey, branch))
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	var result struct {
 		Sources []struct {
+			Line int    `json:"line"`
 			Code string `json:"code"`
 		} `json:"sources"`
 	}
 	if err := json.Unmarshal(resp, &result); err != nil {
-		return "", fmt.Errorf("parsing sources/lines response: %w", err)
+		return nil, fmt.Errorf("parsing sources/lines response: %w", err)
 	}
-	lines := make([]string, 0, len(result.Sources))
+	maxLine := 0
 	for _, s := range result.Sources {
-		lines = append(lines, html.UnescapeString(htmlTagRe.ReplaceAllString(s.Code, "")))
+		if s.Line > maxLine {
+			maxLine = s.Line
+		}
 	}
-	return strings.Join(lines, "\n"), nil
+	if maxLine == 0 {
+		return nil, nil
+	}
+	lines := make([]string, maxLine)
+	for _, s := range result.Sources {
+		if s.Line >= 1 && s.Line <= maxLine {
+			lines[s.Line-1] = s.Code
+		}
+	}
+	return lines, nil
+}
+
+// plainTextFromHighlighted reconstructs plain source text from highlighted HTML
+// lines by stripping tags and unescaping entities. Used as a fallback when
+// api/sources/raw returns empty.
+func plainTextFromHighlighted(lines []string) string {
+	plain := make([]string, len(lines))
+	for i, code := range lines {
+		plain[i] = html.UnescapeString(htmlTagRe.ReplaceAllString(code, ""))
+	}
+	return strings.Join(plain, "\n")
 }
 
 // projectSCMDataTask extracts SCM blame data for each file component.

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -323,6 +323,9 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	// view shows no author/date per line.
 	componentMeasures := loadComponentMeasures(e, input.ServerURL, input.ServerKey, input.Branch)
 	scmByComponent := loadExtractedSCM(e, input.ServerURL, input.ServerKey, input.Branch)
+	// Per-line syntax highlighting (colors in the Code view); without it the
+	// migrated source renders as raw, uncolored text (issue #420).
+	syntaxHighlighting := loadExtractedSyntaxHighlighting(e, input.ServerURL, input.ServerKey, input.Branch)
 
 	if len(components) == 0 {
 		return nil, &importResult{Status: "skipped"}, nil
@@ -448,15 +451,16 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 			FileCountByExt:      countFilesByExt(components),
 			AnalysisUUID:        analysisUUID,
 		}, root.Ref),
-		RootComponent:  root,
-		FileComponents: fileComps,
-		Issues:         scanreport.BuildIssues(issues, cr),
-		ExternalIssues: scanreport.BuildExternalIssues(extIssues, cr),
-		Measures:       scanreport.BuildMeasures(componentMeasures, cr),
-		Changesets:     changesets,
-		ActiveRules:    scanreport.BuildActiveRules(activeRules, now.UnixMilli()),
-		AdHocRules:     scanreport.BuildAdHocRules(adHocRules),
-		Sources:        pbSources,
+		RootComponent:      root,
+		FileComponents:     fileComps,
+		Issues:             scanreport.BuildIssues(issues, cr),
+		ExternalIssues:     scanreport.BuildExternalIssues(extIssues, cr),
+		Measures:           scanreport.BuildMeasures(componentMeasures, cr),
+		Changesets:         changesets,
+		ActiveRules:        scanreport.BuildActiveRules(activeRules, now.UnixMilli()),
+		AdHocRules:         scanreport.BuildAdHocRules(adHocRules),
+		Sources:            pbSources,
+		SyntaxHighlighting: scanreport.BuildSyntaxHighlighting(syntaxHighlighting, pbSources, cr),
 	}
 
 	zipBytes, err := scanreport.PackageReport(reportData)
@@ -630,6 +634,44 @@ func loadExtractedSources(e *Executor, serverURL, serverKey, branch string) []so
 		})
 	}
 	return sources
+}
+
+// loadExtractedSyntaxHighlighting reads the per-line highlighted HTML captured
+// alongside source code (getProjectSourceCode → "highlightedLines") for the
+// given branch, returning one HighlightInput per file. The highlighting is
+// parsed into protobuf rules later by scanreport.BuildSyntaxHighlighting so the
+// migrated Code view renders with colors (issue #420).
+func loadExtractedSyntaxHighlighting(e *Executor, serverURL, serverKey, branch string) []scanreport.HighlightInput {
+	items, err := readExtractItems(e, "getProjectSourceCode")
+	if err != nil {
+		return nil
+	}
+	var inputs []scanreport.HighlightInput
+	for _, item := range items {
+		if item.ServerURL != serverURL {
+			continue
+		}
+		var rec struct {
+			Key              string   `json:"key"`
+			ProjectKey       string   `json:"projectKey"`
+			Branch           string   `json:"branch"`
+			HighlightedLines []string `json:"highlightedLines"`
+		}
+		if err := json.Unmarshal(item.Data, &rec); err != nil {
+			continue
+		}
+		if rec.ProjectKey != serverKey || rec.Branch != branch || rec.Key == "" {
+			continue
+		}
+		if len(rec.HighlightedLines) == 0 {
+			continue
+		}
+		inputs = append(inputs, scanreport.HighlightInput{
+			Component: rec.Key,
+			Lines:     rec.HighlightedLines,
+		})
+	}
+	return inputs
 }
 
 func loadExtractedIssues(e *Executor, serverURL, serverKey, branch string) []scanreport.IssueInput {

--- a/go/internal/scanreport/packager.go
+++ b/go/internal/scanreport/packager.go
@@ -19,13 +19,17 @@ type ReportData struct {
 	Metadata       *pb.Metadata
 	RootComponent  *pb.Component
 	FileComponents []*pb.Component
-	Issues         map[int32][]*pb.Issue          // ref -> issues
-	ExternalIssues map[int32][]*pb.ExternalIssue  // ref -> external issues
-	Measures       map[int32][]*pb.Measure        // ref -> measures
-	Changesets     map[int32]*pb.Changesets        // ref -> changesets
+	Issues         map[int32][]*pb.Issue         // ref -> issues
+	ExternalIssues map[int32][]*pb.ExternalIssue // ref -> external issues
+	Measures       map[int32][]*pb.Measure       // ref -> measures
+	Changesets     map[int32]*pb.Changesets      // ref -> changesets
 	ActiveRules    []*pb.ActiveRule
 	AdHocRules     []*pb.AdHocRule
-	Sources        map[int32]string               // ref -> source code text
+	Sources        map[int32]string // ref -> source code text
+	// SyntaxHighlighting maps a component ref to its ordered syntax-highlighting
+	// rules. Written as syntax-highlightings-<ref>.pb so the migrated Code view
+	// renders with colors instead of raw text (issue #420).
+	SyntaxHighlighting map[int32][]*pb.SyntaxHighlightingRule
 }
 
 // PackageReport assembles a scanner-report.zip from the given report data.
@@ -58,6 +62,9 @@ func PackageReport(data *ReportData) ([]byte, error) {
 		return nil, err
 	}
 	if err := addSources(zw, data.Sources); err != nil {
+		return nil, err
+	}
+	if err := addSyntaxHighlighting(zw, data.SyntaxHighlighting); err != nil {
 		return nil, err
 	}
 	if err := addEmptyContextProps(zw); err != nil {
@@ -169,6 +176,28 @@ func addAdHocRules(zw *zip.Writer, rules []*pb.AdHocRule) error {
 func addSources(zw *zip.Writer, sources map[int32]string) error {
 	for ref, src := range sources {
 		if err := addBytes(zw, fmt.Sprintf("source-%d.txt", ref), []byte(src)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// addSyntaxHighlighting writes one syntax-highlightings-<ref>.pb per component,
+// each a length-delimited stream of SyntaxHighlightingRule messages — the same
+// framing the native scanner uses and CE expects. Refs with no rules are
+// skipped (the scanner omits the file entirely rather than writing an empty one).
+func addSyntaxHighlighting(zw *zip.Writer, highlighting map[int32][]*pb.SyntaxHighlightingRule) error {
+	for ref, rules := range highlighting {
+		if len(rules) == 0 {
+			continue
+		}
+		var buf bytes.Buffer
+		for _, r := range rules {
+			if err := writeDelimited(&buf, r); err != nil {
+				return err
+			}
+		}
+		if err := addBytes(zw, fmt.Sprintf("syntax-highlightings-%d.pb", ref), buf.Bytes()); err != nil {
 			return err
 		}
 	}

--- a/go/internal/scanreport/syntax.go
+++ b/go/internal/scanreport/syntax.go
@@ -1,0 +1,262 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package scanreport
+
+import (
+	"html"
+	"strings"
+
+	pb "github.com/sonar-solutions/sonar-migration-tool/internal/scanreport/proto"
+)
+
+// HighlightInput holds a single file's per-line highlighted HTML, as returned
+// by the source server's /api/sources/lines endpoint ("code" field). Index i
+// holds the HTML for source line i+1. This is the raw input from which the
+// syntax-highlightings-<ref>.pb scanner-report stream is reconstructed.
+type HighlightInput struct {
+	Component string // component key, for ref lookup
+	Lines     []string
+}
+
+// BuildSyntaxHighlighting reconstructs the per-component syntax-highlighting
+// rules from the highlighted HTML lines extracted via /api/sources/lines.
+//
+// SonarQube does not expose the raw scanner highlighting protobuf over the web
+// API; the only place the highlighting survives is the per-line "code" HTML in
+// /api/sources/lines, where each highlighted token is wrapped in a
+// <span class="<cssClass>"> whose class maps to a HighlightingType (see
+// highlightingType). We parse that HTML back into TextRange + type rules so the
+// migrated report renders with the same colors as a native scanner analysis
+// (issue #420). Symbol-reference spans (class "sym"/"sym-N") carry no syntax
+// type and are treated as transparent.
+//
+// Returned ranges are per line (StartLine == EndLine) with 0-based UTF-16
+// column offsets, matching exactly what a native sonar-scanner emits — verified
+// against a real scanner-report syntax-highlightings-*.pb.
+//
+// sources maps a component ref to the exact source text that will be written to
+// source-<ref>.txt. Offsets are validated against it: the highlighting comes
+// from /api/sources/lines while the source text comes from /api/sources/raw, so
+// per-line lengths can diverge (CRLF, BOM, trailing whitespace). If any offset
+// exceeds its line length the SonarCloud CE throws RangeOffsetConverterException
+// and SILENTLY drops ALL highlighting for that file, so we clamp each range to
+// the source line — at worst trimming one token instead of losing the file's
+// colors. A file with no source text is skipped (highlighting would be dropped
+// anyway). Passing a nil sources map disables clamping (used in unit tests).
+func BuildSyntaxHighlighting(inputs []HighlightInput, sources map[int32]string, cr *ComponentRef) map[int32][]*pb.SyntaxHighlightingRule {
+	result := make(map[int32][]*pb.SyntaxHighlightingRule)
+	for _, in := range inputs {
+		ref, ok := cr.refs[in.Component]
+		if !ok {
+			continue
+		}
+		var srcLines []string
+		if sources != nil {
+			src, ok := sources[ref]
+			if !ok {
+				continue // no source-<ref>.txt -> highlighting would be meaningless
+			}
+			srcLines = strings.Split(src, "\n")
+		}
+		var rules []*pb.SyntaxHighlightingRule
+		for i, code := range in.Lines {
+			line := i + 1
+			lineRules := parseHighlightedLine(int32(line), code)
+			if sources != nil {
+				lineRules = clampRulesToSourceLine(lineRules, line, srcLines)
+			}
+			rules = append(rules, lineRules...)
+		}
+		if len(rules) > 0 {
+			result[ref] = rules
+		}
+	}
+	return result
+}
+
+// clampRulesToSourceLine drops or truncates rules so no offset exceeds the
+// UTF-16 length of the matching source line (line is 1-based). The trailing CR
+// of a CRLF line is excluded because the CE measures line length without the
+// terminator. Rules on a line beyond the source's extent are dropped.
+func clampRulesToSourceLine(rules []*pb.SyntaxHighlightingRule, line int, srcLines []string) []*pb.SyntaxHighlightingRule {
+	if line-1 >= len(srcLines) {
+		return nil
+	}
+	maxOff := utf16Len(strings.TrimRight(srcLines[line-1], "\r"))
+	out := make([]*pb.SyntaxHighlightingRule, 0, len(rules))
+	for _, r := range rules {
+		tr := r.GetRange()
+		if tr.GetStartOffset() >= maxOff {
+			continue // starts at or past end of line
+		}
+		if tr.GetEndOffset() > maxOff {
+			tr.EndOffset = maxOff
+		}
+		if tr.GetEndOffset() <= tr.GetStartOffset() {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// parseHighlightedLine converts one line of /api/sources/lines "code" HTML into
+// syntax-highlighting rules. It walks the HTML left to right, maintaining a
+// stack of open <span> classes; the active highlighting type for any stretch of
+// text is the innermost span class that maps to a real type (so nested
+// symbol-reference spans, which carry no type, are seen through). Adjacent text
+// of the same type is coalesced into a single range. Column offsets are counted
+// in UTF-16 code units of the HTML-unescaped text, matching the Java scanner.
+func parseHighlightedLine(line int32, code string) []*pb.SyntaxHighlightingRule {
+	if !strings.Contains(code, "<span") {
+		return nil
+	}
+	lp := lineParser{line: line, curType: pb.SyntaxHighlightingRule_UNSET}
+	var stack []string // raw class attribute of each currently-open span
+
+	for i := 0; i < len(code); {
+		if code[i] == '<' {
+			gt := strings.IndexByte(code[i:], '>')
+			if gt < 0 {
+				break // malformed; stop rather than misattribute offsets
+			}
+			stack = applyTag(code[i:i+gt+1], stack)
+			i += gt + 1
+			continue
+		}
+		end := strings.IndexByte(code[i:], '<')
+		if end < 0 {
+			end = len(code) - i
+		}
+		lp.advance(html.UnescapeString(code[i:i+end]), activeHighlightType(stack))
+		i += end
+	}
+	return lp.finish()
+}
+
+// lineParser accumulates highlighting rules for a single line, coalescing
+// adjacent same-type text runs into one range.
+type lineParser struct {
+	line     int32
+	col      int32
+	curStart int32
+	curType  pb.SyntaxHighlightingRule_HighlightingType
+	rules    []*pb.SyntaxHighlightingRule
+}
+
+// advance consumes one text run of the given active type, emitting the previous
+// range when the type changes.
+func (p *lineParser) advance(text string, t pb.SyntaxHighlightingRule_HighlightingType) {
+	if t != p.curType {
+		p.flush()
+		p.curType = t
+		p.curStart = p.col
+	}
+	p.col += utf16Len(text)
+}
+
+func (p *lineParser) flush() {
+	if p.curType != pb.SyntaxHighlightingRule_UNSET && p.col > p.curStart {
+		p.rules = append(p.rules, &pb.SyntaxHighlightingRule{
+			Range: &pb.TextRange{
+				StartLine:   p.line,
+				EndLine:     p.line,
+				StartOffset: p.curStart,
+				EndOffset:   p.col,
+			},
+			Type: p.curType,
+		})
+	}
+	p.curType = pb.SyntaxHighlightingRule_UNSET
+}
+
+func (p *lineParser) finish() []*pb.SyntaxHighlightingRule {
+	p.flush()
+	return p.rules
+}
+
+// applyTag updates the open-span stack for a single <span>/</span> tag. Other
+// tags leave the stack unchanged.
+func applyTag(tag string, stack []string) []string {
+	switch {
+	case strings.HasPrefix(tag, "</span"):
+		if len(stack) > 0 {
+			return stack[:len(stack)-1]
+		}
+	case strings.HasPrefix(tag, "<span"):
+		return append(stack, classAttr(tag))
+	}
+	return stack
+}
+
+// classAttr extracts the value of the class attribute from a <span ...> tag.
+// Returns "" if the tag has no class attribute.
+func classAttr(tag string) string {
+	idx := strings.Index(tag, "class=\"")
+	if idx < 0 {
+		return ""
+	}
+	rest := tag[idx+len("class=\""):]
+	if end := strings.IndexByte(rest, '"'); end >= 0 {
+		return rest[:end]
+	}
+	return ""
+}
+
+// activeHighlightType returns the highlighting type for the current text,
+// scanning the open-span stack from innermost outward and returning the first
+// class that maps to a real type. Spans with no recognized type (e.g. symbol
+// references) are skipped so the syntax type underneath them is still applied.
+func activeHighlightType(stack []string) pb.SyntaxHighlightingRule_HighlightingType {
+	for i := len(stack) - 1; i >= 0; i-- {
+		if t := highlightingType(stack[i]); t != pb.SyntaxHighlightingRule_UNSET {
+			return t
+		}
+	}
+	return pb.SyntaxHighlightingRule_UNSET
+}
+
+// highlightingType maps a span class attribute (which may contain several
+// space-separated tokens) to its scanner HighlightingType. The CSS class names
+// are SonarQube's TypeOfText abbreviations. Returns UNSET when no token is a
+// recognized syntax-highlighting class (e.g. "sym"/"sym-12" symbol references).
+func highlightingType(class string) pb.SyntaxHighlightingRule_HighlightingType {
+	for _, tok := range strings.Fields(class) {
+		switch tok {
+		case "a":
+			return pb.SyntaxHighlightingRule_ANNOTATION
+		case "c":
+			return pb.SyntaxHighlightingRule_CONSTANT
+		case "cd", "cppd":
+			return pb.SyntaxHighlightingRule_COMMENT
+		case "j":
+			return pb.SyntaxHighlightingRule_STRUCTURED_COMMENT
+		case "k":
+			return pb.SyntaxHighlightingRule_KEYWORD
+		case "s":
+			return pb.SyntaxHighlightingRule_HIGHLIGHTING_STRING
+		case "h":
+			return pb.SyntaxHighlightingRule_KEYWORD_LIGHT
+		case "p":
+			return pb.SyntaxHighlightingRule_PREPROCESS_DIRECTIVE
+		}
+	}
+	return pb.SyntaxHighlightingRule_UNSET
+}
+
+// utf16Len returns the number of UTF-16 code units in s. SonarQube highlighting
+// offsets are Java String indices (UTF-16 code units), so a character outside
+// the Basic Multilingual Plane (e.g. an emoji) counts as 2.
+func utf16Len(s string) int32 {
+	n := int32(0)
+	for _, r := range s {
+		if r > 0xFFFF {
+			n += 2
+		} else {
+			n++
+		}
+	}
+	return n
+}

--- a/go/internal/scanreport/syntax_test.go
+++ b/go/internal/scanreport/syntax_test.go
@@ -1,0 +1,240 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package scanreport
+
+import (
+	"testing"
+
+	pb "github.com/sonar-solutions/sonar-migration-tool/internal/scanreport/proto"
+)
+
+type rng struct {
+	start, end int32
+	typ        pb.SyntaxHighlightingRule_HighlightingType
+}
+
+func gotRanges(rules []*pb.SyntaxHighlightingRule) []rng {
+	out := make([]rng, 0, len(rules))
+	for _, r := range rules {
+		out = append(out, rng{r.GetRange().GetStartOffset(), r.GetRange().GetEndOffset(), r.GetType()})
+	}
+	return out
+}
+
+func TestParseHighlightedLine(t *testing.T) {
+	cases := []struct {
+		name string
+		code string
+		want []rng
+	}{
+		{
+			name: "plain text, no spans",
+			code: "    plain = value",
+			want: nil,
+		},
+		{
+			name: "empty line",
+			code: "",
+			want: nil,
+		},
+		{
+			name: "single comment span",
+			code: `<span class="cd"># sonar-tools</span>`,
+			want: []rng{{0, 13, pb.SyntaxHighlightingRule_COMMENT}},
+		},
+		{
+			name: "two keywords separated by plain text (from X import)",
+			code: `<span class="k">from</span> __future__ <span class="k">import</span> <span class="sym-1 sym">annotations</span>`,
+			want: []rng{
+				{0, 4, pb.SyntaxHighlightingRule_KEYWORD},
+				{16, 22, pb.SyntaxHighlightingRule_KEYWORD},
+			},
+		},
+		{
+			name: "symbol span alone yields no rule",
+			code: `<span class="sym-10 sym">os</span>.path`,
+			want: nil,
+		},
+		{
+			name: "keyword nested inside symbol span (depth 2)",
+			code: `<span class="sym-3 sym"><span class="k">class</span></span> Foo`,
+			want: []rng{{0, 5, pb.SyntaxHighlightingRule_KEYWORD}},
+		},
+		{
+			name: "string then constant",
+			code: `<span class="s">"hi"</span> = <span class="c">42</span>`,
+			want: []rng{
+				{0, 4, pb.SyntaxHighlightingRule_HIGHLIGHTING_STRING},
+				{7, 9, pb.SyntaxHighlightingRule_CONSTANT},
+			},
+		},
+		{
+			name: "html entities count as one char each",
+			// decoded prefix "a < b " is 6 cols (&lt; -> 1 char); spanned "&&" is 2 cols.
+			code: `a &lt; b <span class="k">&amp;&amp;</span> c`,
+			want: []rng{{6, 8, pb.SyntaxHighlightingRule_KEYWORD}},
+		},
+		{
+			name: "structured comment (javadoc/docstring)",
+			code: `<span class="j">"""docstring"""</span>`,
+			want: []rng{{0, 15, pb.SyntaxHighlightingRule_STRUCTURED_COMMENT}},
+		},
+		{
+			name: "preprocess directive and annotation and keyword_light",
+			code: `<span class="p">#include</span> <span class="a">@Override</span> <span class="h">var</span>`,
+			want: []rng{
+				{0, 8, pb.SyntaxHighlightingRule_PREPROCESS_DIRECTIVE},
+				{9, 18, pb.SyntaxHighlightingRule_ANNOTATION},
+				{19, 22, pb.SyntaxHighlightingRule_KEYWORD_LIGHT},
+			},
+		},
+		{
+			name: "unknown class produces no rule",
+			code: `<span class="zzz">weird</span>`,
+			want: nil,
+		},
+		{
+			name: "malformed unterminated tag stops cleanly",
+			code: `<span class="k">def</span> foo <span class="k"`,
+			want: []rng{{0, 3, pb.SyntaxHighlightingRule_KEYWORD}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gotRanges(parseHighlightedLine(7, tc.code))
+			if len(got) != len(tc.want) {
+				t.Fatalf("range count: got %d %+v, want %d %+v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("range[%d]: got %+v, want %+v", i, got[i], tc.want[i])
+				}
+			}
+			// Every emitted rule must be a single-line range anchored to the line.
+			for _, r := range parseHighlightedLine(7, tc.code) {
+				if r.GetRange().GetStartLine() != 7 || r.GetRange().GetEndLine() != 7 {
+					t.Errorf("expected single-line range on line 7, got %+v", r.GetRange())
+				}
+			}
+		})
+	}
+}
+
+func TestUTF16Len(t *testing.T) {
+	cases := []struct {
+		s    string
+		want int32
+	}{
+		{"", 0},
+		{"abc", 3},
+		{"café", 4},         // é is BMP -> 1 unit
+		{"aéb", 3},          // precomposed é
+		{"x\U0001F600y", 4}, // emoji is astral -> 2 units, plus x and y
+	}
+	for _, c := range cases {
+		if got := utf16Len(c.s); got != c.want {
+			t.Errorf("utf16Len(%q) = %d, want %d", c.s, got, c.want)
+		}
+	}
+}
+
+func TestBuildSyntaxHighlighting(t *testing.T) {
+	cr := NewComponentRef()
+	cr.Get("proj")                 // ref 1 (root)
+	fileRef := cr.Get("proj:a.py") // ref 2
+
+	inputs := []HighlightInput{
+		{
+			Component: "proj:a.py",
+			Lines: []string{
+				`<span class="k">def</span> foo():`, // line 1
+				`    <span class="cd"># hi</span>`,  // line 2
+				"    pass",                          // line 3, no highlighting
+			},
+		},
+		{
+			Component: "proj:missing.py", // not in ref map -> skipped
+			Lines:     []string{`<span class="k">if</span>`},
+		},
+	}
+	sources := map[int32]string{
+		fileRef: "def foo():\n    # hi\n    pass\n",
+	}
+
+	got := BuildSyntaxHighlighting(inputs, sources, cr)
+
+	if len(got) != 1 {
+		t.Fatalf("expected highlighting for exactly 1 known component, got %d", len(got))
+	}
+	rules, ok := got[fileRef]
+	if !ok {
+		t.Fatalf("expected rules for ref %d", fileRef)
+	}
+	if len(rules) != 2 {
+		t.Fatalf("expected 2 rules (def, comment), got %d", len(rules))
+	}
+	// Line 1: keyword "def" at [0,3)
+	if r := rules[0].GetRange(); r.GetStartLine() != 1 || r.GetStartOffset() != 0 || r.GetEndOffset() != 3 {
+		t.Errorf("rule0 range = %+v, want line1 [0,3)", r)
+	}
+	if rules[0].GetType() != pb.SyntaxHighlightingRule_KEYWORD {
+		t.Errorf("rule0 type = %v, want KEYWORD", rules[0].GetType())
+	}
+	// Line 2: comment "# hi" at [4,8)
+	if r := rules[1].GetRange(); r.GetStartLine() != 2 || r.GetStartOffset() != 4 || r.GetEndOffset() != 8 {
+		t.Errorf("rule1 range = %+v, want line2 [4,8)", r)
+	}
+	if rules[1].GetType() != pb.SyntaxHighlightingRule_COMMENT {
+		t.Errorf("rule1 type = %v, want COMMENT", rules[1].GetType())
+	}
+}
+
+// TestBuildSyntaxHighlightingClampsToSource guards the robustness fix: when the
+// highlighted HTML (from /api/sources/lines) implies an offset longer than the
+// source line actually shipped (from /api/sources/raw), the rule must be clamped
+// or dropped so the CE never silently discards the whole file's highlighting.
+func TestBuildSyntaxHighlightingClampsToSource(t *testing.T) {
+	cr := NewComponentRef()
+	cr.Get("proj")
+	ref := cr.Get("proj:a.py")
+
+	inputs := []HighlightInput{{
+		Component: "proj:a.py",
+		Lines: []string{
+			`<span class="s">"abcdef"</span>`, // highlight implies cols [0,8)
+			`<span class="k">keyword</span>`,  // highlight implies cols [0,7) but no such source line
+		},
+	}}
+	// Source line 1 is only 4 chars ("abc\r" -> CR stripped -> "abc"=3? use "abcd").
+	// There is no source line 2 (file is a single line).
+	sources := map[int32]string{ref: "abcd"}
+
+	rules := BuildSyntaxHighlighting(inputs, sources, cr)[ref]
+	if len(rules) != 1 {
+		t.Fatalf("expected 1 rule (line1 clamped, line2 dropped), got %d: %+v", len(rules), rules)
+	}
+	r := rules[0].GetRange()
+	if r.GetStartLine() != 1 || r.GetStartOffset() != 0 || r.GetEndOffset() != 4 {
+		t.Errorf("expected line1 clamped to [0,4), got %+v", r)
+	}
+}
+
+func TestClampStripsTrailingCR(t *testing.T) {
+	cr := NewComponentRef()
+	cr.Get("proj")
+	ref := cr.Get("proj:a.py")
+	inputs := []HighlightInput{{
+		Component: "proj:a.py",
+		Lines:     []string{`<span class="k">abc</span>`}, // [0,3)
+	}}
+	// CRLF source: split on "\n" leaves "abc\r"; CE measures length without CR = 3,
+	// so [0,3) must survive unclamped.
+	sources := map[int32]string{ref: "abc\r\nnext"}
+	rules := BuildSyntaxHighlighting(inputs, sources, cr)[ref]
+	if len(rules) != 1 || rules[0].GetRange().GetEndOffset() != 3 {
+		t.Fatalf("CRLF line should keep [0,3), got %+v", rules)
+	}
+}


### PR DESCRIPTION
Closes #420.

## Problem
Migrated projects rendered source code as **raw, uncolored text** in the SonarQube Cloud Code view, while a native scanner analysis is syntax-highlighted. The scanner-report ZIP submitted to the CE *Submit* endpoint never contained the `syntax-highlightings-<ref>.pb` streams. Source text came from `/api/sources/raw` (plain text); the highlighting in `/api/sources/lines` was fetched only as a fallback and stripped away. CloudVoyager never implemented this either (empty stub).

## Fix
Reconstruct highlighting from the per-line `/api/sources/lines` `code` HTML — the only place SonarQube still exposes it.

- **extract** (`tasks_projectdata.go`): `fetchSourceCode` now always fetches the highlighted lines (`fetchHighlightedLines`) and stores them as `highlightedLines`, reusing the response for the existing source-text fallback.
- **scanreport/syntax.go** (new): parse each line's HTML into `SyntaxHighlightingRule` protobufs. CSS class → `HighlightingType` (`a`/`c`/`cd`/`j`/`k`/`s`/`h`/`p`); a **stack-based** walk sees through nested `sym`/`sym-N` symbol-reference spans; **0-based UTF-16** column offsets; single-line ranges (`StartLine == EndLine`) — matching a real `.scannerwork` reference exactly.
- **packager.go**: `addSyntaxHighlighting` writes `syntax-highlightings-<ref>.pb` as a length-delimited stream (same framing as `issues`/`measures`).
- **migrate** (`tasks_projectdata.go`): `loadExtractedSyntaxHighlighting` reads it back and builds with the **same** `ComponentRef` so refs line up with `component-*` / `source-*`.

### Robustness
Offsets (from `/api/sources/lines`) are clamped to the actual `source-<ref>.txt` line length (from `/api/sources/raw`), trailing CR stripped. Without this, a per-line length divergence (CRLF/BOM/trailing whitespace) makes the CE `RangeOffsetConverter` throw and **silently drop ALL highlighting for that file** (DEBUG log; analysis still succeeds). Surfaced by an adversarial review pass.

## Verification
Clean-slate live transfer of `okorach-oss_sonar-tools` (SonarQube Server → SonarQube Cloud), run twice:

- **Before:** target `cli/__init__.py` → 0/22 lines highlighted. **After:** 20/22 (2 blank lines skipped).
- **Parity** across 4 files: **3066 source spans == 3066 target spans, 0 of 2704 lines differ.** All classes migrate (k/s/j/c/cd), on every long branch.
- **No regression:** issues 1292, hotspots 31/31, ncloc 17,379, 4 LONG branches, SCM blame 1572/1572 — all match the known-good baseline; `develop` correctly skipped (source purged).

Unit tests (`syntax_test.go`) cover class mapping, UTF-16 offsets, HTML entities, nested symbol spans, malformed tags, the build/ref mapping, and source-line clamping (incl. CRLF). Full Go suite: 17 ok / 0 fail.

## Out of scope
Symbol references (`symbols-*.pb`, click-to-highlight-occurrences) — a separate feature not recoverable from `/api/sources/lines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)