### PR TITLE
fix(#410): recover real SCM blame when api/sources/scm 404s on non-main files

### DIFF
--- a/go/internal/extract/tasks_projectdata.go
+++ b/go/internal/extract/tasks_projectdata.go
@@ -422,16 +422,86 @@ func fetchSCMData(ctx context.Context, e *Executor, item json.RawMessage, w *Chu
 		e.Logger.Warn("getProjectSCMData skipped: component has no branch field", "file", fileKey)
 		return nil
 	}
-	raw, err := e.Raw.Get(ctx, "api/sources/scm", fileParams(fileKey, branch))
-	if err != nil {
-		return handleNonFatal(e, "getProjectSCMData", fileKey, err)
-	}
-	return w.WriteOne(EnrichRaw(raw, map[string]any{
+	meta := map[string]any{
 		"key":        fileKey,
 		"branch":     branch,
 		"projectKey": extractField(item, "projectKey"),
 		"serverUrl":  e.ServerURL,
-	}))
+	}
+	raw, err := e.Raw.Get(ctx, "api/sources/scm", fileParams(fileKey, branch))
+	if err == nil && scmResponseHasData(raw) {
+		return w.WriteOne(EnrichRaw(raw, meta))
+	}
+	if err != nil && !isNonFatalHTTPErr(err) {
+		return err
+	}
+	// api/sources/scm is missing (404 "component not found") or empty for this
+	// file even though its source — and its per-line blame — are available via
+	// api/sources/lines. SonarQube does this for some files, notably on
+	// non-main branches where /sources/scm 404s while /sources/{raw,lines}
+	// return 200. Reconstruct the blame from api/sources/lines (which carries
+	// scmAuthor/scmDate/scmRevision per line) so these files migrate with real
+	// SCM instead of the synthetic fallback (#410).
+	linesRaw, lerr := e.Raw.Get(ctx, "api/sources/lines", fileParams(fileKey, branch))
+	if lerr != nil {
+		if err != nil {
+			return handleNonFatal(e, "getProjectSCMData", fileKey, err)
+		}
+		return handleNonFatal(e, "getProjectSCMData", fileKey, lerr)
+	}
+	rows := scmRowsFromLines(linesRaw)
+	if len(rows) == 0 {
+		return nil // no blame available for this file on this branch
+	}
+	e.Logger.Debug("getProjectSCMData: recovered blame via sources/lines fallback",
+		"file", fileKey, "branch", branch, "lines", len(rows))
+	meta["scm"] = rows
+	b, mErr := json.Marshal(meta)
+	if mErr != nil {
+		return mErr
+	}
+	return w.WriteOne(b)
+}
+
+// scmResponseHasData reports whether an api/sources/scm response carries at
+// least one blame row. An empty/200 response triggers the sources/lines
+// fallback in fetchSCMData (#410).
+func scmResponseHasData(raw json.RawMessage) bool {
+	var obj struct {
+		Scm [][]json.RawMessage `json:"scm"`
+	}
+	if json.Unmarshal(raw, &obj) != nil {
+		return false
+	}
+	return len(obj.Scm) > 0
+}
+
+// scmRowsFromLines extracts per-line SCM (author, date, revision) from an
+// api/sources/lines response into the [line, author, date, revision] row
+// format used by api/sources/scm, keeping only lines that carry blame (#410).
+func scmRowsFromLines(raw json.RawMessage) [][]any {
+	var result struct {
+		Sources []struct {
+			Line        int    `json:"line"`
+			ScmAuthor   string `json:"scmAuthor"`
+			ScmDate     string `json:"scmDate"`
+			ScmRevision string `json:"scmRevision"`
+		} `json:"sources"`
+	}
+	if json.Unmarshal(raw, &result) != nil {
+		return nil
+	}
+	rows := make([][]any, 0, len(result.Sources))
+	for _, s := range result.Sources {
+		if s.Line <= 0 {
+			continue
+		}
+		if s.ScmAuthor == "" && s.ScmRevision == "" && s.ScmDate == "" {
+			continue
+		}
+		rows = append(rows, []any{s.Line, s.ScmAuthor, s.ScmDate, s.ScmRevision})
+	}
+	return rows
 }
 
 // projectVersionsTask extracts the current project version per branch via

--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -755,6 +755,64 @@ func TestProjectSCMDataTaskNonFatal(t *testing.T) {
 	}
 }
 
+// #410: SonarQube returns 404 from api/sources/scm for some files (notably on
+// non-main branches) even though api/sources/lines serves the file and carries
+// per-line blame. fetchSCMData must reconstruct the blame from sources/lines so
+// those files migrate with real SCM instead of synthetic changesets.
+func TestProjectSCMDataTaskFallsBackToLines(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/sources/scm":
+			w.WriteHeader(404) // mirror SonarQube's behavior for these files
+		case "/api/sources/lines":
+			json.NewEncoder(w).Encode(map[string]any{
+				"sources": []map[string]any{
+					{"line": 1, "code": "a", "scmAuthor": "alice@example.com", "scmDate": "2024-01-01T00:00:00+0000", "scmRevision": "rev1"},
+					{"line": 2, "code": "b", "scmAuthor": "bob@example.com", "scmDate": "2024-02-01T00:00:00+0000", "scmRevision": "rev2"},
+					{"line": 3, "code": "", "scmAuthor": "", "scmDate": "", "scmRevision": ""}, // no blame -> dropped
+				},
+			})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
+
+	w, _ := e.Store.Writer("getProjectComponentTree")
+	b, _ := json.Marshal(map[string]any{"key": "p1:cli/audit.py", "branch": "release-3.x", "projectKey": "p1"})
+	w.WriteOne(b)
+
+	if err := projectSCMDataTask()(ctx(t), e); err != nil {
+		t.Fatalf("projectSCMDataTask: %v", err)
+	}
+
+	items, _ := e.Store.ReadAll("getProjectSCMData")
+	if len(items) != 1 {
+		t.Fatalf("expected 1 reconstructed SCM record, got %d", len(items))
+	}
+	var rec struct {
+		Key    string  `json:"key"`
+		Branch string  `json:"branch"`
+		Scm    [][]any `json:"scm"`
+	}
+	if err := json.Unmarshal(items[0], &rec); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
+	}
+	if rec.Key != "p1:cli/audit.py" || rec.Branch != "release-3.x" {
+		t.Errorf("wrong key/branch: %+v", rec)
+	}
+	if len(rec.Scm) != 2 { // line 3 had no blame -> dropped
+		t.Fatalf("expected 2 blame rows, got %d: %v", len(rec.Scm), rec.Scm)
+	}
+	if rec.Scm[0][1] != "alice@example.com" || rec.Scm[1][1] != "bob@example.com" {
+		t.Errorf("authors not carried into blame rows: %v", rec.Scm)
+	}
+}
+
 func TestProjectIssuesFullTaskNonFatal(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(403)

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -299,6 +299,65 @@ func TestEnsureFileSourcesPresent(t *testing.T) {
 	}
 }
 
+// #410 — real per-line SCM blame must be applied to NON-MAIN branches, not
+// just main. The extract captures SCM per branch (getProjectSCMData carries a
+// branch field); buildBranchReport must load it for the branch being migrated
+// and build real changesets (author/date/revision) rather than the synthetic
+// fallback. This locks in the report-build side (the CE rendering is separate).
+func TestNonMainBranchGetsRealSCMChangesets(t *testing.T) {
+	dir := t.TempDir()
+	extractDir := filepath.Join(dir, "extract-01")
+	writeJSON(filepath.Join(extractDir, "extract.json"),
+		map[string]any{"url": testServerURL, "edition": "enterprise"})
+	// A file on the develop (non-main) branch with source + real blame.
+	writeJSONL(filepath.Join(extractDir, "getProjectComponentTree"), []map[string]any{
+		{"key": "proj1:src/App.java", "name": "App.java", "path": "src/App.java",
+			"language": "java", "lines": 3, "projectKey": "proj1", "branch": "develop",
+			"serverUrl": testServerURL},
+	})
+	writeJSONL(filepath.Join(extractDir, "getProjectSourceCode"), []map[string]any{
+		{"key": "proj1:src/App.java", "branch": "develop", "projectKey": "proj1",
+			"source": "a\nb\nc", "serverUrl": testServerURL},
+	})
+	writeJSONL(filepath.Join(extractDir, "getProjectSCMData"), []map[string]any{
+		{"key": "proj1:src/App.java", "branch": "develop", "projectKey": "proj1",
+			"serverUrl": testServerURL,
+			"scm": [][]any{
+				{1, "alice@example.com", "2024-01-01T00:00:00+0000", "rev1"},
+				{2, "bob@example.com", "2024-02-01T00:00:00+0000", "rev2"},
+				{3, "alice@example.com", "2024-01-01T00:00:00+0000", "rev1"},
+			}},
+	})
+
+	e := newProjectDataExecutor(t, dir)
+	comps := loadExtractedComponents(e, testServerURL, "proj1", "develop")
+	srcs := loadExtractedSources(e, testServerURL, "proj1", "develop")
+	scm := loadExtractedSCM(e, testServerURL, "proj1", "develop")
+	if len(scm) == 0 {
+		t.Fatal("expected SCM blame loaded for non-main branch 'develop', got none")
+	}
+
+	_, _, cr := scanreport.BuildComponents("cloud", comps)
+	pbSrc := map[int32]string{}
+	for _, s := range srcs {
+		if ref, ok := cr.Refs()[s.Component]; ok && s.Source != "" {
+			pbSrc[ref] = s.Source
+		}
+	}
+	cs := buildChangesetMap(cr, comps, pbSrc, scm, time.Unix(1700000000, 0))
+	got := cs[cr.Refs()["proj1:src/App.java"]]
+	if got == nil {
+		t.Fatal("no changeset built for App.java on develop")
+	}
+	authors := map[string]bool{}
+	for _, ch := range got.GetChangeset() {
+		authors[ch.GetAuthor()] = true
+	}
+	if !authors["alice@example.com"] || !authors["bob@example.com"] {
+		t.Errorf("non-main branch must carry real SCM blame authors, got %v", authors)
+	}
+}
+
 // --- Data loading function tests (require extract dir setup) ---
 
 func setupProjectDataExtract(t *testing.T, dir string) {


### PR DESCRIPTION
Follow-up to #416 (closes the non-main-branch gap of #410).

## Symptom
After #416, real per-line SCM blame migrates for most files, but **some files render synthetic blame on the target** — reproducibly on non-main branches. Example on `okorach-oss_sonar-tools` / `release-3.x`: `cli/findings_sync.py` shows real blame, `cli/audit.py` shows synthetic — even though both have real SCM on SQS.

## Root cause (extract-side)
For some files, SonarQube's `api/sources/scm` returns **404 "component not found"** even though `api/sources/raw` and `api/sources/lines` return **200** for the *same* key+branch. Verified in the run log:

```
GET api/sources/scm?branch=release-3.x&key=...:cli/audit.py        -> 404
GET api/sources/raw?branch=release-3.x&key=...:cli/audit.py        -> 200
GET api/sources/lines?branch=release-3.x&key=...:cli/audit.py      -> 200
```

`fetchSCMData` treated the 404 as a non-fatal skip → no SCM record written → `buildChangesetMap` fell back to a **synthetic** changeset for that file. (`release-3.x` had 96 components but only 89 SCM records — the 7 missing were exactly these 404 files.)

## Fix
`api/sources/lines` — which we already fetch for source/highlighting — carries per-line `scmAuthor` / `scmDate` / `scmRevision`. When `api/sources/scm` is missing or empty, `fetchSCMData` now reconstructs the blame from `api/sources/lines` into the same `[line, author, date, revision]` row format. The migrate side is unchanged (it already applies per-branch SCM correctly — verified end-to-end: the `release-3.x` report ZIP already carried 21,958 real-author lines for the files that *did* extract).

## Tests
- `TestProjectSCMDataTaskFallsBackToLines` — scm 404 → blame reconstructed from sources/lines (lines without blame dropped).
- `TestNonMainBranchGetsRealSCMChangesets` (migrate) — locks in that a non-main branch produces real-author changesets, not synthetic.
- `go build`, `go vet`, full `go test ./...` pass.

## Verify on a fresh run
This is an **extraction** fix, so a re-extract + re-migrate is required. After that, confirm `cli/audit.py` on `release-3.x` shows real blame on the target (and `release-3.x` SCM record count rises from 89 to 96).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
