### PR TITLE
refactor: third round of code deduplication

### DIFF
--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -117,9 +117,7 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 		mu.Unlock()
 		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	e := newCustomCloudTest(t, cloudMux)
 
 	// Mix of source metrics:
@@ -268,9 +266,7 @@ func TestAddGateConditionsCollapsesCollisions(t *testing.T) {
 		mu.Unlock()
 		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	e := newCustomCloudTest(t, cloudMux)
 
 	w, _ := e.Store.Writer("getGateConditions")

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -31,111 +31,54 @@ func newCreateTest(t *testing.T) (*Executor, string) {
 	return newTestExecutor(cloudSrv, apiSrv, dir), dir
 }
 
-func TestCreateProjects(t *testing.T) {
+// runCreateTask is a test helper that creates a fresh test environment, writes
+// the standard CSVs, runs the prerequisite mapping task, then executes the
+// named create task and returns its JSONL output. It fatals if the task errors
+// or produces no output — use the returned slice for extra field assertions.
+func runCreateTask(t *testing.T, mappingTask, createTask string) []json.RawMessage {
+	t.Helper()
 	e, dir := newCreateTest(t)
-
-	// Run setup task first.
 	setupCSVs(t, dir)
-	runTask(t, e, "generateProjectMappings")
-
-	// Run createProjects.
+	runTask(t, e, mappingTask)
 	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createProjects"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createProjects: %v", err)
+	if err := reg[createTask].Run(context.Background(), e); err != nil {
+		t.Fatalf("%s: %v", createTask, err)
 	}
-
-	items, _ := e.Store.ReadAll("createProjects")
+	items, _ := e.Store.ReadAll(createTask)
 	if len(items) == 0 {
-		t.Fatal("expected createProjects output")
+		t.Fatalf("expected %s output", createTask)
 	}
-	// Verify cloud_project_key was set.
-	key := extractField(items[0], "cloud_project_key")
-	if key == "" {
+	return items
+}
+
+func TestCreateProjects(t *testing.T) {
+	items := runCreateTask(t, "generateProjectMappings", "createProjects")
+	if key := extractField(items[0], "cloud_project_key"); key == "" {
 		t.Error("expected cloud_project_key to be set")
 	}
 }
 
 func TestCreateProfiles(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateProfileMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createProfiles"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createProfiles: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createProfiles")
-	if len(items) == 0 {
-		t.Fatal("expected createProfiles output")
-	}
-	profKey := extractField(items[0], "cloud_profile_key")
-	if profKey == "" {
+	items := runCreateTask(t, "generateProfileMappings", "createProfiles")
+	if profKey := extractField(items[0], "cloud_profile_key"); profKey == "" {
 		t.Error("expected cloud_profile_key")
 	}
 }
 
 func TestCreateGates(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateGateMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createGates"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createGates: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createGates")
-	if len(items) == 0 {
-		t.Fatal("expected createGates output")
-	}
-	gateID := extractField(items[0], "cloud_gate_id")
-	if gateID == "" {
+	items := runCreateTask(t, "generateGateMappings", "createGates")
+	if gateID := extractField(items[0], "cloud_gate_id"); gateID == "" {
 		t.Error("expected cloud_gate_id")
 	}
 }
 
 func TestCreateGroups(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateGroupMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createGroups"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createGroups: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createGroups")
-	if len(items) == 0 {
-		t.Fatal("expected createGroups output")
-	}
+	runCreateTask(t, "generateGroupMappings", "createGroups")
 }
 
 func TestCreatePermissionTemplates(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateTemplateMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createPermissionTemplates"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createPermissionTemplates: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createPermissionTemplates")
-	if len(items) == 0 {
-		t.Fatal("expected createPermissionTemplates output")
-	}
-	tplID := extractField(items[0], "cloud_template_id")
-	if tplID == "" {
+	items := runCreateTask(t, "generateTemplateMappings", "createPermissionTemplates")
+	if tplID := extractField(items[0], "cloud_template_id"); tplID == "" {
 		t.Error("expected cloud_template_id")
 	}
 }
@@ -240,43 +183,14 @@ func TestCreatePortfoliosReusesExisting(t *testing.T) {
 }
 
 func TestGetMigrationUser(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateOrganizationMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["getMigrationUser"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("getMigrationUser: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("getMigrationUser")
-	if len(items) == 0 {
-		t.Fatal("expected getMigrationUser output")
-	}
-	login := extractField(items[0], "login")
-	if login != "migration-user" {
+	items := runCreateTask(t, "generateOrganizationMappings", "getMigrationUser")
+	if login := extractField(items[0], "login"); login != "migration-user" {
 		t.Errorf("expected login=migration-user, got %q", login)
 	}
 }
 
 func TestGetEnterprises(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateOrganizationMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["getEnterprises"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("getEnterprises: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("getEnterprises")
-	if len(items) == 0 {
-		t.Fatal("expected getEnterprises output")
-	}
+	runCreateTask(t, "generateOrganizationMappings", "getEnterprises")
 }
 
 func TestGetProjectIds(t *testing.T) {
@@ -299,21 +213,7 @@ func TestGetProjectIds(t *testing.T) {
 }
 
 func TestGetOrgRepos(t *testing.T) {
-	e, dir := newCreateTest(t)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateOrganizationMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["getOrgRepos"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("getOrgRepos: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("getOrgRepos")
-	if len(items) == 0 {
-		t.Fatal("expected getOrgRepos output")
-	}
+	runCreateTask(t, "generateOrganizationMappings", "getOrgRepos")
 }
 
 // --- Already-exists idempotency tests ---

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -42,9 +42,7 @@ func runGlobalSettingsTest(t *testing.T,
 	cloudMux := http.NewServeMux()
 	muHits, hitsPtr := mountSettingsSetCapture(cloudMux)
 	mountSettingsDefinitions(cloudMux, sqcDefs...)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	cloudSrv := httptest.NewServer(cloudMux)
 	t.Cleanup(cloudSrv.Close)
 
@@ -62,12 +60,12 @@ func runGlobalSettingsTest(t *testing.T,
 	// would silently leave the production read path empty and the test
 	// would be exercising a different code path than reality. Drop the
 	// records into the configured extract directory instead.
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", sqsSettings)
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", sqsDefs)
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", sqsSettings)
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", sqsDefs)
 	// extract.json is what GetUniqueExtracts inspects to assemble the
 	// ExtractMapping; without it readExtractItems can't resolve the
 	// extract dir for a server URL.
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	// generateOrganizationMappings IS produced by the migrate phase, so
 	// it correctly lives in the migrate store.
 	writeTaskJSONL(t, e, "generateOrganizationMappings", orgs)
@@ -273,29 +271,20 @@ func TestRunSetGlobalSettingsUsesProjectScopeOnlyReasonWhenKeyAtProjectScope(t *
 			{"key": "sonar.java.file.suffixes", "type": "STRING", "multiValues": false},
 		},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 	var logBuf bytes.Buffer
 	// Capture Info + Warn so the test can assert the Info case fires
 	// and the Warn case does NOT.
 	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.java.file.suffixes", "values": []string{".java", ".jav"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.java.file.suffixes", "type": "STRING", "multiValues": false, "defaultValue": ".java"},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "org1"},
 	})
@@ -381,30 +370,21 @@ func TestRunSetGlobalSettingsFallsBackToProjectsOnOrgLevelRejection(t *testing.T
 			{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true},
 		},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 	var logBuf bytes.Buffer
 	// LevelDebug because the "key not settable at org level" log was
 	// demoted to Debug in this PR (per-key-per-org fires too often
 	// at normal verbosity).
 	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "values": []string{"**/jacoco*.xml"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "org1"},
 	})
@@ -503,29 +483,20 @@ func TestRunSetGlobalSettingsOrgLevelRejectionTriedOncePerKey(t *testing.T) {
 		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
 		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 	var logBuf bytes.Buffer
 	// The memoization log was demoted to Debug in #258 — open the
 	// logger to Debug so the assertion below still picks it up.
 	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "values": []string{"**/jacoco*.xml"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	// Three orgs, one project each. The first org's POST rejects;
 	// the next two orgs must NOT re-issue the failing org POST.
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
@@ -592,32 +563,23 @@ func TestRunSetGlobalSettingsFanOutSkipsPerProjectOverrides(t *testing.T) {
 		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
 		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 	var logBuf bytes.Buffer
 	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	// SQS extract: per-project override for projA only.
-	writeExtractTaskJSONL(t, dir, "extract-01", "getProjectSettings", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getProjectSettings", []map[string]any{
 		{"project": "projA", "key": "sonar.coverage.jacoco.xmlReportPaths",
 			"values": []string{"specific-for-A.xml"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "values": []string{"global-default.xml"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "org1"},
 	})
@@ -690,27 +652,18 @@ func TestRunSetGlobalSettingsFanOutRetriesIndexingNotFound(t *testing.T) {
 		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
 		[]map[string]any{{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true}},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 	var logBuf bytes.Buffer
 	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "values": []string{"**/jacoco*.xml"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "org1"},
 	})
@@ -980,23 +933,15 @@ func TestRunSetGlobalSettingsFanOutAllFailedRendersAsFailed(t *testing.T) {
 		[]map[string]any{{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true}},
 		[]map[string]any{{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true}},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.html.file.suffixes", "values": []string{".html", ".xhtml"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "org1"},
 	})
@@ -1068,23 +1013,15 @@ func TestRunSetGlobalSettingsFanOutPartialRendersAsPartial(t *testing.T) {
 		[]map[string]any{{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true}},
 		[]map[string]any{{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true}},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		{"key": "sonar.html.file.suffixes", "values": []string{".html"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "org1"},
 	})
@@ -1419,28 +1356,20 @@ func TestRunSetGlobalSettingsSQSOnlyNoteFiresEvenAtSQSDefault(t *testing.T) {
 	cloudMux := http.NewServeMux()
 	_, _ = mountSettingsSetCapture(cloudMux)
 	mountSettingsDefinitions(cloudMux)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		// value matches parentValue — isSettingCustomized's #196
 		// fix would discard this if it ran first. The SQS-only
 		// interceptor must catch it before that.
 		{"key": "sonar.qualityProfiles.allowDisableInheritedRules",
 			"value": "true", "parentValue": "true"},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.qualityProfiles.allowDisableInheritedRules",
 			"type": "BOOLEAN", "defaultValue": "true"},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "orgA"},
 	})
@@ -1494,29 +1423,21 @@ func TestRunSetGlobalSettingsInterceptsSQSOnlyKeys(t *testing.T) {
 		// handler for them anyway.
 		map[string]any{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettings", []map[string]any{
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettings", []map[string]any{
 		// Two SQS-only keys: one silent, one with a note.
 		{"key": "sonar.core.serverBaseURL", "value": "https://my-sonar.example.com"},
 		{"key": "sonar.technicalDebt.ratingGrid", "value": "0.03,0.07,0.2,0.5"},
 		// One legit customization that SHOULD be migrated.
 		{"key": "sonar.exclusions", "values": []string{"**/*.gen"}},
 	})
-	writeExtractTaskJSONL(t, dir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
+	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.core.serverBaseURL", "type": "STRING", "defaultValue": ""},
 		{"key": "sonar.technicalDebt.ratingGrid", "type": "STRING", "defaultValue": "0.05,0.1,0.2,0.5"},
 		{"key": "sonar.exclusions", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, dir, "extract-01", testServerURL)
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
 	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
 		{"sonarcloud_org_key": "orgA"},
 		{"sonarcloud_org_key": "orgB"},

--- a/go/internal/migrate/tasks_settings_test.go
+++ b/go/internal/migrate/tasks_settings_test.go
@@ -94,9 +94,7 @@ func TestRunSetProjectSettingsDispatchesByShape(t *testing.T) {
 	// Empty definitions registry so EVERY setting falls back to extract
 	// shape — that's exactly what this test exercises.
 	mountSettingsDefinitions(cloudMux)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	e := newCustomCloudTest(t, cloudMux)
 
 	extractDir := filepath.Join(e.ExportDir, "extract-01", "getProjectSettings")
@@ -202,9 +200,7 @@ func TestRunSetProjectSettingsRespectsSQCDefinitions(t *testing.T) {
 		map[string]any{"key": "sonar.exclusions", "type": "STRING", "multiValues": true},
 		map[string]any{"key": "sonar.issue.ignore.allfile", "type": "PROPERTY_SET", "multiValues": false},
 	)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	e := newCustomCloudTest(t, cloudMux)
 
 	extractDir := filepath.Join(e.ExportDir, "extract-01", "getProjectSettings")
@@ -297,9 +293,7 @@ func TestRunSetProjectSettingsRespectsSQCDefinitions(t *testing.T) {
 func TestRunSetProjectSettingsWarnsOnUnmappedProject(t *testing.T) {
 	cloudMux := http.NewServeMux()
 	mountSettingsDefinitions(cloudMux)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	e := newCustomCloudTest(t, cloudMux)
 	// Capture Warn output so the test can assert on it.
 	var buf bytes.Buffer
@@ -368,9 +362,7 @@ func runProjectSettingsPropagationTest(t *testing.T,
 	cloudMux := http.NewServeMux()
 	muHits, hitsPtr := mountSettingsSetCapture(cloudMux)
 	mountSettingsDefinitionsScoped(cloudMux, orgDefs, projectDefs)
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	cloudSrv := httptest.NewServer(cloudMux)
 	t.Cleanup(cloudSrv.Close)
 

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -530,6 +530,15 @@ func writeJSON(path string, data any) {
 	os.WriteFile(path, b, 0o644)
 }
 
+// addDefaultCloudHandler installs a catch-all GET handler that responds with an
+// empty JSON object. Mount this on a cloudMux after all specific handlers so
+// that any unexpected endpoint gets a safe no-op response instead of a 404.
+func addDefaultCloudHandler(mux *http.ServeMux) {
+	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	})
+}
+
 // newCustomCloudTest wires a test environment with a caller-supplied cloudMux,
 // a fresh mock API server, a temp export dir, and a new Executor. It does NOT
 // call setupExtractData — use this for tasks whose extract data is written

--- a/go/internal/regtest/checks.go
+++ b/go/internal/regtest/checks.go
@@ -114,27 +114,34 @@ func checkProjectIdentity(ctx context.Context, s *Suite) []CheckResult {
 
 // ── Issues ────────────────────────────────────────────────────────────
 
-func checkIssueTotals(ctx context.Context, s *Suite) []CheckResult {
-	projects, err := s.getProjects(ctx)
-	if err != nil {
-		return []CheckResult{makeError("Issues", "Total count", err)}
-	}
-	var results []CheckResult
-	for _, proj := range projects {
-		sqsCount, err := queryTotal(ctx, s.sqsRaw, "api/issues/search", urlParams("projectKeys", proj))
+// totalsByProject returns a check function that queries api on both sides
+// using sqsParam/scParam as the project-key query parameter, comparing
+// total item counts per project.
+func totalsByProject(category, api, sqsParam, scParam string) func(context.Context, *Suite) []CheckResult {
+	return func(ctx context.Context, s *Suite) []CheckResult {
+		projects, err := s.getProjects(ctx)
 		if err != nil {
-			results = append(results, makeError("Issues", fmt.Sprintf("Total: %s", proj), err))
-			continue
+			return []CheckResult{makeError(category, "Total count", err)}
 		}
-		scCount, err := queryTotal(ctx, s.scRaw, "api/issues/search", urlParams("projects", s.scProjectKey(proj)))
-		if err != nil {
-			results = append(results, makeError("Issues", fmt.Sprintf("Total: %s", proj), err))
-			continue
+		var results []CheckResult
+		for _, proj := range projects {
+			sqsCount, err := queryTotal(ctx, s.sqsRaw, api, urlParams(sqsParam, proj))
+			if err != nil {
+				results = append(results, makeError(category, fmt.Sprintf("Total: %s", proj), err))
+				continue
+			}
+			scCount, err := queryTotal(ctx, s.scRaw, api, urlParams(scParam, s.scProjectKey(proj)))
+			if err != nil {
+				results = append(results, makeError(category, fmt.Sprintf("Total: %s", proj), err))
+				continue
+			}
+			results = append(results, makeResult(category, fmt.Sprintf("Total: %s", proj), sqsCount, scCount, "Exact"))
 		}
-		results = append(results, makeResult("Issues", fmt.Sprintf("Total: %s", proj), sqsCount, scCount, "Exact"))
+		return results
 	}
-	return results
 }
+
+var checkIssueTotals = totalsByProject("Issues", "api/issues/search", "projectKeys", "projects")
 
 func checkIssueDistribution(filterKey, filterValue string) func(ctx context.Context, s *Suite) []CheckResult {
 	return func(ctx context.Context, s *Suite) []CheckResult {
@@ -165,27 +172,7 @@ func checkIssueDistribution(filterKey, filterValue string) func(ctx context.Cont
 
 // ── Hotspots ──────────────────────────────────────────────────────────
 
-func checkHotspotTotals(ctx context.Context, s *Suite) []CheckResult {
-	projects, err := s.getProjects(ctx)
-	if err != nil {
-		return []CheckResult{makeError("Hotspots", "Total count", err)}
-	}
-	var results []CheckResult
-	for _, proj := range projects {
-		sqsCount, err := queryTotal(ctx, s.sqsRaw, "api/hotspots/search", urlParams("projectKey", proj))
-		if err != nil {
-			results = append(results, makeError("Hotspots", fmt.Sprintf("Total: %s", proj), err))
-			continue
-		}
-		scCount, err := queryTotal(ctx, s.scRaw, "api/hotspots/search", urlParams("projectKey", s.scProjectKey(proj)))
-		if err != nil {
-			results = append(results, makeError("Hotspots", fmt.Sprintf("Total: %s", proj), err))
-			continue
-		}
-		results = append(results, makeResult("Hotspots", fmt.Sprintf("Total: %s", proj), sqsCount, scCount, "Exact"))
-	}
-	return results
-}
+var checkHotspotTotals = totalsByProject("Hotspots", "api/hotspots/search", "projectKey", "projectKey")
 
 func checkHotspotByStatus(status string) func(ctx context.Context, s *Suite) []CheckResult {
 	return func(ctx context.Context, s *Suite) []CheckResult {


### PR DESCRIPTION
## Summary

- **`migrate/testutil_test.go`**: Add `addDefaultCloudHandler(mux)` helper for the 3-line catch-all JSON empty-response handler, used 16 times across three test files
- **`migrate/tasks_setglobalsettings_test.go`**: Replace 9 manual `cloudSrv+apiSrv+dir+executor` blocks with `newCustomCloudTest`; replace all 10 inline default-handler closures with `addDefaultCloudHandler`; replace `dir` variable with `e.ExportDir` throughout
- **`migrate/tasks_settings_test.go`**: Replace 4 default-handler closures with `addDefaultCloudHandler`
- **`migrate/gate_metric_mapping_test.go`**: Replace 2 default-handler closures with `addDefaultCloudHandler`
- **`migrate/tasks_create_test.go`**: Add `runCreateTask(t, mapTask, createTask)` helper; collapse 8 tests (`TestCreateProjects/Profiles/Gates/Groups/PermissionTemplates`, `TestGetMigrationUser/Enterprises/OrgRepos`) from 10–12 lines each to 1–3 lines
- **`regtest/checks.go`**: Extract `totalsByProject(category, api, sqsParam, scParam)` factory; `checkIssueTotals` and `checkHotspotTotals` — formerly two 18-line identical functions — become one-line `var` declarations

## Test plan

- [ ] All Go tests pass: `go test ./...`
- [ ] Net −195 lines with no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)