### PR TITLE
fix(#426): reword migration outcomes to Full/Near Full/Partial Migration

### DIFF
--- a/go/internal/report/summary/markdown.go
+++ b/go/internal/report/summary/markdown.go
@@ -104,11 +104,12 @@ func renderMarkdownTitle(sb *strings.Builder, summary *MigrationSummary) {
 func renderMarkdownExecutiveSummary(sb *strings.Builder, summary *MigrationSummary) {
 	columns := []report.Column{
 		{Header: "Objects", Key: "objects"},
-		{Header: "Perfect", Key: "perfect"},
-		{Header: "Near Perfect", Key: "nearPerfect"},
-		{Header: "Partial", Key: "partial"},
-		{Header: "Failed", Key: "failed"},
-		{Header: "Skipped", Key: "skipped"},
+		// Outcome wording per #426 (legal); shared with the PDF renderer.
+		{Header: outcomeSuccess, Key: "perfect"},
+		{Header: outcomeNearPerfect, Key: "nearPerfect"},
+		{Header: outcomePartial, Key: "partial"},
+		{Header: outcomeFailed, Key: "failed"},
+		{Header: outcomeSkipped, Key: "skipped"},
 	}
 
 	var rows []map[string]any

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -77,11 +77,13 @@ var skipReasonOrder = []struct {
 	{SkipReasonDefaultValue, "Left at default value on SonarQube Server"},
 }
 
-// Outcome labels used in the unified per-section table.
+// Outcome labels used in the unified per-section table. The migration-
+// outcome wording deliberately avoids "Perfect"/"Near Perfect" (issue #426,
+// legal): the green/yellow/orange colours are unchanged, only the text.
 const (
-	outcomeSuccess     = "Perfect"
-	outcomeNearPerfect = "Near Perfect"
-	outcomePartial     = "Partial"
+	outcomeSuccess     = "Full Migration"
+	outcomeNearPerfect = "Near Full Migration"
+	outcomePartial     = "Partial Migration"
 	outcomeFailed      = "Failed"
 	outcomeSkipped     = "Skipped"
 )
@@ -372,24 +374,26 @@ func renderTitlePage(pdf *fpdf.Fpdf, summary *MigrationSummary) {
 }
 
 // renderExecutiveSummary renders the six-column summary table at the top of
-// the report: Objects | Perfect | Near Perfect | Partial | Failed | Skipped.
-// The five status buckets follow the green/yellow/orange/red/grey taxonomy
-// defined in issues #224 and #227; colours are conveyed by the count cells.
-// Sections present in `omit` are skipped entirely (predictive reports
-// omit "Global Settings", #235).
+// the report: Objects | Full Migration | Near Full Migration | Partial
+// Migration | Failed | Skipped. The five status buckets follow the
+// green/yellow/orange/red/grey taxonomy defined in issues #224 and #227;
+// colours are conveyed by the count cells. Sections present in `omit` are
+// skipped entirely (predictive reports omit "Global Settings", #235).
 func renderExecutiveSummary(pdf *fpdf.Fpdf, sections []Section, omit map[string]bool) {
-	headers := []string{"Objects", "Perfect", "Near Perfect", "Partial", "Failed", "Skipped"}
+	headers := []string{"Objects", outcomeSuccess, outcomeNearPerfect, outcomePartial, outcomeFailed, outcomeSkipped}
 	const (
 		objectsWidth = 45.0
 		countWidth   = 30.0
 	)
 	widths := []float64{objectsWidth, countWidth, countWidth, countWidth, countWidth, countWidth}
 
-	// Header row — Poppins Bold on the Sonar primary background (#167).
+	// Header row — Poppins Bold on the Sonar primary background (#167). Font
+	// size 8 so the longest label ("Near Full Migration", ~27mm at 8pt) fits
+	// the 30mm count columns (#426).
 	pdf.SetDrawColor(colorSonarGrey[0], colorSonarGrey[1], colorSonarGrey[2])
 	setFillColor(pdf, colorSonarBlue)
 	pdf.SetTextColor(255, 255, 255)
-	pdf.SetFont(pdfFontFamilyHeading, "B", 10)
+	pdf.SetFont(pdfFontFamilyHeading, "B", 8)
 	for i, h := range headers {
 		align := "C"
 		if i == 0 {
@@ -535,18 +539,18 @@ func renderUnifiedTable(pdf *fpdf.Fpdf, section Section, predictive bool) {
 	switch {
 	case isGlobalSettings && hideOrg:
 		// Predictive Global Settings: narrower Setting Key, wider Details.
-		widths = []float64{72, 25, 99}
+		widths = []float64{72, 30, 94}
 	case isGlobalSettings:
-		widths = []float64{55, 35, 25, 81}
+		widths = []float64{55, 35, 30, 76}
 	case predictive:
 		// Predict always drops the Organization column.
-		widths = []float64{60, 25, 111}
+		widths = []float64{60, 30, 106}
 	case hideOrg:
 		// Real-migrate Portfolios — narrower Name, wider Details.
-		widths = []float64{63, 25, 108}
+		widths = []float64{63, 30, 103}
 	default:
 		// Real-migrate standard 4-column layout.
-		widths = []float64{55, 35, 25, 81}
+		widths = []float64{55, 35, 30, 76}
 	}
 	if hideOrg {
 		headers = []string{nameHeader, "Outcome", "Details"}
@@ -1409,10 +1413,10 @@ func sectionCountSummary(section Section) string {
 		fmt.Sprintf("%d succeeded", len(section.Succeeded)),
 	}
 	if len(section.NearPerfect) > 0 {
-		parts = append(parts, fmt.Sprintf("%d near perfect", len(section.NearPerfect)))
+		parts = append(parts, fmt.Sprintf("%d near full migration", len(section.NearPerfect)))
 	}
 	if len(section.Partial) > 0 {
-		parts = append(parts, fmt.Sprintf("%d partial", len(section.Partial)))
+		parts = append(parts, fmt.Sprintf("%d partial migration", len(section.Partial)))
 	}
 	parts = append(parts, fmt.Sprintf("%d failed", len(section.Failed)))
 

--- a/go/internal/report/summary/testdata/migration_summary.golden.md
+++ b/go/internal/report/summary/testdata/migration_summary.golden.md
@@ -8,18 +8,18 @@
 - Overall status: partial
 
 ## Executive Summary
-| Objects | Perfect | Near Perfect | Partial | Failed | Skipped |
+| Objects | Full Migration | Near Full Migration | Partial Migration | Failed | Skipped |
 |:---|:---|:---|:---|:---|:---|
 | Projects | 1 | 1 | 1 | 1 | 1 |
 | Total | 1 | 1 | 1 | 1 | 1 |
 
 ## Projects
-1 succeeded, 1 near perfect, 1 partial, 1 failed, 1 skipped (1 organization skipped)
+1 succeeded, 1 near full migration, 1 partial migration, 1 failed, 1 skipped (1 organization skipped)
 | Name | Organization | Outcome | Details |
 |:---|:---|:---|:---|
-| Proj Perfect | org1 | Perfect | New Project Key: **org1_perfect** |
-| Proj Near | org1 | Near Perfect | New Project Key: **org1_near**<br>new_security_rating_with_aica <= A --> new_security_rating <= A |
-| Proj Partial | org1 | Partial | New Project Key: **org1_partial**<br>The new-code definition (reference branch) was replaced by the org default |
+| Proj Perfect | org1 | Full Migration | New Project Key: **org1_perfect** |
+| Proj Near | org1 | Near Full Migration | New Project Key: **org1_near**<br>new_security_rating_with_aica <= A --> new_security_rating <= A |
+| Proj Partial | org1 | Partial Migration | New Project Key: **org1_partial**<br>The new-code definition (reference branch) was replaced by the org default |
 | Proj Failed | org1 | Failed | create failed: boom \| already exists |
 | Proj Skipped | org1 | Skipped | org was skipped by the wizard |
 


### PR DESCRIPTION
Closes #426.

## Change (legal wording)
Rename the displayed migration-outcome classifications, keeping the existing colors:
- **Perfect** → **Full Migration** (green)
- **Near Perfect** → **Near Full Migration** (yellow)
- **Partial** → **Partial Migration** (orange)

Applied to every display surface, in both the **PDF** and **Markdown** reports:
- the per-section **Outcome** column,
- the **Executive Summary** table headers,
- the per-section count summary prose ("N near full migration, N partial migration").

Internal identifiers (bucket constants, struct fields `NearPerfect`/`Partial`, data map keys) are unchanged — only display text.

## PDF layout
The new labels are longer, so to avoid overflow (measured against the embedded fonts):
- Executive Summary header font drops 10pt → 8pt ("Near Full Migration" = 27.4mm, fits the 30mm columns).
- Per-section **Outcome** column widens 25mm → 30mm ("Near Full Migration" = 26.2mm at the cell font); **Details** narrows by the same 5mm so row totals are unchanged.

The Markdown headers now reuse the shared outcome constants so PDF/Markdown can't drift.

## Tests
- Markdown golden file regenerated (diff is exactly the wording changes).
- `pdf_test.go` outcome assertions reference the constants, so they track automatically.
- `go build`, `go vet`, full `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
