### PR TITLE
fix(#425): migrate purged-source branches instead of skipping

### DIFF
--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -241,6 +241,7 @@ func recordBranchResult(w *common.ChunkWriter, cloudKey, branchName string, resu
 		"status":            result.Status,
 		"task_id":           result.TaskID,
 		"error":             result.Error,
+		"source_purged":     result.SourcePurged,
 	})
 	w.WriteOne(record) //nolint:errcheck
 }
@@ -260,6 +261,12 @@ type importResult struct {
 	Status string
 	TaskID string
 	Error  string
+	// SourcePurged is true when the branch was migrated without its source
+	// text because SonarQube housekeeping purged it (issue #425). The branch
+	// still imports its measures and issues (status stays "success"); this
+	// flag drives the per-project "source code of branch X is missing" note
+	// in the migration report.
+	SourcePurged bool
 }
 
 func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*importResult, error) {
@@ -296,13 +303,17 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 		return nil, fmt.Errorf("CE task failed: %w", err)
 	}
 
-	return &importResult{Status: "success", TaskID: result.TaskID}, nil
+	return &importResult{Status: "success", TaskID: result.TaskID, SourcePurged: report.SourcePurged}, nil
 }
 
 // branchReport is a packaged scanner report for one branch, ready to submit.
 type branchReport struct {
 	ZIP            []byte
 	ProjectVersion string
+	// SourcePurged is true when this branch's source text was unavailable
+	// (purged by housekeeping) so the report carries measures + issues but no
+	// source. Propagated to the importResult for #425 reporting.
+	SourcePurged bool
 }
 
 // buildBranchReport loads the extracted data for one branch, applies the
@@ -334,16 +345,26 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	// The source server returns no source TEXT for this branch even though line
 	// measures may still exist (SonarQube housekeeping purges source/SCM data
 	// for old or inactive branches while keeping aggregate measures and issues;
-	// /api/sources/{raw,lines} then return empty). Without source, issues cannot
-	// be anchored to real lines: the report would declare N-line files with
-	// empty source, and the SonarCloud CE rejects that inconsistency. Skip
-	// rather than submit a doomed report. (The main branch is actively analyzed
-	// and always carries source, so it is unaffected.)
-	if (len(issues)+len(hotspotIssues)+len(extIssues)) > 0 && totalSourceLen(sources) == 0 {
-		e.Logger.Warn("skipping branch: source code not retrievable (line measures may remain, but source text is gone — likely purged by housekeeping for an inactive branch; re-analyze the branch to restore it)",
+	// /api/sources/{raw,lines} then return empty). Rather than skip the branch
+	// (which dropped it from the target and downgraded the whole project to
+	// "Partial"), migrate it without real source: the measures and issues
+	// still land, matching the source server's own post-purge state (issue
+	// #425). The SonarCloud CE rejects any report containing a FILE component
+	// with no source text — whether or not the file carries issues — so
+	// ensureFileSourcesPresent (below, after the components are built) attaches
+	// blank placeholder source for every source-less file. The purge is
+	// surfaced per-project in the report via the SourcePurged flag. (The main
+	// branch is actively analyzed and always carries source, so it is
+	// unaffected.)
+	//
+	// len(sources)>0 means source extraction ran for this branch (it writes one
+	// record per file, empty when purged); totalSourceLen==0 means every record
+	// came back empty — the whole branch's source is gone.
+	sourcePurged := len(sources) > 0 && totalSourceLen(sources) == 0
+	if sourcePurged {
+		e.Logger.Warn("migrating branch without source: source code not retrievable (line measures may remain, but source text is gone — likely purged by housekeeping for an inactive branch; re-analyze the branch on the source server to restore it)",
 			"project", input.CloudKey, "branch", input.Branch,
 			"findings", len(issues)+len(hotspotIssues)+len(extIssues))
-		return nil, &importResult{Status: "skipped", Error: "source code not retrievable for this branch (line measures may remain, but source text is gone — likely purged by SonarQube housekeeping); re-analyze the branch on the source server to migrate it"}, nil
 	}
 
 	// Fix component line counts (see fixComponentLineCounts).
@@ -390,6 +411,15 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 			pbSources[ref] = s.Source
 		}
 	}
+	// #425 — the SonarCloud CE rejects any report containing a FILE component
+	// with no source text (it fails with "There was an issue whilst processing
+	// the report"), regardless of whether the file carries issues — every
+	// successful report has source for all of its files. When source was purged
+	// the loop above leaves some (or all) files without a source entry, so fill
+	// them with blank placeholder source. The branch then lands with its
+	// measures and issues, matching the source server's own post-purge state;
+	// the purged files simply render as empty.
+	ensureFileSourcesPresent(fileComps, pbSources)
 
 	changesets := buildChangesetMap(cr, components, pbSources, scmByComponent, now)
 
@@ -490,7 +520,28 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 		"activeRules", len(activeRules),
 	)
 
-	return &branchReport{ZIP: zipBytes, ProjectVersion: projectVersion}, nil, nil
+	return &branchReport{ZIP: zipBytes, ProjectVersion: projectVersion, SourcePurged: sourcePurged}, nil, nil
+}
+
+// ensureFileSourcesPresent guarantees every FILE component has a source
+// entry, supplying blank placeholder source — one empty line per declared
+// line — for any file missing real source. Used for #425 purged-source
+// branches: the SonarCloud CE rejects a report containing a file with no
+// source text, so each source-less file is given just enough (empty) lines
+// for the report to be accepted and any issue anchors to fall in range.
+// Files that already have real source are left untouched; the declared line
+// count of a filled file is clamped to at least 1 so the placeholder source
+// and the component agree. No-op for branches whose files all carry source.
+func ensureFileSourcesPresent(fileComps []*pb.Component, sources map[int32]string) {
+	for _, fc := range fileComps {
+		if _, has := sources[fc.GetRef()]; has {
+			continue
+		}
+		if fc.Lines < 1 {
+			fc.Lines = 1
+		}
+		sources[fc.GetRef()] = strings.Repeat("\n", int(fc.Lines)-1)
+	}
 }
 
 // fixComponentLineCounts sets each component's line count to the best available

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -12,11 +12,13 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/scanreport"
+	pb "github.com/sonar-solutions/sonar-migration-tool/internal/scanreport/proto"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
 )
 
@@ -247,6 +249,53 @@ func TestBuildChangesetMap(t *testing.T) {
 	}
 	if _, ok := result[emptyRef]; ok {
 		t.Error("Lines=0 should not produce changeset")
+	}
+}
+
+// #425 — ensureFileSourcesPresent gives every source-less FILE component a
+// blank placeholder source (one empty line per declared line) so the CE
+// accepts the report, while leaving files that already have real source
+// untouched. A zero/negative line count is clamped up to a single empty
+// line and the component's declared line count is bumped to match.
+func TestEnsureFileSourcesPresent(t *testing.T) {
+	fileComps := []*pb.Component{
+		{Ref: 1, Type: pb.Component_FILE, Lines: 10}, // purged -> 10 blank lines
+		{Ref: 2, Type: pb.Component_FILE, Lines: 1},  // purged -> 1 blank line
+		{Ref: 3, Type: pb.Component_FILE, Lines: 0},  // purged, no measure -> clamp to 1
+		{Ref: 4, Type: pb.Component_FILE, Lines: 2},  // already has real source -> untouched
+	}
+	sources := map[int32]string{4: "real\nsource"}
+
+	ensureFileSourcesPresent(fileComps, sources)
+
+	if len(sources) != 4 {
+		t.Fatalf("want a source entry per file (4), got %d", len(sources))
+	}
+	check := func(ref int32, wantLines int, wantBlank bool) {
+		src, ok := sources[ref]
+		if !ok {
+			t.Errorf("ref %d: missing source", ref)
+			return
+		}
+		if gotLines := strings.Count(src, "\n") + 1; gotLines != wantLines {
+			t.Errorf("ref %d: want %d lines, got %d", ref, wantLines, gotLines)
+		}
+		if wantBlank && strings.TrimRight(src, "\n") != "" {
+			t.Errorf("ref %d: placeholder source must be blank, got %q", ref, src)
+		}
+	}
+	check(1, 10, true)
+	check(2, 1, true)
+	check(3, 1, true)
+	if fileComps[2].Lines != 1 {
+		t.Errorf("zero-line file must be clamped to Lines=1, got %d", fileComps[2].Lines)
+	}
+	// File that already had real source is left exactly as-is.
+	if sources[4] != "real\nsource" {
+		t.Errorf("file with real source must be untouched, got %q", sources[4])
+	}
+	if fileComps[3].Lines != 2 {
+		t.Errorf("file with real source must keep its line count, got %d", fileComps[3].Lines)
 	}
 }
 

--- a/go/internal/predict/branch_source_purged.go
+++ b/go/internal/predict/branch_source_purged.go
@@ -1,0 +1,117 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package predict
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+)
+
+// synthesizeBranchSourcePurged predicts, per project, which branches will
+// be migrated WITHOUT their source code because SonarQube housekeeping has
+// purged the source text (issue #425). It mirrors the actual-migrate
+// decision in migrate.buildBranchReport: a branch is migrated source-less
+// when it has findings (issues/hotspots) but zero source bytes were
+// extracted for it.
+//
+// For each such branch it writes an importProjectData JSONL row with
+// status="success" and source_purged=true. That feeds the same summary
+// collector (collectBranchSourcePurged → attachBranchSourcePurged) the
+// actual report uses, so the predictive report shows the identical
+// "Source code of branch(es) X is missing (likely purged in SQS)" note in
+// the affected project's Details column. Rows are emitted ONLY for purged
+// branches, so the predictive report's project outcomes are unchanged.
+//
+// The synthesizer joins extract items back to the synthesized
+// createProjects rows by (server_url, projectKey) so the cloud_project_key
+// matches what the rest of the predict pipeline uses.
+func synthesizeBranchSourcePurged(exportDir, runDir string, extractMapping structure.ExtractMapping) error {
+	store := common.NewDataStore(runDir)
+	projects, err := store.ReadAll("createProjects")
+	if err != nil || len(projects) == 0 {
+		return nil
+	}
+
+	// branchKey identifies a single (server, project, branch) tuple.
+	type branchKey struct{ serverURL, projectKey, branch string }
+	// projectKey identifies a (server, project) tuple.
+	type projectKeyT struct{ serverURL, projectKey string }
+
+	// Source bytes and record presence per branch. A purged branch still
+	// has (empty) source records — the extract writes one per file even
+	// when the source text is gone — so record presence distinguishes
+	// "purged" from "source never extracted".
+	sourceBytes := make(map[branchKey]int)
+	sourceRecords := make(map[branchKey]int)
+	if items, err := structure.ReadExtractData(exportDir, extractMapping, "getProjectSourceCode"); err == nil {
+		for _, item := range items {
+			bk := branchKey{item.ServerURL, jsonStringField(item.Data, "projectKey"), jsonStringField(item.Data, "branch")}
+			sourceBytes[bk] += len(jsonStringField(item.Data, "source"))
+			sourceRecords[bk]++
+		}
+	}
+
+	// Branches per project (LONG branches only). Projects with no recorded
+	// branches fall back to a lone "main" branch, matching migrate.
+	branchesByProject := make(map[projectKeyT][]string)
+	if items, err := structure.ReadExtractData(exportDir, extractMapping, "getBranches"); err == nil {
+		for _, item := range items {
+			if strings.ToUpper(jsonStringField(item.Data, "type")) == "SHORT" {
+				continue
+			}
+			name := jsonStringField(item.Data, "name")
+			if name == "" {
+				continue
+			}
+			pk := projectKeyT{item.ServerURL, jsonStringField(item.Data, "projectKey")}
+			branchesByProject[pk] = append(branchesByProject[pk], name)
+		}
+	}
+
+	w, err := store.Writer("importProjectData")
+	if err != nil {
+		return err
+	}
+
+	for _, p := range projects {
+		sourceKey := jsonStringField(p, "key")
+		serverURL := jsonStringField(p, "server_url")
+		cloudKey := jsonStringField(p, "cloud_project_key")
+		if cloudKey == "" || sourceKey == "" {
+			continue
+		}
+		pk := projectKeyT{serverURL, sourceKey}
+		branches := branchesByProject[pk]
+		if len(branches) == 0 {
+			branches = []string{"main"}
+		}
+		for _, branch := range branches {
+			bk := branchKey{serverURL, sourceKey, branch}
+			// A branch is migrated source-less when source extraction ran
+			// (records exist) but every record came back empty — matching
+			// migrate.buildBranchReport's sourcePurged test. Findings are not
+			// required: a branch with purged source and no issues is still
+			// migrated without source (the CE rejects source-less files
+			// regardless of issues).
+			if !(sourceBytes[bk] == 0 && sourceRecords[bk] > 0) {
+				continue
+			}
+			rec := map[string]any{
+				"cloud_project_key": cloudKey,
+				"branch":            branch,
+				"status":            "success",
+				"source_purged":     true,
+			}
+			b, _ := json.Marshal(rec)
+			if err := w.WriteOne(b); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/go/internal/predict/branch_source_purged_test.go
+++ b/go/internal/predict/branch_source_purged_test.go
@@ -1,0 +1,80 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package predict
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// #425 — BuildPredictiveRun flags branches whose source was purged
+// (findings present, zero source bytes, but source records exist) by
+// emitting importProjectData rows with source_purged=true and
+// status=success. Branches that still carry source are not flagged.
+func TestSynthesizeBranchSourcePurged(t *testing.T) {
+	exportDir := t.TempDir()
+
+	writeFile(t, exportDir, "organizations.csv",
+		"sonarqube_org_key,sonarcloud_org_key,server_url\n"+
+			"default,target-org,"+testServerURL+"\n")
+	writeFile(t, exportDir, "projects.csv",
+		"name,key,server_url,sonarqube_org_key\n"+
+			"App,com.example:app,"+testServerURL+",default\n")
+
+	extractDir := filepath.Join(exportDir, "extract-0001")
+	writeFile(t, extractDir, "extract.json", `{"url":"`+testServerURL+`"}`)
+
+	// Two LONG branches: main (has source) and release-1.0 (purged).
+	writeJSONL(t, filepath.Join(extractDir, "getBranches", "b.jsonl"),
+		[]map[string]any{
+			{"projectKey": "com.example:app", "name": "main", "type": "LONG", "isMain": true},
+			{"projectKey": "com.example:app", "name": "release-1.0", "type": "LONG"},
+		})
+	// Source: main carries text; release-1.0 has a record but it is empty
+	// (purged — the extract still wrote a per-file record).
+	writeJSONL(t, filepath.Join(extractDir, "getProjectSourceCode", "s.jsonl"),
+		[]map[string]any{
+			{"projectKey": "com.example:app", "branch": "main", "key": "f1", "source": "a\nb\nc"},
+			{"projectKey": "com.example:app", "branch": "release-1.0", "key": "f1", "source": ""},
+		})
+	// Both branches have a finding.
+	writeJSONL(t, filepath.Join(extractDir, "getProjectIssuesFull", "i.jsonl"),
+		[]map[string]any{
+			{"projectKey": "com.example:app", "branch": "main", "key": "AX1", "status": "OPEN", "rule": "java:S100"},
+			{"projectKey": "com.example:app", "branch": "release-1.0", "key": "AX2", "status": "OPEN", "rule": "java:S100"},
+		})
+
+	runDir, err := BuildPredictiveRun(exportDir)
+	if err != nil {
+		t.Fatalf("BuildPredictiveRun: %v", err)
+	}
+
+	rows, err := common.NewDataStore(runDir).ReadAll("importProjectData")
+	if err != nil {
+		t.Fatalf("read importProjectData: %v", err)
+	}
+
+	purgedBranches := map[string]bool{}
+	for _, r := range rows {
+		if common.ExtractField(r, "branch") != "" && common.ExtractBool(r, "source_purged") {
+			if common.ExtractField(r, "status") != "success" {
+				t.Errorf("purged row status: want success, got %q", common.ExtractField(r, "status"))
+			}
+			if common.ExtractField(r, "cloud_project_key") == "" {
+				t.Errorf("purged row missing cloud_project_key: %s", string(r))
+			}
+			purgedBranches[common.ExtractField(r, "branch")] = true
+		}
+	}
+
+	if !purgedBranches["release-1.0"] {
+		t.Errorf("expected release-1.0 flagged as source-purged, got %v", purgedBranches)
+	}
+	if purgedBranches["main"] {
+		t.Errorf("main carries source and must NOT be flagged as purged")
+	}
+}

--- a/go/internal/predict/synthesize.go
+++ b/go/internal/predict/synthesize.go
@@ -145,6 +145,12 @@ func BuildPredictiveRun(exportDir string) (string, error) {
 		if err := synthesizeSyncHotspotMetadata(exportDir, runDir, extractMapping); err != nil {
 			return "", fmt.Errorf("synthesizing syncHotspotMetadata: %w", err)
 		}
+		// #425 — predict which branches will migrate without their source
+		// (purged on the source server). Must run after the createProjects
+		// synthesis above so it can join on the synthetic cloud_project_key.
+		if err := synthesizeBranchSourcePurged(exportDir, runDir, extractMapping); err != nil {
+			return "", fmt.Errorf("synthesizing branch source-purged: %w", err)
+		}
 	}
 
 	return runDir, nil

--- a/go/internal/report/summary/branch_source_purged_test.go
+++ b/go/internal/report/summary/branch_source_purged_test.go
@@ -1,0 +1,92 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// #425 — collectBranchSourcePurged groups purged branches per project,
+// de-duplicating repeats and preserving first-seen order. Only rows with
+// source_purged=true contribute.
+func TestCollectBranchSourcePurged(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskJSONL(t, dir, "importProjectData", []map[string]any{
+		{"cloud_project_key": "proj-a", "branch": "main", "status": "success"},
+		{"cloud_project_key": "proj-a", "branch": "release-1.0", "status": "success", "source_purged": true},
+		{"cloud_project_key": "proj-a", "branch": "release-2.0", "status": "success", "source_purged": true},
+		// duplicate purged row must collapse to a single branch entry.
+		{"cloud_project_key": "proj-a", "branch": "release-2.0", "status": "success", "source_purged": true},
+		{"cloud_project_key": "proj-b", "branch": "feature/x", "status": "success", "source_purged": true},
+		// proj-c has no purged branch — must be absent from the map.
+		{"cloud_project_key": "proj-c", "branch": "main", "status": "success"},
+	})
+
+	got := collectBranchSourcePurged(common.NewDataStore(dir))
+
+	if len(got["proj-a"]) != 2 || got["proj-a"][0] != "release-1.0" || got["proj-a"][1] != "release-2.0" {
+		t.Errorf("proj-a: want [release-1.0 release-2.0], got %v", got["proj-a"])
+	}
+	if len(got["proj-b"]) != 1 || got["proj-b"][0] != "feature/x" {
+		t.Errorf("proj-b: want [feature/x], got %v", got["proj-b"])
+	}
+	if _, ok := got["proj-c"]; ok {
+		t.Errorf("proj-c must not be present, got %v", got["proj-c"])
+	}
+}
+
+// #425 — the marker round-trips through attach + parse + render, producing
+// the operator-facing line with the affected branches named once. Plural
+// noun for multiple branches.
+func TestAttachAndRenderBranchSourcePurged_Plural(t *testing.T) {
+	items := []EntityItem{{Name: "Proj A", Detail: "proj-a"}}
+	attachBranchSourcePurged(items, map[string][]string{"proj-a": {"release-1.0", "release-2.0"}})
+
+	rendered := successDetails(items[0], false, false, true)
+	for _, want := range []string{
+		"Source code of branches",
+		"release-1.0",
+		"release-2.0",
+		"is missing (likely purged in SQS). Migration is executed without the sources.",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Errorf("missing %q in:\n%s", want, rendered)
+		}
+	}
+}
+
+// renderBranchSourcePurgedLine: singular noun for one branch, empty for no
+// payload, and bold-wrapped branch names.
+func TestRenderBranchSourcePurgedLine(t *testing.T) {
+	if got := renderBranchSourcePurgedLine(""); got != "" {
+		t.Errorf("empty payload: want empty, got %q", got)
+	}
+	one := renderBranchSourcePurgedLine("main")
+	if !strings.Contains(one, "Source code of branch ") || strings.Contains(one, "branches") {
+		t.Errorf("singular: unexpected wording: %q", one)
+	}
+	if !strings.Contains(one, inlineBoldStart+"main"+inlineBoldEnd) {
+		t.Errorf("singular: branch name not bold-wrapped: %q", one)
+	}
+	many := renderBranchSourcePurgedLine("a,b,c")
+	if !strings.Contains(many, "Source code of branches ") {
+		t.Errorf("plural: unexpected wording: %q", many)
+	}
+}
+
+// #425 — the predictive report is NOT suppressed: the purged-source line
+// renders in predictive mode too (unlike sync/scan markers).
+func TestBranchSourcePurged_RendersInPredictive(t *testing.T) {
+	items := []EntityItem{{Name: "Proj A", Detail: "predict:createProjects:org1:proj-a"}}
+	attachBranchSourcePurged(items, map[string][]string{"predict:createProjects:org1:proj-a": {"release-1.0"}})
+
+	rendered := successDetails(items[0], true /* predictive */, false, true)
+	if !strings.Contains(rendered, "is missing (likely purged in SQS)") {
+		t.Errorf("predictive render missing purged line:\n%s", rendered)
+	}
+}

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -44,6 +44,7 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 	ncdFallbackMap := collectNCDFallback(store)
 	ncdBranchOverrideSet := collectNCDBranchOverrides(store)
 	syncStatsMap := collectSyncStats(store)
+	branchSourcePurgedMap := collectBranchSourcePurged(store)
 	extractMapping, _ := structure.GetUniqueExtracts(exportDir)
 	// #353 — per-object dropped-user-permission counts: SonarQube Cloud
 	// has no API to grant permissions to individual users, so any user
@@ -81,6 +82,13 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 			attachSyncStats(section.Succeeded, syncStatsMap)
 			attachSyncStats(section.NearPerfect, syncStatsMap)
 			attachSyncStats(section.Partial, syncStatsMap)
+			// #425 — note branches migrated without their source (purged
+			// on the source server) in each affected project's Details
+			// column. Applied to all routed buckets; the outcome itself
+			// is unchanged (the branch still imports measures + issues).
+			attachBranchSourcePurged(section.Succeeded, branchSourcePurgedMap)
+			attachBranchSourcePurged(section.NearPerfect, branchSourcePurgedMap)
+			attachBranchSourcePurged(section.Partial, branchSourcePurgedMap)
 		}
 		// #353 — attach the dropped-user-permission count marker to
 		// every entity in every routed bucket so the per-row Details
@@ -1206,6 +1214,61 @@ func encodeSyncStats(c projectSyncCounts) string {
 		parts = append(parts, fmt.Sprintf("ack=%d", c.HotspotAckDemoted))
 	}
 	return strings.Join(parts, ",")
+}
+
+// collectBranchSourcePurged reads importProjectData JSONL and returns,
+// per cloud project key, the ordered list of branch names whose source
+// text was purged on the source server and were therefore migrated
+// without it (issue #425). Branches are de-duplicated and kept in
+// first-seen order so the report lists each affected branch once.
+func collectBranchSourcePurged(store *common.DataStore) map[string][]string {
+	items, err := store.ReadAll("importProjectData")
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	result := make(map[string][]string)
+	seen := make(map[string]bool)
+	for _, item := range items {
+		if !jsonBool(item, "source_purged") {
+			continue
+		}
+		key := jsonStr(item, "cloud_project_key")
+		branch := jsonStr(item, "branch")
+		if key == "" || branch == "" {
+			continue
+		}
+		dedupKey := key + "\x00" + branch
+		if seen[dedupKey] {
+			continue
+		}
+		seen[dedupKey] = true
+		result[key] = append(result[key], branch)
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// attachBranchSourcePurged appends a "|srcPurged:branchA,branchB" marker
+// to each affected project's Detail field. The renderer turns it into a
+// one-line "Source code of branch(es) X, Y is missing (likely purged in
+// SQS). Migration is executed without the sources." note in the Details
+// column, shown in both the actual and predictive reports (#425). The
+// project's outcome is unchanged — the branches still migrate their
+// measures and issues.
+func attachBranchSourcePurged(projects []EntityItem, purgedMap map[string][]string) {
+	if len(purgedMap) == 0 || len(projects) == 0 {
+		return
+	}
+	for i := range projects {
+		key := projectCloudKey(projects[i].Detail)
+		branches, ok := purgedMap[key]
+		if !ok || len(branches) == 0 {
+			continue
+		}
+		projects[i].Detail = projects[i].Detail + "|srcPurged:" + strings.Join(branches, ",")
+	}
 }
 
 // collectNCDFallback reads the setNewCodePeriods JSONL and returns a

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -1424,8 +1424,10 @@ func TestCollectProjectDataOutcomes(t *testing.T) {
 		{"cloud_project_key": "proj-never-analyzed", "branch": "main", "status": "skipped"},
 		// proj-permission — skipped branch with a permission-shaped error.
 		{"cloud_project_key": "proj-permission", "branch": "main", "status": "skipped", "error": "403 Forbidden: insufficient privileges"},
-		// proj-source-purged — skipped branch with a free-text error.
-		{"cloud_project_key": "proj-source-purged", "branch": "feat-1", "status": "skipped", "error": "source code not retrievable for this branch (purged by SonarQube housekeeping)"},
+		// proj-freetext-skip — skipped branch with an arbitrary free-text
+		// error (verbatim passthrough). Note: purged source is no longer a
+		// skip as of #425 — it migrates without source and stays success.
+		{"cloud_project_key": "proj-freetext-skip", "branch": "feat-1", "status": "skipped", "error": "some unmapped extraction error"},
 		// proj-mixed — main failed, secondary skipped. Failed wins.
 		{"cloud_project_key": "proj-mixed", "branch": "main", "status": "failed", "error": "CE task failed: HTTP 500"},
 		{"cloud_project_key": "proj-mixed", "branch": "develop", "status": "skipped", "error": "skipped: main branch CE failed"},
@@ -1438,7 +1440,7 @@ func TestCollectProjectDataOutcomes(t *testing.T) {
 		"proj-success":        {State: "success"},
 		"proj-never-analyzed": {State: "skipped", Reason: "Source project was provisioned but never analyzed"},
 		"proj-permission":     {State: "skipped", Reason: "Not enough permission on the source project to extract data"},
-		"proj-source-purged":  {State: "skipped", Reason: "source code not retrievable for this branch (purged by SonarQube housekeeping)"},
+		"proj-freetext-skip":  {State: "skipped", Reason: "some unmapped extraction error"},
 		"proj-mixed":          {State: "failed", Reason: "API error when migrating project data: CE task failed: HTTP 500"},
 	}
 	for k, w := range want {

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -1160,7 +1160,7 @@ const (
 // bold markers so the PDF renderer can stress it. Other sections keep
 // the bare cloud key as-is.
 func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey bool) string {
-	cloudKey, scan, ncdFallback, syncStats, userPerms := parseProjectDetailMarkers(item.Detail)
+	cloudKey, scan, ncdFallback, syncStats, userPerms, srcPurged := parseProjectDetailMarkers(item.Detail)
 	if hideCloudKey || (predictive && strings.HasPrefix(cloudKey, "predict:")) {
 		cloudKey = ""
 	}
@@ -1207,7 +1207,40 @@ func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey b
 	if line := renderDroppedUserPermsLine(userPerms, predictive); line != "" {
 		parts = append(parts, line)
 	}
+	// #425 — branches whose source was purged on the source server are
+	// migrated without their source (measures + issues only). Surface the
+	// affected branches once per project, in both actual and predictive
+	// reports.
+	if line := renderBranchSourcePurgedLine(srcPurged); line != "" {
+		parts = append(parts, line)
+	}
 	return strings.Join(parts, "\n")
+}
+
+// renderBranchSourcePurgedLine turns a |srcPurged:branchA,branchB marker
+// payload into the operator-facing line for issue #425. Branch names are
+// stressed with inline bold; the noun is singular for one branch. Empty
+// payload yields "" so callers can skip appending.
+func renderBranchSourcePurgedLine(payload string) string {
+	if payload == "" {
+		return ""
+	}
+	var branches []string
+	for _, b := range strings.Split(payload, ",") {
+		if b = strings.TrimSpace(b); b != "" {
+			branches = append(branches, inlineBoldStart+b+inlineBoldEnd)
+		}
+	}
+	if len(branches) == 0 {
+		return ""
+	}
+	noun := "branches"
+	if len(branches) == 1 {
+		noun = "branch"
+	}
+	return fmt.Sprintf(
+		"Source code of %s %s is missing (likely purged in SQS). Migration is executed without the sources.",
+		noun, strings.Join(branches, ", "))
 }
 
 // renderDroppedUserPermsLine turns a |userPerms:N marker payload into
@@ -1443,12 +1476,18 @@ func parseProjectData(detail string) (string, string) {
 // #353 dropped-user-permissions count payload (or empty). Markers
 // are stripped in reverse-attachment order so trailing payloads
 // don't get absorbed into earlier ones' suffix matching.
-func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, syncStats, userPerms string) {
+func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, syncStats, userPerms, srcPurged string) {
 	cloudKey = detail
 	// userPerms marker (always last when present — attachDroppedUserPerms
-	// runs after attachSyncStats / attachProjectData / etc.).
+	// runs after attachSyncStats / attachBranchSourcePurged / etc.).
 	if idx := strings.Index(cloudKey, "|userPerms:"); idx >= 0 {
 		userPerms = cloudKey[idx+len("|userPerms:"):]
+		cloudKey = cloudKey[:idx]
+	}
+	// srcPurged marker (#425 — branches migrated without their purged
+	// source; attached after syncStats, before userPerms).
+	if idx := strings.Index(cloudKey, "|srcPurged:"); idx >= 0 {
+		srcPurged = cloudKey[idx+len("|srcPurged:"):]
 		cloudKey = cloudKey[:idx]
 	}
 	// syncStats marker.
@@ -1466,7 +1505,7 @@ func parseProjectDetailMarkers(detail string) (cloudKey, scan, ncdFallback, sync
 		ncdFallback = cloudKey[idx+len("|ncdFallback:"):]
 		cloudKey = cloudKey[:idx]
 	}
-	return cloudKey, scan, ncdFallback, syncStats, userPerms
+	return cloudKey, scan, ncdFallback, syncStats, userPerms, srcPurged
 }
 
 func checkPageBreak(pdf *fpdf.Fpdf, h float64) {

--- a/go/internal/report/summary/repro_359_test.go
+++ b/go/internal/report/summary/repro_359_test.go
@@ -26,8 +26,11 @@ func TestCollectSummary_ProjectDataAndSyncStats(t *testing.T) {
 		{"cloud_project_key": "org1_projok", "branch": "main", "status": "success"},
 		{"cloud_project_key": "org1_proj_mm", "branch": "main", "status": "success"},
 		{"cloud_project_key": "org1_skipped", "branch": "main", "status": "skipped"},
-		{"cloud_project_key": "org1_purged", "branch": "main", "status": "skipped",
-			"error": "source code not retrievable for this branch (line measures may remain, but source text is gone — likely purged by SonarQube housekeeping)"},
+		// #425 — a branch whose source was purged now migrates WITHOUT its
+		// source (status success, source_purged=true) rather than being
+		// skipped. The project outcome stays Succeeded.
+		{"cloud_project_key": "org1_purged", "branch": "main", "status": "success"},
+		{"cloud_project_key": "org1_purged", "branch": "release-1.0", "status": "success", "source_purged": true},
 		{"cloud_project_key": "org1_failed", "branch": "main", "status": "failed", "error": "CE task failed: 500"},
 	})
 	writeTaskJSONL(t, dir, "syncIssueMetadata", []map[string]any{
@@ -35,7 +38,8 @@ func TestCollectSummary_ProjectDataAndSyncStats(t *testing.T) {
 		{"cloud_project_key": "org1_proj_mm", "synced": float64(36), "line_mismatch": float64(2), "not_found": float64(43), "actionable": float64(81)},
 		// Skipped-import projects: defensive — sync records may exist (older fashion) or not. Either way they must not surface a sync line.
 		{"cloud_project_key": "org1_skipped", "synced": float64(0), "line_mismatch": float64(0), "not_found": float64(0), "actionable": float64(0)},
-		{"cloud_project_key": "org1_purged", "synced": float64(0), "line_mismatch": float64(0), "not_found": float64(4), "actionable": float64(4)},
+		// Purged-source project: import succeeded, issues fully synced — stays Succeeded.
+		{"cloud_project_key": "org1_purged", "synced": float64(4), "line_mismatch": float64(0), "not_found": float64(0), "actionable": float64(4)},
 	})
 
 	summary, err := CollectSummary(dir, "")
@@ -104,14 +108,18 @@ func TestCollectSummary_ProjectDataAndSyncStats(t *testing.T) {
 			},
 		},
 		"ProjPurged": {
-			bucket: "Partial",
+			bucket: "Succeeded",
 			mustContain: []string{
-				"Project data migration skipped: source code not retrievable for this branch",
+				// #425 — branch migrated without its purged source; the
+				// project stays Succeeded and names the affected branch.
+				"Source code of branch",
+				"release-1.0",
+				"is missing (likely purged in SQS). Migration is executed without the sources.",
 			},
 			mustNot: []string{
+				"Project data migration skipped",
 				"Project data migration was skipped",
-				"synced",
-				"Issue sync had unresolved",
+				"Source code of branches", // singular form for one branch
 			},
 		},
 		"ProjFailed": {


### PR DESCRIPTION
Closes #425.

## Problem
When migrating an SQS project whose source code was purged (by housekeeping) on a branch, the tool:
- **skipped** the branch (it never appeared on the target SQC),
- **downgraded** the whole project to **"Partial"**, and
- emitted a generic message that never said **which** branch was affected.

## Change
Migrate the purged branch **without its source** — its measures and issues still land, matching the source server's own post-purge state.

- **`buildBranchReport`** no longer skips. The SonarCloud CE rejects any report containing a FILE component with no source text (confirmed across two live runs — every successful branch has `sources == components`), so **`ensureFileSourcesPresent`** supplies blank placeholder source (one empty line per declared line) for every source-less file and clamps the declared line count to match. The branch returns `success`, so the project stays **Succeeded** (no more "Partial").
- The affected branches are surfaced **once per project in the Details column** via a new `|srcPurged:` marker:
  > Source code of branch(es) **X**, **Y** is missing (likely purged in SQS). Migration is executed without the sources.
- The **predictive report** synthesizes the same signal from the extract data, so the message appears in both reports.

## Tests
- New: `TestEnsureFileSourcesPresent`, `TestCollectBranchSourcePurged`, `TestAttachAndRenderBranchSourcePurged_Plural`, `TestRenderBranchSourcePurgedLine`, `TestBranchSourcePurged_RendersInPredictive`, `TestSynthesizeBranchSourcePurged`.
- Updated `repro_359_test.go` / `collect_test.go` to the new Succeeded behavior.
- `go build`, `go vet`, full `go test ./...` all pass.

## Follow-up to verify on a live run
- Whether the CE keeps the submitted `ncloc` measure or recomputes it from the blank source.
- Whether zero-line files (clamped to a single empty-line source) are accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
