### PR TITLE
test: cover branch-aware sync resolution paths (follow-up to #434)

### DIFF
--- a/go/internal/migrate/issuesync_branch_test.go
+++ b/go/internal/migrate/issuesync_branch_test.go
@@ -47,3 +47,43 @@ func TestFindCloudIssueCandidatesPassesBranch(t *testing.T) {
 		t.Errorf("expected single candidate iss-1, got %+v", got)
 	}
 }
+
+// A cloud-search failure during issue resolution is reported as a lookup
+// error (and not a silent skip), exercising the branch-aware call site.
+func TestResolveAndSyncIssueLookupError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	src := matchableIssue{Key: "s1", Rule: "java:S100", Component: "src-proj:src/app.go", Line: 10, Branch: "develop"}
+	got := resolveAndSyncIssue(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	if got != syncOutcomeLookupError {
+		t.Fatalf("want syncOutcomeLookupError, got %v", got)
+	}
+}
+
+// A cloud-search failure during hotspot resolution is reported as a lookup
+// error, exercising the branch-aware call site.
+func TestResolveAndSyncHotspotLookupError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/hotspots/search", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	src := matchableHotspot{Key: "h1", RuleKey: "rk1", Component: "src-proj:src/app.go", Line: 10, Branch: "develop"}
+	got := resolveAndSyncHotspot(context.Background(), e, "cloud-proj", "cloud-org", "", "src-proj", src, nil)
+	if got != syncOutcomeLookupError {
+		t.Fatalf("want syncOutcomeLookupError, got %v", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #434.

#434's auto-merge captured only the functional commit; this test-only commit (covering the changed `resolveAndSyncIssue` / `resolveAndSyncHotspot` call sites via their cloud-search lookup-error path) didn't ride along, leaving new-code coverage on that change below the gate. This restores it.

No production code changes — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
