### PR TITLE
refactor: second round of code deduplication

### DIFF
--- a/go/internal/extract/debug_test.go
+++ b/go/internal/extract/debug_test.go
@@ -14,6 +14,17 @@ import (
 	"testing"
 )
 
+// captureSlogDefault swaps the process-wide slog logger for one that writes
+// to the returned buffer at Debug level, and restores the original on cleanup.
+func captureSlogDefault(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+	return &buf
+}
+
 // With cfg.Debug=true, baseSDKOptions installs the HTTP debug logger so
 // every API request the SDK makes emits a Debug slog entry. Verify by
 // hitting an httptest server and checking the captured log output.
@@ -23,12 +34,7 @@ func TestBaseSDKOptions_DebugTrueEmitsHTTPLog(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	// Swap the slog default for one writing into a buffer so the debug
-	// transport's output is observable.
-	var buf bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	buf := captureSlogDefault(t)
 
 	cfg := ExtractConfig{
 		URL:   srv.URL + "/",
@@ -59,10 +65,7 @@ func TestBaseSDKOptions_DebugFalseSuppressesHTTPLog(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	var buf bytes.Buffer
-	prev := slog.Default()
-	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
-	t.Cleanup(func() { slog.SetDefault(prev) })
+	buf := captureSlogDefault(t)
 
 	cfg := ExtractConfig{
 		URL:   srv.URL + "/",

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"sort"
 	"sync"
 	"testing"
@@ -121,14 +120,7 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, cloudMux)
 
 	// Mix of source metrics:
 	//  - coverage (unmapped, pass-through, preserves source op/error)
@@ -279,14 +271,7 @@ func TestAddGateConditionsCollapsesCollisions(t *testing.T) {
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, cloudMux)
 
 	w, _ := e.Store.Writer("getGateConditions")
 	payload := map[string]any{

--- a/go/internal/migrate/tasks_delete_test.go
+++ b/go/internal/migrate/tasks_delete_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"testing"
 )
@@ -45,23 +44,7 @@ func TestRunResetGlobalSettings(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	// Seed the org mapping so the task has one org to iterate.
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{
-		"sonarqube_org_key":  "org1",
-		"sonarcloud_org_key": testCloudOrg,
-	})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetGlobalSettings(context.Background(), e); err != nil {
 		t.Fatalf("runResetGlobalSettings: %v", err)
@@ -119,19 +102,7 @@ func TestRunDeleteGatesDestroysOnlyNonBuiltIn(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runDeleteGates(context.Background(), e); err != nil {
 		t.Fatalf("runDeleteGates: %v", err)
@@ -186,19 +157,7 @@ func TestRunDeleteGatesAcceptsNumericDefaultField(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runDeleteGates(context.Background(), e); err != nil {
 		t.Fatalf("runDeleteGates: %v", err)
@@ -229,19 +188,7 @@ func TestRunDeleteGatesBuiltInByName(t *testing.T) {
 		destroyCalls++
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runDeleteGates(context.Background(), e); err != nil {
 		t.Fatalf("runDeleteGates: %v", err)
@@ -283,19 +230,7 @@ func TestRunResetDefaultGates(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetDefaultGates(context.Background(), e); err != nil {
 		t.Fatalf("runResetDefaultGates: %v", err)
@@ -335,19 +270,7 @@ func TestRunResetDefaultGatesNameFallback(t *testing.T) {
 		setDefaultID = r.FormValue("id")
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetDefaultGates(context.Background(), e); err != nil {
 		t.Fatalf("runResetDefaultGates: %v", err)
@@ -374,19 +297,7 @@ func TestRunResetDefaultGatesSkipsWhenAlreadyDefault(t *testing.T) {
 		setDefaultHits++
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetDefaultGates(context.Background(), e); err != nil {
 		t.Fatalf("runResetDefaultGates: %v", err)
@@ -436,19 +347,7 @@ func TestRunResetDefaultProfilesPerLanguage(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetDefaultProfiles(context.Background(), e); err != nil {
 		t.Fatalf("runResetDefaultProfiles: %v", err)
@@ -509,19 +408,7 @@ func TestRunDeleteProfilesDeletesOnlyNonBuiltIn(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runDeleteProfiles(context.Background(), e); err != nil {
 		t.Fatalf("runDeleteProfiles: %v", err)
@@ -565,21 +452,7 @@ func TestRunResetGlobalSettingsAllInherited(t *testing.T) {
 		resetCalls++
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{
-		"sonarcloud_org_key": testCloudOrg,
-	})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetGlobalSettings(context.Background(), e); err != nil {
 		t.Fatalf("runResetGlobalSettings: %v", err)
@@ -627,19 +500,7 @@ func TestRunResetPermissionTemplatesPromotesBuiltInForEveryQualifier(t *testing.
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
 		t.Fatalf("runResetPermissionTemplates: %v", err)
@@ -693,19 +554,7 @@ func TestRunResetPermissionTemplatesSkipsWhenAlreadyDefault(t *testing.T) {
 		setCalls++
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runResetPermissionTemplates(context.Background(), e); err != nil {
 		t.Fatalf("runResetPermissionTemplates: %v", err)
@@ -749,19 +598,7 @@ func TestRunDeleteTemplatesEnumeratesAndDeletes(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	w, _ := e.Store.Writer("generateOrganizationMappings")
-	b, _ := json.Marshal(map[string]any{"sonarcloud_org_key": testCloudOrg})
-	w.WriteOne(b)
+	e := newDeleteTest(t, mux)
 
 	if err := runDeleteTemplates(context.Background(), e); err != nil {
 		t.Fatalf("runDeleteTemplates: %v", err)

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -97,16 +97,9 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
+	e := newCustomCloudTest(t, cloudMux)
 
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	extractDir := filepath.Join(dir, "extract-01", "getProjectSettings")
+	extractDir := filepath.Join(e.ExportDir, "extract-01", "getProjectSettings")
 	if err := os.MkdirAll(extractDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -212,16 +205,9 @@ func TestRunSetProjectSettingsRespectsSQCDefinitions(t *testing.T) {
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
+	e := newCustomCloudTest(t, cloudMux)
 
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	extractDir := filepath.Join(dir, "extract-01", "getProjectSettings")
+	extractDir := filepath.Join(e.ExportDir, "extract-01", "getProjectSettings")
 	if err := os.MkdirAll(extractDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -314,19 +300,12 @@ func TestRunSetProjectSettingsWarnsOnUnmappedProject(t *testing.T) {
 	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		_ = json.NewEncoder(w).Encode(map[string]any{})
 	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, cloudMux)
 	// Capture Warn output so the test can assert on it.
 	var buf bytes.Buffer
 	e.Logger = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
 
-	extractDir := filepath.Join(dir, "extract-01", "getProjectSettings")
+	extractDir := filepath.Join(e.ExportDir, "extract-01", "getProjectSettings")
 	if err := os.MkdirAll(extractDir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}

--- a/go/internal/migrate/tasks_setup.go
+++ b/go/internal/migrate/tasks_setup.go
@@ -6,50 +6,26 @@ package migrate
 
 import "context"
 
+// csvMappingTask builds a TaskDef that loads a CSV file into JSONL under the
+// given task name. All generate*Mappings tasks share this structure.
+func csvMappingTask(name, csvFile string) TaskDef {
+	return TaskDef{
+		Name: name,
+		Run: func(ctx context.Context, e *Executor) error {
+			return loadCSVToJSONL(e, name, csvFile)
+		},
+	}
+}
+
 // setupTasks returns tasks that load CSV mappings into JSONL for the migrate pipeline.
 func setupTasks() []TaskDef {
 	return []TaskDef{
-		{
-			Name: "generateProjectMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generateProjectMappings", "projects.csv")
-			},
-		},
-		{
-			Name: "generateProfileMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generateProfileMappings", "profiles.csv")
-			},
-		},
-		{
-			Name: "generateGateMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generateGateMappings", "gates.csv")
-			},
-		},
-		{
-			Name: "generateGroupMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generateGroupMappings", "groups.csv")
-			},
-		},
-		{
-			Name: "generateTemplateMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generateTemplateMappings", "templates.csv")
-			},
-		},
-		{
-			Name: "generatePortfolioMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generatePortfolioMappings", "portfolios.csv")
-			},
-		},
-		{
-			Name: "generateOrganizationMappings",
-			Run: func(ctx context.Context, e *Executor) error {
-				return loadCSVToJSONL(e, "generateOrganizationMappings", "organizations.csv")
-			},
-		},
+		csvMappingTask("generateProjectMappings", "projects.csv"),
+		csvMappingTask("generateProfileMappings", "profiles.csv"),
+		csvMappingTask("generateGateMappings", "gates.csv"),
+		csvMappingTask("generateGroupMappings", "groups.csv"),
+		csvMappingTask("generateTemplateMappings", "templates.csv"),
+		csvMappingTask("generatePortfolioMappings", "portfolios.csv"),
+		csvMappingTask("generateOrganizationMappings", "organizations.csv"),
 	}
 }

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
 	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sq-api-go/cloud"
@@ -527,6 +528,38 @@ func writeJSON(path string, data any) {
 	os.MkdirAll(filepath.Dir(path), 0o755)
 	b, _ := json.Marshal(data)
 	os.WriteFile(path, b, 0o644)
+}
+
+// newCustomCloudTest wires a test environment with a caller-supplied cloudMux,
+// a fresh mock API server, a temp export dir, and a new Executor. It does NOT
+// call setupExtractData — use this for tasks whose extract data is written
+// inline by the test. Servers are closed via t.Cleanup.
+func newCustomCloudTest(t *testing.T, cloudMux *http.ServeMux) *Executor {
+	t.Helper()
+	cloudSrv := httptest.NewServer(cloudMux)
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	dir := t.TempDir()
+	return newTestExecutor(cloudSrv, apiSrv, dir)
+}
+
+// newDeleteTest wires a test environment for delete/reset tasks: mock servers,
+// extract data, an Executor, and a pre-seeded generateOrganizationMappings row
+// for testCloudOrg. Servers are closed via t.Cleanup.
+func newDeleteTest(t *testing.T, mux *http.ServeMux) *Executor {
+	t.Helper()
+	cloudSrv := httptest.NewServer(mux)
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	dir := t.TempDir()
+	setupExtractData(dir)
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"sonarqube_org_key": "org1", "sonarcloud_org_key": testCloudOrg},
+	})
+	return e
 }
 
 func writeJSONL(taskDir string, items []map[string]any) {

--- a/go/internal/pipeline/helpers.go
+++ b/go/internal/pipeline/helpers.go
@@ -51,6 +51,26 @@ func fetchAllIssues(ctx context.Context, client *sqapi.Client, projectKey, param
 	})
 }
 
+// doPageGET executes a GET request for the given URL and returns the open
+// response. The caller is responsible for closing the body. Returns an error
+// when the request cannot be built, the transport fails, or the status is
+// not HTTP 200.
+func doPageGET(ctx context.Context, client *sqapi.Client, u string, page int) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request for page %d: %w", page, err)
+	}
+	resp, err := client.HTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching page %d: %w", page, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("API returned HTTP %d (page %d)", resp.StatusCode, page)
+	}
+	return resp, nil
+}
+
 func fetchIssuesPage(ctx context.Context, client *sqapi.Client, projectKey, paramName string, statusValues []string, page, pageSize int) ([]Issue, int, error) {
 	params := url.Values{
 		"componentKeys": {projectKey},
@@ -58,19 +78,11 @@ func fetchIssuesPage(ctx context.Context, client *sqapi.Client, projectKey, para
 		"p":             {strconv.Itoa(page)},
 		"ps":            {strconv.Itoa(pageSize)},
 	}
-	u := client.BaseURL() + "api/issues/search?" + params.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	resp, err := doPageGET(ctx, client, client.BaseURL()+"api/issues/search?"+params.Encode(), page)
 	if err != nil {
-		return nil, 0, fmt.Errorf("building issues request: %w", err)
-	}
-	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("fetching issues page %d: %w", page, err)
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("issues/search returned HTTP %d", resp.StatusCode)
-	}
 	var result struct {
 		Paging pagingResult `json:"paging"`
 		Issues []Issue      `json:"issues"`
@@ -95,19 +107,11 @@ func fetchHotspotsPage(ctx context.Context, client *sqapi.Client, projectKey str
 		"p":          {strconv.Itoa(page)},
 		"ps":         {strconv.Itoa(pageSize)},
 	}
-	u := client.BaseURL() + "api/hotspots/search?" + params.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	resp, err := doPageGET(ctx, client, client.BaseURL()+"api/hotspots/search?"+params.Encode(), page)
 	if err != nil {
-		return nil, 0, fmt.Errorf("building hotspots request: %w", err)
-	}
-	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("fetching hotspots page %d: %w", page, err)
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("hotspots/search returned HTTP %d", resp.StatusCode)
-	}
 	var result struct {
 		Paging   pagingResult `json:"paging"`
 		Hotspots []Hotspot    `json:"hotspots"`
@@ -193,19 +197,11 @@ func fetchComponentMetricsPage(ctx context.Context, client *sqapi.Client, projec
 		"p":          {strconv.Itoa(page)},
 		"ps":         {strconv.Itoa(pageSize)},
 	}
-	u := client.BaseURL() + "api/measures/component_tree?" + params.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	resp, err := doPageGET(ctx, client, client.BaseURL()+"api/measures/component_tree?"+params.Encode(), page)
 	if err != nil {
-		return nil, 0, fmt.Errorf("building metrics request: %w", err)
-	}
-	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("fetching metrics page %d: %w", page, err)
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("measures/component_tree returned HTTP %d", resp.StatusCode)
-	}
 	var result struct {
 		Paging     pagingResult `json:"paging"`
 		Components []struct {
@@ -236,19 +232,11 @@ func fetchGroupsPage(ctx context.Context, client *sqapi.Client, page, pageSize i
 		"p":  {strconv.Itoa(page)},
 		"ps": {strconv.Itoa(pageSize)},
 	}
-	u := client.BaseURL() + "api/user_groups/search?" + params.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	resp, err := doPageGET(ctx, client, client.BaseURL()+"api/user_groups/search?"+params.Encode(), page)
 	if err != nil {
-		return nil, 0, fmt.Errorf("building groups request: %w", err)
-	}
-	resp, err := client.HTTPClient().Do(req)
-	if err != nil {
-		return nil, 0, fmt.Errorf("fetching groups page %d: %w", page, err)
+		return nil, 0, err
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("user_groups/search returned HTTP %d", resp.StatusCode)
-	}
 	var result struct {
 		Paging pagingResult `json:"paging"`
 		Groups []Group      `json:"groups"`


### PR DESCRIPTION
## Summary

- **`migrate/tasks_setup.go`**: Extract `csvMappingTask(name, csvFile)` factory — 7 identical 4-line closures replaced by single-line calls, file shrinks from 55 to 26 lines
- **`migrate/testutil_test.go`**: Add two shared helpers: `newCustomCloudTest(t, mux)` (mux+apiSrv+executor, no extract data) and `newDeleteTest(t, mux)` (mux+apiSrv+setupExtractData+executor+org seed)
- **`migrate/tasks_delete_test.go`**: Replace 12 identical 10-line setup blocks with `newDeleteTest`; remove unused `httptest` import
- **`migrate/tasks_settings_test.go`**: Replace 3 identical 7-line server+executor blocks with `newCustomCloudTest`; use `e.ExportDir` instead of a separate `dir` variable
- **`migrate/gate_metric_mapping_test.go`**: Replace 2 identical 7-line blocks with `newCustomCloudTest`; remove unused `httptest` import
- **`extract/debug_test.go`**: Extract `captureSlogDefault` helper, eliminating 4 identical lines in each of the 2 debug SDK tests
- **`pipeline/helpers.go`**: Extract `doPageGET` helper that handles the build+do+status-check sequence; removes the identical 9-line block from `fetchIssuesPage`, `fetchHotspotsPage`, `fetchComponentMetricsPage`, and `fetchGroupsPage`

## Test plan

- [ ] All Go tests pass: `go test ./...`
- [ ] Net −199 lines with no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)