### PR TITLE
refactor: reduce code duplication across test and production files

### DIFF
--- a/go/internal/extract/tasks_projectdata_test.go
+++ b/go/internal/extract/tasks_projectdata_test.go
@@ -207,24 +207,15 @@ func TestForEachProjectBranchError(t *testing.T) {
 }
 
 func TestProjectIssuesFullTask(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"issues": []map[string]any{
 				{"key": "issue-1", "rule": "java:S100"},
 			},
 			"paging": map[string]any{"total": 1, "pageIndex": 1, "pageSize": 500},
 		})
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectIssuesFullTask()
 	err := fn(ctx(t), e)
@@ -251,7 +242,7 @@ func TestProjectIssuesFullTaskUsesComponentKeysParam(t *testing.T) {
 		mu   sync.Mutex
 		urls []string
 	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		urls = append(urls, r.URL.RawQuery)
 		mu.Unlock()
@@ -261,17 +252,8 @@ func TestProjectIssuesFullTaskUsesComponentKeysParam(t *testing.T) {
 			},
 			"paging": map[string]any{"total": 1, "pageIndex": 1, "pageSize": 500},
 		})
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	if err := projectIssuesFullTask()(ctx(t), e); err != nil {
 		t.Fatalf("projectIssuesFullTask: %v", err)
@@ -302,7 +284,7 @@ func TestProjectIssuesFullTaskSkipIssueSync(t *testing.T) {
 		mu     sync.Mutex
 		params []string
 	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		mu.Lock()
 		params = append(params, r.URL.Query().Get("additionalFields"))
 		mu.Unlock()
@@ -312,18 +294,9 @@ func TestProjectIssuesFullTaskSkipIssueSync(t *testing.T) {
 			},
 			"paging": map[string]any{"total": 1, "pageIndex": 1, "pageSize": 500},
 		})
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
 	e.SkipIssueSync = true
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	if err := projectIssuesFullTask()(ctx(t), e); err != nil {
 		t.Fatalf("projectIssuesFullTask: %v", err)
@@ -350,7 +323,7 @@ func TestProjectHotspotsFullTaskSkipsDetailEnrichment(t *testing.T) {
 		mu       sync.Mutex
 		showHits int
 	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/hotspots/search":
 			status := r.URL.Query().Get("status")
@@ -375,18 +348,9 @@ func TestProjectHotspotsFullTaskSkipsDetailEnrichment(t *testing.T) {
 		default:
 			w.WriteHeader(http.StatusNotFound)
 		}
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
 	e.SkipIssueSync = true
-
-	pw, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	pw.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	if err := projectHotspotsFullTask()(ctx(t), e); err != nil {
 		t.Fatalf("projectHotspotsFullTask: %v", err)
@@ -409,7 +373,7 @@ func TestProjectHotspotsFullTaskQueriesBothStatuses(t *testing.T) {
 		mu     sync.Mutex
 		seen   []string
 	)
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/hotspots/search" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -436,17 +400,8 @@ func TestProjectHotspotsFullTaskQueriesBothStatuses(t *testing.T) {
 		default:
 			t.Errorf("unexpected status param: %q", status)
 		}
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	pw, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	pw.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectHotspotsFullTask()
 	if err := fn(ctx(t), e); err != nil {
@@ -470,24 +425,15 @@ func TestProjectHotspotsFullTaskQueriesBothStatuses(t *testing.T) {
 }
 
 func TestProjectComponentTreeTask(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{
 			"components": []map[string]any{
 				{"key": "p1:src/Main.java", "name": "Main.java", "language": "java"},
 			},
 			"paging": map[string]any{"total": 1, "pageIndex": 1, "pageSize": 500},
 		})
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectComponentTreeTask()
 	err := fn(ctx(t), e)
@@ -609,19 +555,10 @@ func TestProjectSCMDataTask(t *testing.T) {
 }
 
 func TestProjectComponentTreeTaskNonFatal(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(403)
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectComponentTreeTask()
 	err := fn(ctx(t), e)
@@ -814,19 +751,10 @@ func TestProjectSCMDataTaskFallsBackToLines(t *testing.T) {
 }
 
 func TestProjectIssuesFullTaskNonFatal(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(403)
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectIssuesFullTask()
 	err := fn(ctx(t), e)
@@ -836,7 +764,7 @@ func TestProjectIssuesFullTaskNonFatal(t *testing.T) {
 }
 
 func TestProjectVersionsTask(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/api/navigation/component" {
 			json.NewEncoder(w).Encode(map[string]any{
 				"key":     r.URL.Query().Get("component"),
@@ -846,17 +774,8 @@ func TestProjectVersionsTask(t *testing.T) {
 			return
 		}
 		w.WriteHeader(404)
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectVersionsTask()
 	err := fn(ctx(t), e)
@@ -883,19 +802,10 @@ func TestProjectVersionsTask(t *testing.T) {
 }
 
 func TestProjectVersionsTaskNonFatal(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv, e := newSrvExecutor(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(403)
-	}))
+	})
 	defer srv.Close()
-
-	e := newTestExecutor(t)
-	e.ServerURL = "http://test/"
-	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
-
-	w, _ := e.Store.Writer("getProjects")
-	b, _ := json.Marshal(map[string]any{"key": "p1"})
-	w.WriteOne(b)
-	e.Store.Writer("getBranches")
 
 	fn := projectVersionsTask()
 	err := fn(ctx(t), e)
@@ -907,4 +817,20 @@ func TestProjectVersionsTaskNonFatal(t *testing.T) {
 func ctx(t *testing.T) context.Context {
 	t.Helper()
 	return context.Background()
+}
+
+// newSrvExecutor creates an httptest server with handler, hooks a new executor's
+// Raw client to it, seeds a single project "p1" into getProjects, and opens an
+// empty getBranches writer. Callers must defer srv.Close().
+func newSrvExecutor(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *Executor) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	e := newTestExecutor(t)
+	e.ServerURL = "http://test/"
+	e.Raw = NewRawClient(srv.Client(), srv.URL+"/")
+	w, _ := e.Store.Writer("getProjects")
+	b, _ := json.Marshal(map[string]any{"key": "p1"})
+	w.WriteOne(b)
+	e.Store.Writer("getBranches")
+	return srv, e
 }

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -17,14 +17,22 @@ import (
 	"testing"
 )
 
-func TestCreateProjects(t *testing.T) {
+// newCreateTest creates a complete test environment for create-task tests:
+// mock servers, extract data, and a fresh Executor. The servers are closed
+// via t.Cleanup. Returns the executor and its export directory.
+func newCreateTest(t *testing.T) (*Executor, string) {
+	t.Helper()
 	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
+	t.Cleanup(cloudSrv.Close)
 	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
+	t.Cleanup(apiSrv.Close)
 	dir := t.TempDir()
 	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	return newTestExecutor(cloudSrv, apiSrv, dir), dir
+}
+
+func TestCreateProjects(t *testing.T) {
+	e, dir := newCreateTest(t)
 
 	// Run setup task first.
 	setupCSVs(t, dir)
@@ -49,13 +57,7 @@ func TestCreateProjects(t *testing.T) {
 }
 
 func TestCreateProfiles(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateProfileMappings")
@@ -77,13 +79,7 @@ func TestCreateProfiles(t *testing.T) {
 }
 
 func TestCreateGates(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateGateMappings")
@@ -105,13 +101,7 @@ func TestCreateGates(t *testing.T) {
 }
 
 func TestCreateGroups(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateGroupMappings")
@@ -129,13 +119,7 @@ func TestCreateGroups(t *testing.T) {
 }
 
 func TestCreatePermissionTemplates(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateTemplateMappings")
@@ -157,13 +141,7 @@ func TestCreatePermissionTemplates(t *testing.T) {
 }
 
 func TestCreatePortfolios(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generatePortfolioMappings")
@@ -262,13 +240,7 @@ func TestCreatePortfoliosReusesExisting(t *testing.T) {
 }
 
 func TestGetMigrationUser(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateOrganizationMappings")
@@ -290,13 +262,7 @@ func TestGetMigrationUser(t *testing.T) {
 }
 
 func TestGetEnterprises(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateOrganizationMappings")
@@ -314,13 +280,7 @@ func TestGetEnterprises(t *testing.T) {
 }
 
 func TestGetProjectIds(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, _ := newCreateTest(t)
 
 	// Write createProjects dependency.
 	w, _ := e.Store.Writer("createProjects")
@@ -339,13 +299,7 @@ func TestGetProjectIds(t *testing.T) {
 }
 
 func TestGetOrgRepos(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e, dir := newCreateTest(t)
 
 	setupCSVs(t, dir)
 	runTask(t, e, "generateOrganizationMappings")

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -14,6 +14,22 @@ import (
 	"testing"
 )
 
+// newFlowTest creates a complete test environment: mock servers, extract
+// data, and an Executor pre-loaded with the standard create* outputs.
+// The servers are closed automatically via t.Cleanup.
+func newFlowTest(t *testing.T) *Executor {
+	t.Helper()
+	cloudSrv := newMockCloudServer()
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	setupCreateOutputs(t, e)
+	return e
+}
+
 // setupCreateOutputs populates the Store with mock createX outputs
 // that downstream tasks depend on.
 func setupCreateOutputs(t *testing.T, e *Executor) {
@@ -74,14 +90,7 @@ func setupCreateOutputs(t *testing.T, e *Executor) {
 }
 
 func TestSetProfileParent(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProfileParent"].Run(context.Background(), e)
@@ -91,14 +100,7 @@ func TestSetProfileParent(t *testing.T) {
 }
 
 func TestSetDefaultProfiles(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// restoreProfiles is a dependency — stub it.
 	w, _ := e.Store.Writer("restoreProfiles")
@@ -112,14 +114,7 @@ func TestSetDefaultProfiles(t *testing.T) {
 }
 
 func TestSetDefaultGates(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// addGateConditions dependency.
 	w, _ := e.Store.Writer("addGateConditions")
@@ -133,14 +128,7 @@ func TestSetDefaultGates(t *testing.T) {
 }
 
 func TestSetDefaultTemplates(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setDefaultTemplates"].Run(context.Background(), e)
@@ -150,14 +138,7 @@ func TestSetDefaultTemplates(t *testing.T) {
 }
 
 func TestAddGateConditions(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// getGateConditions dependency — write mock data with conditions.
 	w, _ := e.Store.Writer("getGateConditions")
@@ -172,14 +153,7 @@ func TestAddGateConditions(t *testing.T) {
 }
 
 func TestRestoreProfiles(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// setProfileParent dependency.
 	w, _ := e.Store.Writer("setProfileParent")
@@ -198,14 +172,7 @@ func TestRestoreProfiles(t *testing.T) {
 }
 
 func TestSetProjectProfiles(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProjectProfiles"].Run(context.Background(), e)
@@ -318,14 +285,7 @@ func TestSetProjectProfilesUsesExplicitAssignmentsOnly(t *testing.T) {
 }
 
 func TestSetProjectGates(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProjectGates"].Run(context.Background(), e)
@@ -335,14 +295,7 @@ func TestSetProjectGates(t *testing.T) {
 }
 
 func TestSetProjectGroupPermissions(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProjectGroupPermissions"].Run(context.Background(), e)
@@ -352,14 +305,7 @@ func TestSetProjectGroupPermissions(t *testing.T) {
 }
 
 func TestSetProjectSettings(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProjectSettings"].Run(context.Background(), e)
@@ -369,14 +315,7 @@ func TestSetProjectSettings(t *testing.T) {
 }
 
 func TestSetProjectTags(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProjectTags"].Run(context.Background(), e)
@@ -386,14 +325,7 @@ func TestSetProjectTags(t *testing.T) {
 }
 
 func TestCreateMigrationGroups(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["createMigrationGroups"].Run(context.Background(), e)
@@ -538,14 +470,7 @@ func TestGrantMigrationUserIsAPrerequisiteForPerProjectTasks(t *testing.T) {
 }
 
 func TestAddMigrationUserToGroups(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["addMigrationUserToMigrationGroups"].Run(context.Background(), e)
@@ -555,14 +480,7 @@ func TestAddMigrationUserToGroups(t *testing.T) {
 }
 
 func TestAddMigrationGroupToTemplates(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["addMigrationGroupToTemplates"].Run(context.Background(), e)
@@ -572,14 +490,7 @@ func TestAddMigrationGroupToTemplates(t *testing.T) {
 }
 
 func TestSetOrgGroupPermissions(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setOrgGroupPermissions"].Run(context.Background(), e)
@@ -589,14 +500,7 @@ func TestSetOrgGroupPermissions(t *testing.T) {
 }
 
 func TestSetProfileGroupPermissions(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["setProfileGroupPermissions"].Run(context.Background(), e)
@@ -606,14 +510,7 @@ func TestSetProfileGroupPermissions(t *testing.T) {
 }
 
 func TestUpdateRuleTags(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["updateRuleTags"].Run(context.Background(), e)
@@ -628,14 +525,7 @@ func TestUpdateRuleTags(t *testing.T) {
 }
 
 func TestUpdateRuleDescriptions(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["updateRuleDescriptions"].Run(context.Background(), e)
@@ -743,14 +633,7 @@ func TestApplyOrgPermissions(t *testing.T) {
 }
 
 func TestDeleteTasks(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// getCreatedProjects dependency for deleteProjects.
 	w, _ := e.Store.Writer("getCreatedProjects")
@@ -804,14 +687,7 @@ func TestDeletePortfolios(t *testing.T) {
 }
 
 func TestMatchProjectReposAndBind(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// getProjectIds dependency.
 	writeItem := func(task string, data map[string]any) {
@@ -852,14 +728,7 @@ func TestMatchProjectReposAndBind(t *testing.T) {
 }
 
 func TestSetPortfolioProjects(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	// createPortfolios dependency.
 	w, _ := e.Store.Writer("createPortfolios")

--- a/go/internal/migrate/tasks_read_test.go
+++ b/go/internal/migrate/tasks_read_test.go
@@ -13,14 +13,7 @@ import (
 )
 
 func TestGetGateConditions(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["getGateConditions"].Run(context.Background(), e)
@@ -35,14 +28,7 @@ func TestGetGateConditions(t *testing.T) {
 }
 
 func TestGetProfileBackups(t *testing.T) {
-	cloudSrv := newMockCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	setupCreateOutputs(t, e)
+	e := newFlowTest(t)
 
 	reg := BuildMigrateRegistry(RegisterAll())
 	err := reg["getProfileBackups"].Run(context.Background(), e)

--- a/go/internal/predict/global_settings.go
+++ b/go/internal/predict/global_settings.go
@@ -396,21 +396,30 @@ func predictedAiCodeFixOutcome(org string, row migrate.AiCodeFixRowOutcome) map[
 	}
 }
 
-// jsonStringField pulls a top-level string field out of a JSON object
-// blob without allocating a full map per call. Returns "" when missing
-// or non-string.
-func jsonStringField(raw json.RawMessage, key string) string {
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return ""
+// jsonStringField extracts a top-level string field from a JSON object.
+// Alias of common.ExtractField so the implementation lives in one place.
+var jsonStringField = common.ExtractField
+
+// jsonBoolField extracts a top-level bool field from a JSON object.
+// Alias of common.ExtractBool so the implementation lives in one place.
+var jsonBoolField = common.ExtractBool
+
+// projID identifies a project by its originating server URL and source key.
+// Used as a map key when joining extract items back to createProjects rows.
+type projID struct{ serverURL, sourceKey string }
+
+// buildCloudByProject indexes a slice of createProjects JSONL rows into a
+// (serverURL, sourceKey) → cloud_project_key map for O(1) lookup.
+func buildCloudByProject(projects []json.RawMessage) map[projID]string {
+	out := make(map[projID]string, len(projects))
+	for _, p := range projects {
+		sourceKey := jsonStringField(p, "key")
+		serverURL := jsonStringField(p, "server_url")
+		cloudKey := jsonStringField(p, "cloud_project_key")
+		if cloudKey == "" || sourceKey == "" {
+			continue
+		}
+		out[projID{serverURL, sourceKey}] = cloudKey
 	}
-	v, ok := obj[key]
-	if !ok {
-		return ""
-	}
-	var s string
-	if err := json.Unmarshal(v, &s); err != nil {
-		return ""
-	}
-	return s
+	return out
 }

--- a/go/internal/predict/new_code_periods.go
+++ b/go/internal/predict/new_code_periods.go
@@ -50,17 +50,7 @@ func synthesizeSetNewCodePeriods(exportDir, runDir string, extractMapping struct
 	}
 
 	// Index (server_url, source key) → cloud_project_key.
-	type projID struct{ serverURL, sourceKey string }
-	cloudByProject := make(map[projID]string, len(projects))
-	for _, p := range projects {
-		sourceKey := jsonStringField(p, "key")
-		serverURL := jsonStringField(p, "server_url")
-		cloudKey := jsonStringField(p, "cloud_project_key")
-		if cloudKey == "" || sourceKey == "" {
-			continue
-		}
-		cloudByProject[projID{serverURL, sourceKey}] = cloudKey
-	}
+	cloudByProject := buildCloudByProject(projects)
 
 	w, err := store.Writer("setNewCodePeriods")
 	if err != nil {
@@ -124,18 +114,3 @@ func synthesizeSetNewCodePeriods(exportDir, runDir string, extractMapping struct
 	return nil
 }
 
-// jsonBoolField extracts a top-level bool field from a raw JSON
-// message. Returns false on missing/unparseable values.
-func jsonBoolField(raw json.RawMessage, key string) bool {
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal(raw, &obj); err != nil {
-		return false
-	}
-	v, ok := obj[key]
-	if !ok {
-		return false
-	}
-	var b bool
-	_ = json.Unmarshal(v, &b)
-	return b
-}

--- a/go/internal/predict/predict_test.go
+++ b/go/internal/predict/predict_test.go
@@ -123,6 +123,23 @@ func setupPredictiveFixture(t *testing.T) string {
 	return exportDir
 }
 
+// findPredictiveRunDir returns the predictive run directory created under
+// exportDir by GeneratePredictiveReport, or fatals if none is found.
+func findPredictiveRunDir(t *testing.T, exportDir string) string {
+	t.Helper()
+	entries, err := os.ReadDir(exportDir)
+	if err != nil {
+		t.Fatalf("readdir exportDir: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), "predictive-") {
+			return filepath.Join(exportDir, e.Name())
+		}
+	}
+	t.Fatal("no predictive run directory found under exportDir")
+	return ""
+}
+
 // findSection returns the named section from a summary, or nil.
 func findSection(s *summary.MigrationSummary, name string) *summary.Section {
 	for i := range s.Sections {
@@ -150,20 +167,7 @@ func TestGeneratePredictiveReport_HappyPath(t *testing.T) {
 	// Walk the predictive run dir so we can re-collect the summary and
 	// inspect the section contents directly (the PDF itself is binary
 	// and not worth parsing in a unit test).
-	entries, err := os.ReadDir(exportDir)
-	if err != nil {
-		t.Fatalf("readdir exportDir: %v", err)
-	}
-	var runDir string
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "predictive-") {
-			runDir = filepath.Join(exportDir, e.Name())
-			break
-		}
-	}
-	if runDir == "" {
-		t.Fatal("no predictive run directory found under exportDir")
-	}
+	runDir := findPredictiveRunDir(t, exportDir)
 
 	mig, err := summary.CollectSummary(runDir, exportDir)
 	if err != nil {
@@ -302,20 +306,7 @@ func TestGeneratePredictiveReport_ConsolidatesSonarAuth(t *testing.T) {
 		t.Fatalf("GeneratePredictiveReport: %v", err)
 	}
 
-	entries, err := os.ReadDir(exportDir)
-	if err != nil {
-		t.Fatalf("readdir: %v", err)
-	}
-	var runDir string
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "predictive-") {
-			runDir = filepath.Join(exportDir, e.Name())
-			break
-		}
-	}
-	if runDir == "" {
-		t.Fatal("no predictive run directory found")
-	}
+	runDir := findPredictiveRunDir(t, exportDir)
 
 	mig, err := summary.CollectSummary(runDir, exportDir)
 	if err != nil {
@@ -388,20 +379,7 @@ func TestGeneratePredictiveReport_HotspotAcknowledgedDemotion(t *testing.T) {
 		t.Fatalf("GeneratePredictiveReport: %v", err)
 	}
 
-	entries, err := os.ReadDir(exportDir)
-	if err != nil {
-		t.Fatalf("readdir: %v", err)
-	}
-	var runDir string
-	for _, e := range entries {
-		if e.IsDir() && strings.HasPrefix(e.Name(), "predictive-") {
-			runDir = filepath.Join(exportDir, e.Name())
-			break
-		}
-	}
-	if runDir == "" {
-		t.Fatal("no predictive run directory found")
-	}
+	runDir := findPredictiveRunDir(t, exportDir)
 
 	mig, err := summary.CollectSummary(runDir, exportDir)
 	if err != nil {

--- a/go/internal/predict/sync_hotspot_metadata.go
+++ b/go/internal/predict/sync_hotspot_metadata.go
@@ -40,19 +40,8 @@ func synthesizeSyncHotspotMetadata(exportDir, runDir string, extractMapping stru
 		return nil
 	}
 
-	// Index (server_url, source key) → cloud_project_key (mirrors
-	// new_code_periods.go).
-	type projID struct{ serverURL, sourceKey string }
-	cloudByProject := make(map[projID]string, len(projects))
-	for _, p := range projects {
-		sourceKey := jsonStringField(p, "key")
-		serverURL := jsonStringField(p, "server_url")
-		cloudKey := jsonStringField(p, "cloud_project_key")
-		if cloudKey == "" || sourceKey == "" {
-			continue
-		}
-		cloudByProject[projID{serverURL, sourceKey}] = cloudKey
-	}
+	// Index (server_url, source key) → cloud_project_key.
+	cloudByProject := buildCloudByProject(projects)
 
 	type counts struct {
 		actionable int

--- a/go/internal/wizard/wizard_test.go
+++ b/go/internal/wizard/wizard_test.go
@@ -521,8 +521,6 @@ func writeExtractMeta(t *testing.T, dir string) {
 // always come from the seed because the on-disk state never carries
 // them (json:"-").
 func TestMergeSeed(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
-
 	cases := []struct {
 		name  string
 		state WizardState
@@ -615,7 +613,6 @@ func TestMergeSeed(t *testing.T) {
 // .wizard_state.json — they're json:"-" so Save() drops them. Resume
 // reloads the file and gets nil tokens.
 func TestWizardState_TokensNotPersisted(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
 	dir := t.TempDir()
 	state := &WizardState{
 		SourceURL:   strPtr("https://sq"),

--- a/lib/sq-api-go/ratelimit_test.go
+++ b/lib/sq-api-go/ratelimit_test.go
@@ -121,6 +121,16 @@ func TestParseRetryAfter(t *testing.T) {
 	}
 }
 
+// doGet performs a GET to url using client, closes the response body, and
+// returns the response. It fatals if the request fails.
+func doGet(t *testing.T, client *http.Client, url string) *http.Response {
+	t.Helper()
+	resp, err := client.Get(url)
+	require.NoError(t, err)
+	resp.Body.Close()
+	return resp
+}
+
 func TestRetryTransportSQCBackoff(t *testing.T) {
 	var attempts atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -144,9 +154,7 @@ func TestRetryTransportSQCBackoff(t *testing.T) {
 	})
 
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
-	require.NoError(t, err)
-	resp.Body.Close()
+	resp := doGet(t, client, ts.URL)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int32(2), attempts.Load(), "should retry once after the 429")
@@ -172,9 +180,7 @@ func TestRetryTransportFailFastForCloudflare(t *testing.T) {
 	})
 
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
-	require.NoError(t, err)
-	resp.Body.Close()
+	resp := doGet(t, client, ts.URL)
 
 	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	assert.Equal(t, int32(2), attempts.Load(),
@@ -202,10 +208,8 @@ func TestRetryTransportRetryAfterHonored(t *testing.T) {
 
 	start := time.Now()
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
+	resp := doGet(t, client, ts.URL)
 	elapsed := time.Since(start)
-	require.NoError(t, err)
-	resp.Body.Close()
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.GreaterOrEqual(t, elapsed, 1*time.Second,
@@ -246,9 +250,7 @@ func TestRetryTransportRecoveryFiresAfter429(t *testing.T) {
 	})
 
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
-	require.NoError(t, err)
-	resp.Body.Close()
+	resp := doGet(t, client, ts.URL)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Len(t, calls, 1, "recovery must fire exactly once when a 429 clears")
@@ -277,9 +279,7 @@ func TestRetryTransportRecoveryNotFiredFor5xx(t *testing.T) {
 	})
 
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
-	require.NoError(t, err)
-	resp.Body.Close()
+	resp := doGet(t, client, ts.URL)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int32(0), fired.Load(), "5xx retries are not rate limiting — recovery must not fire")
@@ -305,9 +305,7 @@ func TestRetryTransportRecoveryNotFiredWhenScheduleExhausted(t *testing.T) {
 	})
 
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
-	require.NoError(t, err)
-	resp.Body.Close()
+	resp := doGet(t, client, ts.URL)
 
 	assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	assert.Equal(t, int32(0), fired.Load(), "a request that never clears the 429 has not recovered")
@@ -329,9 +327,7 @@ func TestRetryTransportRecoveryNotFiredOnImmediateSuccess(t *testing.T) {
 	})
 
 	client := &http.Client{Transport: transport}
-	resp, err := client.Get(ts.URL)
-	require.NoError(t, err)
-	resp.Body.Close()
+	resp := doGet(t, client, ts.URL)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, int32(0), fired.Load(), "a request that was never throttled has not recovered")


### PR DESCRIPTION
## Summary

- **predict package**: Replace duplicate `jsonStringField`/`jsonBoolField` function bodies with `common.ExtractField`/`ExtractBool` aliases; extract shared `projID` type and `buildCloudByProject` helper (used by `new_code_periods.go` and `sync_hotspot_metadata.go`)
- **predict_test**: Extract `findPredictiveRunDir` helper, eliminating 3 copies of a 12-line `os.ReadDir` + loop pattern
- **extract/tasks_projectdata_test**: Add `newSrvExecutor` helper (seeds one project + empty branches) used by 8 test functions
- **migrate/tasks_flow_test**: Add `newFlowTest` helper combining mock server setup + `setupCreateOutputs`, replacing 21 identical 8-line setup blocks
- **migrate/tasks_create_test**: Add `newCreateTest` helper, replacing 10 identical 7-line setup blocks
- **migrate/tasks_read_test**: Adopt `newFlowTest` for 2 tests
- **wizard_test**: Remove 2 local `strPtr` redefinitions that shadowed the package-level one from `helpers.go`
- **ratelimit_test (sq-api-go)**: Extract `doGet` helper, replacing 6 copies of the `client.Get + require.NoError + Body.Close` block

## Test plan

- [ ] All Go tests pass: `go test ./...` in both `go/` and `lib/sq-api-go/`
- [ ] Net −321 lines with no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)