### PR TITLE
fix(#428): preserve the source main branch name on SonarCloud

### DIFF
--- a/go/internal/migrate/branch_rename_test.go
+++ b/go/internal/migrate/branch_rename_test.go
@@ -1,0 +1,82 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	sqapi "github.com/sonar-solutions/sq-api-go"
+	"github.com/sonar-solutions/sq-api-go/cloud"
+)
+
+// renameRecorder is a mock SonarCloud server that reports a configurable main
+// branch name and records any rename request it receives. #428.
+func newBranchRenameServer(t *testing.T, currentMain string) (*httptest.Server, *string) {
+	t.Helper()
+	var renamedTo string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/project_branches/list", func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"branches": []map[string]any{
+				{"name": currentMain, "isMain": true, "type": "LONG"},
+				{"name": "develop", "isMain": false, "type": "LONG"},
+			},
+		})
+	})
+	mux.HandleFunc("POST /api/project_branches/rename", func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		renamedTo = r.FormValue("name")
+		w.WriteHeader(http.StatusNoContent)
+	})
+	return httptest.NewServer(mux), &renamedTo
+}
+
+func newCloudOnlyExecutor(srv *httptest.Server) *Executor {
+	return &Executor{
+		Cloud:  cloud.New(sqapi.NewCloudClient(srv.URL+"/", "test-token")),
+		Logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1})),
+	}
+}
+
+// #428 — the SonarCloud main branch (created as "master") is renamed to the
+// source main branch name.
+func TestRenameSCMainBranchToSource_Renames(t *testing.T) {
+	srv, renamedTo := newBranchRenameServer(t, "master")
+	defer srv.Close()
+	e := newCloudOnlyExecutor(srv)
+
+	renameSCMainBranchToSource(context.Background(), e, "cloud-proj", "main")
+
+	if *renamedTo != "main" {
+		t.Errorf("expected rename to %q, got %q", "main", *renamedTo)
+	}
+}
+
+// No rename when the SonarCloud main branch already carries the source name
+// (e.g. source main is "master" and SonarCloud's default is also "master").
+func TestRenameSCMainBranchToSource_NoOpWhenSame(t *testing.T) {
+	srv, renamedTo := newBranchRenameServer(t, "master")
+	defer srv.Close()
+	e := newCloudOnlyExecutor(srv)
+
+	renameSCMainBranchToSource(context.Background(), e, "cloud-proj", "master")
+
+	if *renamedTo != "" {
+		t.Errorf("expected no rename, but renamed to %q", *renamedTo)
+	}
+}
+
+// No panic / no call when no Cloud client is configured (e.g. dry contexts).
+func TestRenameSCMainBranchToSource_NilCloud(t *testing.T) {
+	e := &Executor{Logger: slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1}))}
+	// Must not panic.
+	renameSCMainBranchToSource(context.Background(), e, "cloud-proj", "main")
+}

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -110,6 +110,30 @@ func fetchSCMainBranch(ctx context.Context, e *Executor, cloudKey string) string
 	return ""
 }
 
+// renameSCMainBranchToSource renames the project's SonarCloud main branch to
+// the source project's main branch name (#428). SonarCloud always creates the
+// first/main branch under its own default name (typically "master"), so unless
+// the source main branch already carries that name its name would be lost.
+// No-op when the Cloud client is unavailable, the source name is empty, the
+// current main name can't be determined, or it already matches. A rename
+// failure is logged but not fatal — the branch content has already migrated.
+func renameSCMainBranchToSource(ctx context.Context, e *Executor, cloudKey, sourceMainName string) {
+	if e.Cloud == nil || e.Cloud.Branches == nil || sourceMainName == "" {
+		return
+	}
+	current := fetchSCMainBranch(ctx, e, cloudKey)
+	if current == "" || current == sourceMainName {
+		return
+	}
+	if err := e.Cloud.Branches.Rename(ctx, cloudKey, sourceMainName); err != nil {
+		logAPIWarn(e.Logger, "failed to rename SonarCloud main branch to match source", err,
+			"project", cloudKey, "from", current, "to", sourceMainName)
+		return
+	}
+	e.Logger.Info("renamed SonarCloud main branch to match source",
+		"project", cloudKey, "from", current, "to", sourceMainName)
+}
+
 // importProjectBranches imports project data for every branch of one project.
 // Main branch is imported first; if it fails, remaining branches are skipped.
 func importProjectBranches(ctx context.Context, e *Executor, proj json.RawMessage,
@@ -162,6 +186,14 @@ func importProjectBranches(ctx context.Context, e *Executor, proj json.RawMessag
 			}
 			return fmt.Errorf("main branch CE failed for %s: %w", cloudKey, err)
 		}
+		// #428 — SonarCloud creates the project's main branch under its own
+		// default name (typically "master"), discarding the source main branch
+		// name. Rename it to match the source now — BEFORE the non-main branches
+		// are imported, because they reference the main branch as their merge
+		// branch (bctx.MainTargetName == the source main name) and because the
+		// rename frees the old default name in case a non-main branch uses it
+		// (e.g. a source "master" branch when "develop" is the main branch).
+		renameSCMainBranchToSource(ctx, e, cloudKey, mainBranch.Name)
 	}
 
 	// Phase 2: import non-main branches sequentially.
@@ -173,16 +205,16 @@ func importProjectBranches(ctx context.Context, e *Executor, proj json.RawMessag
 
 // resolveMainTargetName returns the project's main branch name on the target,
 // used as the reference/merge branch for non-main branch imports. It prefers
-// the SonarCloud main branch name (which may have been renamed during project
-// creation) and falls back to the source main branch name.
+// the SOURCE main branch name: #428 renames the SonarCloud main branch to match
+// the source right after the main branch is migrated, so by the time non-main
+// branches are imported the main branch carries the source name. It falls back
+// to the SonarCloud main branch name only when the source main branch is
+// unknown (no branch data was extracted for the project).
 func resolveMainTargetName(scMainBranch string, mainBranch *branchInfo) string {
-	if scMainBranch != "" {
-		return scMainBranch
-	}
-	if mainBranch != nil {
+	if mainBranch != nil && mainBranch.Name != "" {
 		return mainBranch.Name
 	}
-	return ""
+	return scMainBranch
 }
 
 type branchImportContext struct {
@@ -192,7 +224,8 @@ type branchImportContext struct {
 	ServerKey    string
 	SCMainBranch string
 	// MainTargetName is the project's main branch name on the SonarCloud target
-	// (the SC main branch if known, else the SQ main branch name). Non-main
+	// (the source main branch name, which the SC main branch is renamed to per
+	// #428; the SC main branch name only when no source main is known). Non-main
 	// branches use it as their reference/merge branch on submit.
 	MainTargetName string
 	Completed      map[string]bool

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -412,14 +412,18 @@ func TestCollectBranchInfo(t *testing.T) {
 
 func TestResolveMainTargetName(t *testing.T) {
 	master := branchInfo{Name: "master", IsMain: true}
+	main := branchInfo{Name: "main", IsMain: true}
 	cases := []struct {
 		name         string
 		scMainBranch string
 		mainBranch   *branchInfo
 		want         string
 	}{
-		{"prefers SC main branch name", "main", &master, "main"},
-		{"falls back to SQ main when SC unknown", "", &master, "master"},
+		// #428: the source main branch name wins — the SC main branch is
+		// renamed to match it, so non-main branches must reference it.
+		{"prefers source main over SC name", "master", &main, "main"},
+		{"uses source main when SC unknown", "", &master, "master"},
+		{"falls back to SC main when source unknown", "develop", nil, "develop"},
 		{"empty when no main known", "", nil, ""},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
Closes #428.

## Problem
SonarCloud always creates a project's main branch under its own default name (typically `master`). So a source project whose main branch was `main` (or `develop`, etc.) landed on SonarCloud with the main branch named `master` — the real name was lost.

## Change
After the main branch is migrated — and **before** any non-main branch — rename the SonarCloud main branch to the source main branch name via `api/project_branches/rename` (the `Branches.Rename` client method already existed).

- `renameSCMainBranchToSource` fetches the current SC main name and, if it differs from the source main name, renames it. No-op when they already match; best-effort (a failure is logged, not fatal, since the branch content already migrated).
- Renaming **first** is deliberate: non-main branches reference the main branch as their merge branch, and it frees the old default name in case a non-main branch uses it (e.g. a source `master` branch when `develop` is the main branch).
- `resolveMainTargetName` now prefers the **source** main branch name (what the SC main branch carries after the rename), falling back to the SC name only when no source main is known.

Covers all the issue's examples:
- `master` (main), `develop`, `release-3.2` → migrate main (stays `master`), no rename needed, then the rest.
- `main` (main), … → migrate main → `master`, rename `master`→`main`, then the rest.
- `develop` (main), `master`, `release-3.2` → migrate `develop` → `master`, rename `master`→`develop`, then migrate the source `master` as a regular branch (its name is now free).

## Tests
- `TestRenameSCMainBranchToSource_*` (renames when different, no-op when same, no-op when no Cloud client).
- `TestResolveMainTargetName` updated for the source-preferred priority.
- `go build`, `go vet`, full `go test ./...` all pass.

## Worth a live run before merge
This changes branch-migration behavior and depends on the real SonarCloud CE/rename timing. Suggest verifying on a project whose main branch is `main` (and one of the `develop`-is-main cases) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
