### PR TITLE
fix(#432): don't degrade never-analyzed projects to Partial Migration

### DIFF
--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -821,6 +821,12 @@ type projectDataOutcome struct {
 	// State=="skipped" / "failed". Empty when the state is success
 	// or when no signal could be derived.
 	Reason string
+	// NeverAnalyzed is true for the specific skip case where the source
+	// project was created but never analyzed (no components on any
+	// branch). Per #432 this must NOT degrade the project outcome to
+	// Partial — its non-analysis settings still migrate — and the Details
+	// note is informational rather than a "migration skipped" warning.
+	NeverAnalyzed bool
 }
 
 // collectProjectData reads importProjectData JSONL and returns the
@@ -866,7 +872,19 @@ func collectProjectData(store *common.DataStore) map[string]projectDataOutcome {
 		case len(a.states["failed"]) > 0:
 			result[key] = projectDataOutcome{State: "failed", Reason: projectDataFailureReason(a.errs["failed"])}
 		case len(a.states["skipped"]) > 0:
-			result[key] = projectDataOutcome{State: "skipped", Reason: projectDataSkipReason(a.errs["skipped"])}
+			skipErr := a.errs["skipped"]
+			if skipErr == "" {
+				// #432 — provisioned but never analyzed: the project's
+				// settings still migrate and the outcome must NOT be
+				// degraded. Carry an informational note instead.
+				result[key] = projectDataOutcome{
+					State:         "skipped",
+					Reason:        "Source project was provisioned but never analyzed, project settings migrated anyway",
+					NeverAnalyzed: true,
+				}
+			} else {
+				result[key] = projectDataOutcome{State: "skipped", Reason: projectDataSkipReason(skipErr)}
+			}
 		case len(a.states["success"]) > 0:
 			result[key] = projectDataOutcome{State: "success"}
 		default:
@@ -928,7 +946,14 @@ func attachProjectData(projects []EntityItem, scanMap map[string]projectDataOutc
 		if !ok || outcome.State == "" {
 			continue
 		}
-		marker := outcome.State
+		// #432 — the never-analyzed case uses a distinct marker state so the
+		// renderer shows an informational note (not a "migration skipped"
+		// warning) and does not treat it as a degraded outcome.
+		markerState := outcome.State
+		if outcome.NeverAnalyzed {
+			markerState = "noanalysis"
+		}
+		marker := markerState
 		if outcome.Reason != "" {
 			marker += ":" + outcome.Reason
 		}

--- a/go/internal/report/summary/collect_test.go
+++ b/go/internal/report/summary/collect_test.go
@@ -1438,7 +1438,7 @@ func TestCollectProjectDataOutcomes(t *testing.T) {
 
 	want := map[string]projectDataOutcome{
 		"proj-success":        {State: "success"},
-		"proj-never-analyzed": {State: "skipped", Reason: "Source project was provisioned but never analyzed"},
+		"proj-never-analyzed": {State: "skipped", Reason: "Source project was provisioned but never analyzed, project settings migrated anyway", NeverAnalyzed: true},
 		"proj-permission":     {State: "skipped", Reason: "Not enough permission on the source project to extract data"},
 		"proj-freetext-skip":  {State: "skipped", Reason: "some unmapped extraction error"},
 		"proj-mixed":          {State: "failed", Reason: "API error when migrating project data: CE task failed: HTTP 500"},

--- a/go/internal/report/summary/pdf.go
+++ b/go/internal/report/summary/pdf.go
@@ -1186,7 +1186,13 @@ func successDetails(item EntityItem, predictive, hideCloudKey, labelProjectKey b
 	// pre-migration extract).
 	state, reason := parseScanMarker(scan)
 	dataSkipped := state == "skipped" || state == "failed"
-	if !predictive && dataSkipped {
+	switch {
+	case state == "noanalysis":
+		// #432 — provisioned but never analyzed: the outcome is not degraded
+		// and the project's settings still migrated. Surface the reason as an
+		// informational note (no "migration skipped" framing).
+		parts = append(parts, reason)
+	case !predictive && dataSkipped:
 		parts = append(parts, formatProjectDataSkipped(reason))
 	}
 	// #356 / #323 — render the per-project "x% of items with manual

--- a/go/internal/report/summary/pdf_test.go
+++ b/go/internal/report/summary/pdf_test.go
@@ -453,6 +453,14 @@ func TestSuccessDetailsProjectData(t *testing.T) {
 			want:       "proj1",
 			mustNot:    []string{"Project data", "skipped"},
 		},
+		{
+			// #432 — never-analyzed renders an informational note, NOT a
+			// "migration skipped" warning.
+			name:    "never analyzed — informational note, no skip framing",
+			detail:  "proj1|scan:noanalysis:Source project was provisioned but never analyzed, project settings migrated anyway",
+			want:    "proj1\nSource project was provisioned but never analyzed, project settings migrated anyway",
+			mustNot: []string{"migration skipped", "Project data migration"},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/go/internal/report/summary/project_failures.go
+++ b/go/internal/report/summary/project_failures.go
@@ -334,6 +334,12 @@ func collectProjectSyncSkips(store *common.DataStore, scanMap map[string]project
 		if key == "" || status == "success" || seenSkipped[key] {
 			continue
 		}
+		// #432 — a project that was provisioned but never analyzed on the
+		// source must keep whatever outcome the other migration steps gave
+		// it (its settings still migrated); do not route it to Partial.
+		if o, ok := scanMap[key]; ok && o.NeverAnalyzed {
+			continue
+		}
 		seenSkipped[key] = true
 		out = append(out, projectFailure{
 			CloudProjectKey: key,

--- a/go/internal/report/summary/repro_359_test.go
+++ b/go/internal/report/summary/repro_359_test.go
@@ -97,13 +97,16 @@ func TestCollectSummary_ProjectDataAndSyncStats(t *testing.T) {
 			},
 		},
 		"ProjNeverAnalyzed": {
-			bucket: "Partial",
+			// #432 — never-analyzed projects keep their (Succeeded) outcome;
+			// the Details note is informational, not a "migration skipped".
+			bucket: "Succeeded",
 			mustContain: []string{
-				"Project data migration skipped: Source project was provisioned but never analyzed",
+				"Source project was provisioned but never analyzed, project settings migrated anyway",
 			},
 			mustNot: []string{
-				"Project data migration was skipped", // legacy duplicate must be gone
-				"synced",                             // sync line must be gone
+				"Project data migration skipped", // must no longer be framed as a skip
+				"Project data migration was skipped",
+				"synced", // sync line must be gone
 				"Issue sync had unresolved",
 			},
 		},


### PR DESCRIPTION
Closes #432.

## Problem
A source project that was provisioned but **never analyzed** (no components on any branch) was reported as **Partial Migration**, with the Details note _"Project data migration skipped: Source project was provisioned but never analyzed"_ — even though all of its non-analysis settings migrated fine.

## Change
- The project now keeps whatever outcome the **other** migration steps produced (typically **Full Migration**). `collectProjectSyncSkips` no longer routes the never-analyzed case to Partial.
- The Details note is reworded to the informational _"Source project was provisioned but never analyzed, project settings migrated anyway"_ and is no longer framed as a skipped/degraded migration.

Implementation: `collectProjectData` flags this specific case (`status: skipped` with empty error) via a new `NeverAnalyzed` field; `attachProjectData` stamps a distinct `|scan:noanalysis:` marker; `successDetails` renders that marker as a plain informational line (no "migration skipped" prefix). Other genuine skip/failure reasons (permission denied, main-branch CE failure, API errors) still degrade to Partial as before.

## Tests
- Updated `TestCollectProjectDataOutcomes` (new reason + `NeverAnalyzed: true`) and `repro_359_test.go` `ProjNeverAnalyzed` (now **Succeeded**, informational note, no "migration skipped").
- New `TestSuccessDetailsProjectData` case for the `noanalysis` marker rendering.
- `go build`, `go vet`, full `go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
