### PR TITLE
refactor: fourth round of code deduplication

### DIFF
--- a/go/internal/extract/extract_test.go
+++ b/go/internal/extract/extract_test.go
@@ -346,6 +346,17 @@ func newMockServer() *httptest.Server {
 	return httptest.NewServer(mux)
 }
 
+// firstExtractDir returns the path of the first subdirectory created under dir
+// by a RunExtract call, fataling if none exists. This is the extract run dir.
+func firstExtractDir(t *testing.T, dir string) string {
+	t.Helper()
+	entries, _ := os.ReadDir(dir)
+	if len(entries) == 0 {
+		t.Fatal("expected extract run directory under export dir")
+	}
+	return filepath.Join(dir, entries[0].Name())
+}
+
 // TestRunExtractIntegration runs a small extract with a mock SonarQube server.
 func TestRunExtractIntegration(t *testing.T) {
 	srv := newMockServer()
@@ -362,11 +373,7 @@ func TestRunExtractIntegration(t *testing.T) {
 		t.Fatalf("RunExtract failed: %v", err)
 	}
 
-	entries, _ := os.ReadDir(dir)
-	if len(entries) == 0 {
-		t.Fatal("expected extract directory to be created")
-	}
-	extractDir := filepath.Join(dir, entries[0].Name())
+	extractDir := firstExtractDir(t, dir)
 
 	// Verify extract.json metadata.
 	metaData, err := os.ReadFile(filepath.Join(extractDir, "extract.json"))
@@ -405,11 +412,7 @@ func TestRunExtractFull(t *testing.T) {
 		t.Fatalf("RunExtract (full) failed: %v", err)
 	}
 
-	entries, _ := os.ReadDir(dir)
-	if len(entries) == 0 {
-		t.Fatal("expected extract directory")
-	}
-	extractDir := filepath.Join(dir, entries[0].Name())
+	extractDir := firstExtractDir(t, dir)
 
 	// Verify key task output directories exist.
 	expectedTasks := []string{
@@ -572,11 +575,7 @@ func TestRunExtractAiCodeFixSkippedOnOldSQS(t *testing.T) {
 		t.Error("api/v2/fix-suggestions/feature-enablements was called; task should skip on SQS < 2025.3")
 	}
 
-	entries, _ := os.ReadDir(dir)
-	if len(entries) == 0 {
-		t.Fatal("expected extract run directory")
-	}
-	extractDir := filepath.Join(dir, entries[0].Name())
+	extractDir := firstExtractDir(t, dir)
 	if _, err := os.Stat(filepath.Join(extractDir, "getAiCodeFixConfig")); !os.IsNotExist(err) {
 		t.Errorf("getAiCodeFixConfig directory should not exist on SQS < 2025.3, got err=%v", err)
 	}

--- a/go/internal/migrate/gate_metric_mapping_test.go
+++ b/go/internal/migrate/gate_metric_mapping_test.go
@@ -95,21 +95,24 @@ func TestLookupMetricReplacement(t *testing.T) {
 	}
 }
 
-// TestAddGateConditionsAppliesMetricMapping exercises the end-to-end path:
-// source conditions on mapped/unmapped/dropped metrics, asserting the
-// CreateCondition payloads (metric + op + threshold) the migrator actually
-// sends to SQC.
-func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
-	type call struct{ metric, op, errVal string }
+// conditionCall captures a single POST /api/qualitygates/create_condition
+// request for assertion.
+type conditionCall struct{ metric, op, errVal string }
+
+// mountCreateConditionCapture installs a create_condition handler that records
+// every call into the returned slice (guarded by the returned mutex), and
+// returns a fresh Executor wired to that mux.
+func mountCreateConditionCapture(t *testing.T) (*Executor, *sync.Mutex, *[]conditionCall) {
+	t.Helper()
 	var (
 		mu       sync.Mutex
-		recorded []call
+		recorded []conditionCall
 	)
 	cloudMux := http.NewServeMux()
 	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
 		_ = r.ParseForm()
 		mu.Lock()
-		recorded = append(recorded, call{
+		recorded = append(recorded, conditionCall{
 			metric: r.FormValue("metric"),
 			op:     r.FormValue("op"),
 			errVal: r.FormValue("error"),
@@ -118,7 +121,11 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
 	})
 	addDefaultCloudHandler(cloudMux)
-	e := newCustomCloudTest(t, cloudMux)
+	return newCustomCloudTest(t, cloudMux), &mu, &recorded
+}
+
+func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
+	e, mu, recPtr := mountCreateConditionCapture(t)
 
 	// Mix of source metrics:
 	//  - coverage (unmapped, pass-through, preserves source op/error)
@@ -147,6 +154,7 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	recorded := *recPtr
 
 	// Expected: 1 (coverage, LT 80) + 1 (new_security_rating, inherited GT 1)
 	//         + 2 (security_rating GT 4, reliability_rating GT 4)
@@ -155,7 +163,7 @@ func TestAddGateConditionsAppliesMetricMapping(t *testing.T) {
 		t.Fatalf("expected 4 create_condition calls, got %d: %+v", len(recorded), recorded)
 	}
 
-	want := map[string]call{
+	want := map[string]conditionCall{
 		"coverage":            {metric: "coverage", op: "LT", errVal: "80"},
 		"new_security_rating": {metric: "new_security_rating", op: "GT", errVal: "1"},
 		"security_rating":     {metric: "security_rating", op: "GT", errVal: "4"},
@@ -249,25 +257,7 @@ func TestIsObviousMetricRemap(t *testing.T) {
 //   - security_rating GT 2     (medium beats blocker)
 //   - reliability_rating GT 2  (direct == medium, ties — first wins; same value)
 func TestAddGateConditionsCollapsesCollisions(t *testing.T) {
-	type call struct{ metric, op, errVal string }
-	var (
-		mu       sync.Mutex
-		recorded []call
-	)
-	cloudMux := http.NewServeMux()
-	cloudMux.HandleFunc("POST /api/qualitygates/create_condition", func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		mu.Lock()
-		recorded = append(recorded, call{
-			metric: r.FormValue("metric"),
-			op:     r.FormValue("op"),
-			errVal: r.FormValue("error"),
-		})
-		mu.Unlock()
-		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
-	})
-	addDefaultCloudHandler(cloudMux)
-	e := newCustomCloudTest(t, cloudMux)
+	e, mu, recPtr := mountCreateConditionCapture(t)
 
 	w, _ := e.Store.Writer("getGateConditions")
 	payload := map[string]any{
@@ -290,11 +280,12 @@ func TestAddGateConditionsCollapsesCollisions(t *testing.T) {
 
 	mu.Lock()
 	defer mu.Unlock()
+	recorded := *recPtr
 
 	if len(recorded) != 2 {
 		t.Fatalf("expected 2 create_condition calls after collapse, got %d: %+v", len(recorded), recorded)
 	}
-	want := map[string]call{
+	want := map[string]conditionCall{
 		"security_rating":    {metric: "security_rating", op: "GT", errVal: "2"},
 		"reliability_rating": {metric: "reliability_rating", op: "GT", errVal: "2"},
 	}

--- a/go/internal/migrate/tasks_create_test.go
+++ b/go/internal/migrate/tasks_create_test.go
@@ -216,30 +216,28 @@ func TestGetOrgRepos(t *testing.T) {
 	runCreateTask(t, "generateOrganizationMappings", "getOrgRepos")
 }
 
+// runAlreadyExistsTask is like runCreateTask but uses the already-exists cloud
+// server — covering re-run idempotency paths where resources already exist.
+func runAlreadyExistsTask(t *testing.T, mappingTask, createTask string) []json.RawMessage {
+	t.Helper()
+	e, dir := newAlreadyExistsTest(t)
+	setupCSVs(t, dir)
+	runTask(t, e, mappingTask)
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg[createTask].Run(context.Background(), e); err != nil {
+		t.Fatalf("%s: %v", createTask, err)
+	}
+	items, _ := e.Store.ReadAll(createTask)
+	if len(items) == 0 {
+		t.Fatalf("expected %s output on re-run", createTask)
+	}
+	return items
+}
+
 // --- Already-exists idempotency tests ---
 
 func TestCreateProjects_AlreadyExists(t *testing.T) {
-	cloudSrv := newAlreadyExistsCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateProjectMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createProjects"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createProjects: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createProjects")
-	if len(items) == 0 {
-		t.Fatal("expected createProjects output on re-run")
-	}
+	items := runAlreadyExistsTask(t, "generateProjectMappings", "createProjects")
 	key := extractField(items[0], "cloud_project_key")
 	if key == "" {
 		t.Error("expected cloud_project_key to be set from derived key")
@@ -298,113 +296,29 @@ func TestCreateProjects_AlreadyExistsInDifferentOrg(t *testing.T) {
 }
 
 func TestCreateProfiles_AlreadyExists(t *testing.T) {
-	cloudSrv := newAlreadyExistsCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateProfileMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createProfiles"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createProfiles: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createProfiles")
-	if len(items) == 0 {
-		t.Fatal("expected createProfiles output on re-run")
-	}
-	profKey := extractField(items[0], "cloud_profile_key")
-	if profKey != "existing-prof-key" {
+	items := runAlreadyExistsTask(t, "generateProfileMappings", "createProfiles")
+	if profKey := extractField(items[0], "cloud_profile_key"); profKey != "existing-prof-key" {
 		t.Errorf("expected existing-prof-key, got %q", profKey)
 	}
 }
 
 func TestCreateGates_AlreadyExists(t *testing.T) {
-	cloudSrv := newAlreadyExistsCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateGateMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createGates"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createGates: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createGates")
-	if len(items) == 0 {
-		t.Fatal("expected createGates output on re-run")
-	}
-	gateID := extractField(items[0], "cloud_gate_id")
-	if gateID != "99" {
+	items := runAlreadyExistsTask(t, "generateGateMappings", "createGates")
+	if gateID := extractField(items[0], "cloud_gate_id"); gateID != "99" {
 		t.Errorf("expected gate ID 99, got %q", gateID)
 	}
 }
 
 func TestCreateGroups_AlreadyExists(t *testing.T) {
-	cloudSrv := newAlreadyExistsCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateGroupMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createGroups"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createGroups: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createGroups")
-	if len(items) == 0 {
-		t.Fatal("expected createGroups output on re-run")
-	}
-	groupID := extractField(items[0], "cloud_group_id")
-	if groupID != "77" {
+	items := runAlreadyExistsTask(t, "generateGroupMappings", "createGroups")
+	if groupID := extractField(items[0], "cloud_group_id"); groupID != "77" {
 		t.Errorf("expected group ID 77, got %q", groupID)
 	}
 }
 
 func TestCreatePermissionTemplates_AlreadyExists(t *testing.T) {
-	cloudSrv := newAlreadyExistsCloudServer()
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-	dir := t.TempDir()
-	setupExtractData(dir)
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
-
-	setupCSVs(t, dir)
-	runTask(t, e, "generateTemplateMappings")
-
-	reg := BuildMigrateRegistry(RegisterAll())
-	err := reg["createPermissionTemplates"].Run(context.Background(), e)
-	if err != nil {
-		t.Fatalf("createPermissionTemplates: %v", err)
-	}
-
-	items, _ := e.Store.ReadAll("createPermissionTemplates")
-	if len(items) == 0 {
-		t.Fatal("expected createPermissionTemplates output on re-run")
-	}
-	tplID := extractField(items[0], "cloud_template_id")
-	if tplID != "existing-tpl-id" {
+	items := runAlreadyExistsTask(t, "generateTemplateMappings", "createPermissionTemplates")
+	if tplID := extractField(items[0], "cloud_template_id"); tplID != "existing-tpl-id" {
 		t.Errorf("expected existing-tpl-id, got %q", tplID)
 	}
 }

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -367,16 +367,8 @@ func TestGrantMigrationUserProjectPermissions(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 	// getMigrationUser → login.
 	uw, _ := e.Store.Writer("getMigrationUser")
 	uw.WriteOne([]byte(`{"login":"migration-bot","name":"Migration Bot"}`))

--- a/go/internal/migrate/tasks_gate_override_test.go
+++ b/go/internal/migrate/tasks_gate_override_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"sync"
 	"testing"
 
@@ -60,17 +59,8 @@ func TestAddGateConditionsOverrideClearsExisting(t *testing.T) {
 		mu.Unlock()
 		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 
 	// Pre-existing gate "Custom Gate" — was_preexisting=true.
 	w, _ := e.Store.Writer("getGateConditions")
@@ -131,17 +121,8 @@ func TestAddGateConditionsFreshGateSkipsClear(t *testing.T) {
 		_ = r.ParseForm()
 		_ = json.NewEncoder(w).Encode(types.QualityGateCondition{ID: 1, Metric: r.FormValue("metric")})
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
-	cloudSrv := httptest.NewServer(cloudMux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
 
 	w, _ := e.Store.Writer("getGateConditions")
 	payload := map[string]any{

--- a/go/internal/migrate/tasks_newcode_test.go
+++ b/go/internal/migrate/tasks_newcode_test.go
@@ -56,9 +56,7 @@ func runSetGlobalNCDTest(t *testing.T, ncd map[string]any, orgs []map[string]any
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"organizations": out})
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	cloudSrv := httptest.NewServer(cloudMux)
 	t.Cleanup(cloudSrv.Close)
 
@@ -175,9 +173,7 @@ func TestRunSetGlobalNewCodePeriodEmitsReportRecord(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{"organizations": out})
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	cloudSrv := httptest.NewServer(cloudMux)
 	defer cloudSrv.Close()
 
@@ -341,9 +337,7 @@ func TestRunSetNewCodePeriodsTranslatesAndSets(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudMux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{})
-	})
+	addDefaultCloudHandler(cloudMux)
 	cloudSrv := httptest.NewServer(cloudMux)
 	defer cloudSrv.Close()
 

--- a/go/internal/migrate/tasks_setglobalsettings_test.go
+++ b/go/internal/migrate/tasks_setglobalsettings_test.go
@@ -284,10 +284,7 @@ func TestRunSetGlobalSettingsUsesProjectScopeOnlyReasonWhenKeyAtProjectScope(t *
 	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.java.file.suffixes", "type": "STRING", "multiValues": false, "defaultValue": ".java"},
 	})
-	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
-	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
-		{"sonarcloud_org_key": "org1"},
-	})
+	writeGlobalSettingsOrg(t, e)
 	// createProjects record so loadProjectScopedSettingDefinitionsForOrgs
 	// has a probe project to query SQC with component=.
 	pw, _ := e.Store.Writer("createProjects")
@@ -384,10 +381,7 @@ func TestRunSetGlobalSettingsFallsBackToProjectsOnOrgLevelRejection(t *testing.T
 	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
-	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
-		{"sonarcloud_org_key": "org1"},
-	})
+	writeGlobalSettingsOrg(t, e)
 	// Two projects in the org — both should receive the fan-out call.
 	pw, _ := e.Store.Writer("createProjects")
 	for _, key := range []string{"projA", "projB"} {
@@ -579,10 +573,7 @@ func TestRunSetGlobalSettingsFanOutSkipsPerProjectOverrides(t *testing.T) {
 	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
-	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
-		{"sonarcloud_org_key": "org1"},
-	})
+	writeGlobalSettingsOrg(t, e)
 	pw, _ := e.Store.Writer("createProjects")
 	for _, key := range []string{"projA", "projB"} {
 		b, _ := json.Marshal(map[string]any{
@@ -663,10 +654,7 @@ func TestRunSetGlobalSettingsFanOutRetriesIndexingNotFound(t *testing.T) {
 	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.coverage.jacoco.xmlReportPaths", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
-	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
-		{"sonarcloud_org_key": "org1"},
-	})
+	writeGlobalSettingsOrg(t, e)
 	pw, _ := e.Store.Writer("createProjects")
 	for _, key := range []string{"projA", "projB"} {
 		b, _ := json.Marshal(map[string]any{
@@ -941,10 +929,7 @@ func TestRunSetGlobalSettingsFanOutAllFailedRendersAsFailed(t *testing.T) {
 	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
-	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
-		{"sonarcloud_org_key": "org1"},
-	})
+	writeGlobalSettingsOrg(t, e)
 	pw, _ := e.Store.Writer("createProjects")
 	for _, key := range []string{"projA", "projB"} {
 		b, _ := json.Marshal(map[string]any{
@@ -1021,10 +1006,7 @@ func TestRunSetGlobalSettingsFanOutPartialRendersAsPartial(t *testing.T) {
 	writeExtractTaskJSONL(t, e.ExportDir, "extract-01", "getServerSettingsDefinitions", []map[string]any{
 		{"key": "sonar.html.file.suffixes", "type": "STRING", "multiValues": true, "defaultValue": ""},
 	})
-	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
-	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
-		{"sonarcloud_org_key": "org1"},
-	})
+	writeGlobalSettingsOrg(t, e)
 	pw, _ := e.Store.Writer("createProjects")
 	for _, key := range []string{"projA", "projB"} {
 		b, _ := json.Marshal(map[string]any{

--- a/go/internal/migrate/testutil_test.go
+++ b/go/internal/migrate/testutil_test.go
@@ -553,6 +553,30 @@ func newCustomCloudTest(t *testing.T, cloudMux *http.ServeMux) *Executor {
 	return newTestExecutor(cloudSrv, apiSrv, dir)
 }
 
+// newAlreadyExistsTest is like newCreateTest but uses newAlreadyExistsCloudServer
+// instead of newMockCloudServer — covering the already-exists idempotency paths.
+func newAlreadyExistsTest(t *testing.T) (*Executor, string) {
+	t.Helper()
+	cloudSrv := newAlreadyExistsCloudServer()
+	t.Cleanup(cloudSrv.Close)
+	apiSrv := newMockAPIServer()
+	t.Cleanup(apiSrv.Close)
+	dir := t.TempDir()
+	setupExtractData(dir)
+	return newTestExecutor(cloudSrv, apiSrv, dir), dir
+}
+
+// writeGlobalSettingsOrg writes the shared boilerplate needed by custom
+// setGlobalSettings tests: the extract.json metadata for extract-01 and a
+// single generateOrganizationMappings row for org1.
+func writeGlobalSettingsOrg(t *testing.T, e *Executor) {
+	t.Helper()
+	writeExtractMetaJSON(t, e.ExportDir, "extract-01", testServerURL)
+	writeTaskJSONL(t, e, "generateOrganizationMappings", []map[string]any{
+		{"sonarcloud_org_key": "org1"},
+	})
+}
+
 // newDeleteTest wires a test environment for delete/reset tasks: mock servers,
 // extract data, an Executor, and a pre-seeded generateOrganizationMappings row
 // for testCloudOrg. Servers are closed via t.Cleanup.

--- a/go/internal/migrate/timing_log_test.go
+++ b/go/internal/migrate/timing_log_test.go
@@ -12,12 +12,21 @@ import (
 	"testing"
 )
 
+// newTimingTestEnv creates the shared executor + log buffer + RunTimings used
+// by all timing_log tests.
+func newTimingTestEnv(t *testing.T) (*Executor, *bytes.Buffer, *RunTimings) {
+	t.Helper()
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	e := &Executor{Sem: make(chan struct{}, 4), Logger: logger}
+	return e, &buf, &RunTimings{}
+}
+
 // Issue #311: runPhase must emit a "Task <name>: Duration hh:mm:ss.xxx"
 // INFO line at the end of every task, on both the success and failure
 // paths.
 func TestRunPhaseEmitsTaskDurationLog(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	e, buf, tm := newTimingTestEnv(t)
 
 	registry := map[string]*TaskDef{
 		"quickTask": {
@@ -27,12 +36,6 @@ func TestRunPhaseEmitsTaskDurationLog(t *testing.T) {
 			},
 		},
 	}
-
-	e := &Executor{
-		Sem:    make(chan struct{}, 4),
-		Logger: logger,
-	}
-	tm := &RunTimings{}
 
 	if err := runPhase(context.Background(), e, []string{"quickTask"}, registry, 1, tm); err != nil {
 		t.Fatalf("runPhase: %v", err)
@@ -49,8 +52,7 @@ func TestRunPhaseEmitsTaskDurationLog(t *testing.T) {
 // emits one combined "task summary" line carrying counts + duration
 // instead of the previous separate summary + duration pair.
 func TestRunPhaseEmitsMergedSummaryWhenCounterRecorded(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	e, buf, tm := newTimingTestEnv(t)
 
 	registry := map[string]*TaskDef{
 		"countingTask": {
@@ -64,12 +66,6 @@ func TestRunPhaseEmitsMergedSummaryWhenCounterRecorded(t *testing.T) {
 			},
 		},
 	}
-
-	e := &Executor{
-		Sem:    make(chan struct{}, 4),
-		Logger: logger,
-	}
-	tm := &RunTimings{}
 
 	if err := runPhase(context.Background(), e, []string{"countingTask"}, registry, 1, tm); err != nil {
 		t.Fatalf("runPhase: %v", err)
@@ -97,8 +93,7 @@ func TestRunPhaseEmitsMergedSummaryWhenCounterRecorded(t *testing.T) {
 // On failure the task still gets a closing duration line — the
 // log bookend must not depend on success.
 func TestRunPhaseEmitsTaskDurationLogOnFailure(t *testing.T) {
-	var buf bytes.Buffer
-	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	e, buf, tm := newTimingTestEnv(t)
 
 	registry := map[string]*TaskDef{
 		"failingTask": {
@@ -108,12 +103,6 @@ func TestRunPhaseEmitsTaskDurationLogOnFailure(t *testing.T) {
 			},
 		},
 	}
-
-	e := &Executor{
-		Sem:    make(chan struct{}, 4),
-		Logger: logger,
-	}
-	tm := &RunTimings{}
 
 	// Expect runPhase to surface the error.
 	if err := runPhase(context.Background(), e, []string{"failingTask"}, registry, 1, tm); err == nil {


### PR DESCRIPTION
## Summary

Guided by SonarCloud duplication report (top files ranked by % duplication × line count):

- **`migrate/testutil_test.go`**: Add three new helpers — `newAlreadyExistsTest` (mirrors `newCreateTest` with `newAlreadyExistsCloudServer`), `runAlreadyExistsTask` (mirrors `runCreateTask` for re-run idempotency tests), and `writeGlobalSettingsOrg` (writes the shared extract-01 meta + org mapping row repeated in every custom setGlobalSettings test)
- **`migrate/tasks_create_test.go`**: Collapse 5 `AlreadyExists` tests from ~20 lines each to 3 lines using `runAlreadyExistsTask`
- **`migrate/timing_log_test.go`**: Extract `newTimingTestEnv(t)` helper; 3 tests each shed their identical 6-line `buf+logger+executor+RunTimings` setup
- **`migrate/gate_metric_mapping_test.go`**: Extract `conditionCall` type and `mountCreateConditionCapture` helper; two tests share the 14-line `create_condition` handler+recorder setup
- **`migrate/tasks_gate_override_test.go`**: Replace 2 remaining inline default-handler closures + manual cloudSrv/apiSrv/dir/executor setup with `addDefaultCloudHandler` + `newCustomCloudTest`
- **`migrate/tasks_flow_test.go` + `tasks_newcode_test.go`**: Replace remaining `cloudMux.HandleFunc("/", json.empty)` closures with `addDefaultCloudHandler`
- **`migrate/tasks_setglobalsettings_test.go`**: Use `writeGlobalSettingsOrg` to collapse 6 identical 4-line extract-meta + org-mapping write blocks
- **`extract/extract_test.go`**: Extract `firstExtractDir(t, dir)` helper; 3 tests shed their identical 4-line `ReadDir + check + filepath.Join` block

## Test plan

- [ ] All tests pass: `go test ./...`
- [ ] Net −134 lines with no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)