### PR TITLE
fix: sync issue/hotspot metadata on non-main branches

### DIFF
--- a/go/internal/migrate/issuesync_branch_test.go
+++ b/go/internal/migrate/issuesync_branch_test.go
@@ -1,0 +1,49 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The cloud issue search must be scoped to the source issue's branch;
+// without it /api/issues/search resolves to the project's main branch only
+// and non-main-branch issues never find their counterpart (so they go
+// unsynced). Source and target branch names match 1:1 after import (#428).
+func TestFindCloudIssueCandidatesPassesBranch(t *testing.T) {
+	var seenBranch string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		seenBranch = r.URL.Query().Get("branch")
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{
+				{"key": "iss-1", "rule": "java:S100", "component": "cloud-proj:src/app.go", "line": 10},
+			},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+		})
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	got, err := findCloudIssueCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go", "java:S100", "release-3.x")
+	if err != nil {
+		t.Fatalf("findCloudIssueCandidates: %v", err)
+	}
+	if seenBranch != "release-3.x" {
+		t.Errorf("expected branch=release-3.x forwarded to cloud search, got %q", seenBranch)
+	}
+	if len(got) != 1 || got[0].Key != "iss-1" {
+		t.Errorf("expected single candidate iss-1, got %+v", got)
+	}
+}

--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -380,10 +380,10 @@ func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, b
 		e.Logger.Debug("syncHotspotMetadata: source hotspot not matchable", "key", src.Key, "rule", src.RuleKey, "component", src.Component, "line", src.Line)
 		return syncOutcomeNotFound
 	}
-	candidates, err := findCloudHotspotCandidates(ctx, e, cloudKey, orgKey, filePath)
+	candidates, err := findCloudHotspotCandidates(ctx, e, cloudKey, orgKey, filePath, src.Branch)
 	if err != nil {
 		logAPIWarn(e.Logger, "syncHotspotMetadata: cloud candidate lookup failed", err,
-			"project", cloudKey, "source_key", src.Key, "file", filePath)
+			"project", cloudKey, "source_key", src.Key, "file", filePath, "branch", src.Branch)
 		return syncOutcomeLookupError
 	}
 	target, outcome := classifyHotspotCandidatesByLine(candidates, src.RuleKey, src.Line, src.Offset)
@@ -527,13 +527,23 @@ func classifyHotspotCandidatesByLine(candidates []matchableHotspot, sourceRule s
 //
 // Uses e.Raw (the cloud-side raw client) because the typed
 // HotspotsClient's SearchAll doesn't expose a per-file filter.
-func findCloudHotspotCandidates(ctx context.Context, e *Executor, cloudKey, orgKey, filePath string) ([]matchableHotspot, error) {
+//
+// The branch parameter is essential for multi-branch projects: without it
+// /api/hotspots/search resolves against the project's main branch only, so
+// hotspots on non-main branches never find their cloud counterpart and go
+// unsynced. Source and target branch names match 1:1 (the main branch is
+// renamed to the source name on import — #428), so the source branch name
+// is the correct cloud branch to search.
+func findCloudHotspotCandidates(ctx context.Context, e *Executor, cloudKey, orgKey, filePath, branch string) ([]matchableHotspot, error) {
 	baseParams := func() url.Values {
 		p := url.Values{}
 		p.Set("projectKey", cloudKey)
 		p.Set("files", filePath)
 		if orgKey != "" {
 			p.Set("organization", orgKey)
+		}
+		if branch != "" {
+			p.Set("branch", branch)
 		}
 		return p
 	}

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -387,12 +387,14 @@ func TestFindCloudHotspotCandidatesQueriesBothStatuses(t *testing.T) {
 	var (
 		mu          sync.Mutex
 		seenStatus  []string
+		seenBranch  []string
 	)
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /api/hotspots/search", func(w http.ResponseWriter, r *http.Request) {
 		status := r.URL.Query().Get("status")
 		mu.Lock()
 		seenStatus = append(seenStatus, status)
+		seenBranch = append(seenBranch, r.URL.Query().Get("branch"))
 		mu.Unlock()
 		switch status {
 		case "TO_REVIEW":
@@ -424,7 +426,7 @@ func TestFindCloudHotspotCandidatesQueriesBothStatuses(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
 
-	got, err := findCloudHotspotCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go")
+	got, err := findCloudHotspotCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go", "develop")
 	if err != nil {
 		t.Fatalf("findCloudHotspotCandidates: %v", err)
 	}
@@ -433,6 +435,13 @@ func TestFindCloudHotspotCandidatesQueriesBothStatuses(t *testing.T) {
 	defer mu.Unlock()
 	if len(seenStatus) != 2 || seenStatus[0] != "TO_REVIEW" || seenStatus[1] != "REVIEWED" {
 		t.Errorf("expected status queries [TO_REVIEW, REVIEWED], got %v", seenStatus)
+	}
+	// The branch must be forwarded to the cloud search so non-main-branch
+	// hotspots are matched (otherwise the search resolves to main only).
+	for _, b := range seenBranch {
+		if b != "develop" {
+			t.Errorf("expected branch=develop on every hotspot search, got %q in %v", b, seenBranch)
+		}
 	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2 candidates (one per status), got %d: %+v", len(got), got)
@@ -468,7 +477,7 @@ func TestFindCloudHotspotCandidatesDedupsByKey(t *testing.T) {
 	dir := t.TempDir()
 	e := newTestExecutor(cloudSrv, apiSrv, dir)
 
-	got, err := findCloudHotspotCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go")
+	got, err := findCloudHotspotCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go", "")
 	if err != nil {
 		t.Fatalf("findCloudHotspotCandidates: %v", err)
 	}

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -573,10 +573,10 @@ func resolveAndSyncIssue(ctx context.Context, e *Executor, cloudKey, orgKey, bas
 		e.Logger.Debug("syncIssueMetadata: source issue not matchable", "key", src.Key, "rule", src.Rule, "component", src.Component, "line", src.Line)
 		return syncOutcomeNotFound
 	}
-	candidates, err := findCloudIssueCandidates(ctx, e, cloudKey, orgKey, filePath, src.Rule)
+	candidates, err := findCloudIssueCandidates(ctx, e, cloudKey, orgKey, filePath, src.Rule, src.Branch)
 	if err != nil {
 		logAPIWarn(e.Logger, "syncIssueMetadata: cloud candidate lookup failed", err,
-			"project", cloudKey, "source_key", src.Key, "rule", src.Rule, "file", filePath)
+			"project", cloudKey, "source_key", src.Key, "rule", src.Rule, "file", filePath, "branch", src.Branch)
 		return syncOutcomeLookupError
 	}
 	target, outcome := classifyIssueCandidatesByLine(candidates, src.Line)
@@ -624,14 +624,24 @@ func classifyIssueCandidatesByLine(candidates []matchableIssue, sourceLine int) 
 }
 
 // findCloudIssueCandidates queries /api/issues/search for cloud issues
-// matching the given file path + rule. Typical result set is 1–3
-// issues; pagination cost is dwarfed by the savings from no longer
-// fetching every issue in the project.
-func findCloudIssueCandidates(ctx context.Context, e *Executor, cloudKey, orgKey, filePath, ruleKey string) ([]matchableIssue, error) {
+// matching the given file path + rule on the given branch. Typical result
+// set is 1–3 issues; pagination cost is dwarfed by the savings from no
+// longer fetching every issue in the project.
+//
+// The branch parameter is essential for multi-branch projects: without it
+// /api/issues/search resolves against the project's main branch only, so
+// issues on non-main branches never find their cloud counterpart and go
+// unsynced. Source and target branch names match 1:1 (the main branch is
+// renamed to the source name on import — #428), so the source branch name
+// is the correct cloud branch to search.
+func findCloudIssueCandidates(ctx context.Context, e *Executor, cloudKey, orgKey, filePath, ruleKey, branch string) ([]matchableIssue, error) {
 	params := url.Values{}
 	params.Set("componentKeys", cloudKey+":"+filePath)
 	params.Set("organization", orgKey)
 	params.Set("rules", ruleKey)
+	if branch != "" {
+		params.Set("branch", branch)
+	}
 	// Same statuses we already use on the source side — we want to be
 	// idempotent against issues that were already migrated in a prior
 	// run (the cloud counterpart may be in ACCEPTED / FALSE_POSITIVE


### PR DESCRIPTION
## Problem
When migrating a project with multiple branches, issue/hotspot metadata sync only matched counterparts on the **main branch** — issues and hotspots on every other branch (`develop`, `release-3.x`, …) were never synced.

Observed on reference project `okorach-oss_sonar-tools`:
- 57% of issues synced (130/225)
- 53% of hotspots synced (30/56)

i.e. roughly the main-branch fraction.

## Root cause
The source issues/hotspots are loaded **per-branch** (each `matchableIssue`/`matchableHotspot` carries its `Branch`), but the SonarCloud candidate search — `findCloudIssueCandidates` / `findCloudHotspotCandidates` — called `api/issues/search` / `api/hotspots/search` **without a `branch` parameter**. Those endpoints then resolve against the project's main branch only, so non-main items found no counterpart and were skipped (`not_found`).

## Fix
Forward the source item's branch to the cloud search. Source and target branch names match 1:1 after import (the main branch is renamed to the source name — #428), so the source branch name is the correct cloud branch to query. An empty branch falls back to the previous default (main), so the main-branch behavior is unchanged.

As a bonus this also reduces false `line_mismatch` results: searching without a branch could return the same (file, rule, line) issue from multiple branches at once.

## Tests
- New `TestFindCloudIssueCandidatesPassesBranch` — asserts `branch` is forwarded to `api/issues/search`.
- Extended `TestFindCloudHotspotCandidatesQueriesBothStatuses` — asserts `branch` is forwarded on every hotspot search.
- `go build`, `go vet`, full `go test ./...` all pass.

## Worth a live run before merge
This changes what gets synced. Suggest re-running the reference migration (`okorach-oss_sonar-tools`) and confirming the synced fraction rises to ~100% of actionable issues/hotspots across all branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
