### PR TITLE
refactor: fifth round of code deduplication (top SonarCloud files)

### DIFF
--- a/go/internal/extract/tasks_system.go
+++ b/go/internal/extract/tasks_system.go
@@ -17,6 +17,19 @@ import (
 // is skipped entirely on those servers (issue #372).
 var aiCodeFixV2Available = common.MustParseVersion("2025.3")
 
+// serverArrayTask builds a TaskDef that fetches a paginated API array and
+// enriches each record with the server URL. Covers the common pattern of
+// system-level endpoints that return a named array and need serverUrl tracking.
+func serverArrayTask(name, path, resultKey string) TaskDef {
+	return TaskDef{
+		Name:     name,
+		Editions: AllEditions,
+		Run: func(ctx context.Context, e *Executor) error {
+			return fetchAndWriteArray(ctx, e, name, path, resultKey, nil, map[string]any{"serverUrl": e.ServerURL})
+		},
+	}
+}
+
 func systemTasks() []TaskDef {
 	return []TaskDef{
 		{
@@ -26,24 +39,12 @@ func systemTasks() []TaskDef {
 				return fetchAndWriteSingle(ctx, e, "getServerInfo", "api/system/info", nil, "", map[string]any{"serverUrl": e.ServerURL})
 			},
 		},
-		{
-			Name:     "getServerSettings",
-			Editions: AllEditions,
-			Run: func(ctx context.Context, e *Executor) error {
-				return fetchAndWriteArray(ctx, e, "getServerSettings", "api/settings/values", "settings", nil, map[string]any{"serverUrl": e.ServerURL})
-			},
-		},
-		{
-			// Companion to getServerSettings: extracts the SQS-side
-			// setting definitions (key, type, multiValues, defaultValue)
-			// so the migrate phase can decide which global settings have
-			// been customized (value != defaultValue — issue #186).
-			Name:     "getServerSettingsDefinitions",
-			Editions: AllEditions,
-			Run: func(ctx context.Context, e *Executor) error {
-				return fetchAndWriteArray(ctx, e, "getServerSettingsDefinitions", "api/settings/list_definitions", "definitions", nil, map[string]any{"serverUrl": e.ServerURL})
-			},
-		},
+		serverArrayTask("getServerSettings", "api/settings/values", "settings"),
+		// Companion to getServerSettings: extracts the SQS-side setting
+		// definitions (key, type, multiValues, defaultValue) so the migrate
+		// phase can decide which global settings have been customized
+		// (value != defaultValue — issue #186).
+		serverArrayTask("getServerSettingsDefinitions", "api/settings/list_definitions", "definitions"),
 		{
 			Name:     "getPlugins",
 			Editions: AllEditions,
@@ -59,13 +60,7 @@ func systemTasks() []TaskDef {
 				return fetchAndWriteArray(ctx, e, "getUsage", "api/projects/license_usage", "projects", nil, nil)
 			},
 		},
-		{
-			Name:     "getBindings",
-			Editions: AllEditions,
-			Run: func(ctx context.Context, e *Executor) error {
-				return fetchAndWriteArray(ctx, e, "getBindings", "api/alm_settings/list", "almSettings", nil, map[string]any{"serverUrl": e.ServerURL})
-			},
-		},
+		serverArrayTask("getBindings", "api/alm_settings/list", "almSettings"),
 		{
 			// AI Code Fix configuration (issue #251). Single JSON
 			// object exposing the global enablement state, the list

--- a/go/internal/extract/tasks_templates.go
+++ b/go/internal/extract/tasks_templates.go
@@ -10,22 +10,22 @@ import (
 	"net/url"
 )
 
+// searchTemplatesTask builds a TaskDef that fetches one result key from
+// /api/permissions/search_templates, enriching records with serverUrl.
+func searchTemplatesTask(name, resultKey string) TaskDef {
+	return TaskDef{
+		Name:     name,
+		Editions: AllEditions,
+		Run: func(ctx context.Context, e *Executor) error {
+			return fetchAndWriteArray(ctx, e, name, "api/permissions/search_templates", resultKey, nil, map[string]any{"serverUrl": e.ServerURL})
+		},
+	}
+}
+
 func templateTasks() []TaskDef {
 	return []TaskDef{
-		{
-			Name:     "getTemplates",
-			Editions: AllEditions,
-			Run: func(ctx context.Context, e *Executor) error {
-				return fetchAndWriteArray(ctx, e, "getTemplates", "api/permissions/search_templates", "permissionTemplates", nil, map[string]any{"serverUrl": e.ServerURL})
-			},
-		},
-		{
-			Name:     "getDefaultTemplates",
-			Editions: AllEditions,
-			Run: func(ctx context.Context, e *Executor) error {
-				return fetchAndWriteArray(ctx, e, "getDefaultTemplates", "api/permissions/search_templates", "defaultTemplates", nil, map[string]any{"serverUrl": e.ServerURL})
-			},
-		},
+		searchTemplatesTask("getTemplates", "permissionTemplates"),
+		searchTemplatesTask("getDefaultTemplates", "defaultTemplates"),
 		{
 			Name:         "getTemplateGroupsScanners",
 			Editions:     AllEditions,

--- a/go/internal/gui/server_test.go
+++ b/go/internal/gui/server_test.go
@@ -62,26 +62,29 @@ func TestServerStartAndShutdown(t *testing.T) {
 	}
 }
 
-func TestServerAPIRoutes(t *testing.T) {
+// startTestServerWithRun creates a server backed by an export dir that already
+// contains one run directory (04-20-2026-01) with an extract.json stub.
+// The context is cancelled via t.Cleanup. Returns the server's base URL.
+func startTestServerWithRun(t *testing.T) string {
+	t.Helper()
 	wp := NewWebPrompter(context.Background(), func(ServerMessage) {})
 	hub := NewHub(wp)
 	tmpl := mustParseTemplates(t)
-
 	exportDir := t.TempDir()
-
-	// Create a run directory for the API to find.
 	runDir := filepath.Join(exportDir, "04-20-2026-01")
 	os.MkdirAll(runDir, 0o755)
 	os.WriteFile(filepath.Join(runDir, "extract.json"),
 		[]byte(`{"url":"https://test.com/"}`), 0o644)
-
 	srv := NewServer("localhost:0", exportDir, hub, tmpl)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
+	t.Cleanup(cancel)
 	go srv.Start(ctx)
 	<-srv.Ready()
-	base := srv.URL()
+	return srv.URL()
+}
+
+func TestServerAPIRoutes(t *testing.T) {
+	base := startTestServerWithRun(t)
 
 	// Test /api/runs.
 	resp, err := http.Get(base + "/api/runs")
@@ -115,24 +118,7 @@ func TestServerAPIRoutes(t *testing.T) {
 }
 
 func TestServerPageRoutes(t *testing.T) {
-	wp := NewWebPrompter(context.Background(), func(ServerMessage) {})
-	hub := NewHub(wp)
-	tmpl := mustParseTemplates(t)
-
-	exportDir := t.TempDir()
-
-	runDir := filepath.Join(exportDir, "04-20-2026-01")
-	os.MkdirAll(runDir, 0o755)
-	os.WriteFile(filepath.Join(runDir, "extract.json"),
-		[]byte(`{"url":"https://test.com/"}`), 0o644)
-
-	srv := NewServer("localhost:0", exportDir, hub, tmpl)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	go srv.Start(ctx)
-	<-srv.Ready()
-	base := srv.URL()
+	base := startTestServerWithRun(t)
 
 	routes := []struct {
 		path       string

--- a/go/internal/migrate/tasks_hotspotsync_test.go
+++ b/go/internal/migrate/tasks_hotspotsync_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -273,13 +272,7 @@ func TestSyncOneHotspotAddsSourceLink(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, mux)
 
 	// A REVIEWED/SAFE hotspot on a feature branch with NO source comments —
 	// the link must still be added and carry the branch.
@@ -339,14 +332,7 @@ func TestSyncOneHotspotAcknowledgedResetsToToReview(t *testing.T) {
 		mu.Unlock()
 		w.WriteHeader(http.StatusNoContent)
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, mux)
 
 	pair := hotspotPair{
 		source: matchableHotspot{Key: "src-1", Status: "REVIEWED", Resolution: "ACKNOWLEDGED",
@@ -417,14 +403,7 @@ func TestFindCloudHotspotCandidatesQueriesBothStatuses(t *testing.T) {
 			t.Errorf("unexpected status param: %q", status)
 		}
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, mux)
 
 	got, err := findCloudHotspotCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go", "develop")
 	if err != nil {
@@ -468,14 +447,7 @@ func TestFindCloudHotspotCandidatesDedupsByKey(t *testing.T) {
 			"paging": map[string]any{"pageIndex": 1, "pageSize": 100, "total": 1},
 		})
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, mux)
 
 	got, err := findCloudHotspotCandidates(context.Background(), e, "cloud-proj", "cloud-org", "src/app.go", "")
 	if err != nil {
@@ -628,14 +600,7 @@ func TestSyncOneHotspotSafeCallsChangeStatus(t *testing.T) {
 	mux.HandleFunc("GET /api/hotspots/show", func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]any{"comment": []map[string]any{}})
 	})
-	cloudSrv := httptest.NewServer(mux)
-	defer cloudSrv.Close()
-
-	apiSrv := newMockAPIServer()
-	defer apiSrv.Close()
-
-	dir := t.TempDir()
-	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	e := newCustomCloudTest(t, mux)
 
 	pair := hotspotPair{
 		source: matchableHotspot{Key: "src-1", Status: "REVIEWED", Resolution: "SAFE"},

--- a/go/internal/pipeline/shared_test.go
+++ b/go/internal/pipeline/shared_test.go
@@ -84,11 +84,19 @@ func TestStandardExtractHotspots(t *testing.T) {
 	}
 }
 
-func TestStandardExtractHotspotsError(t *testing.T) {
+// new403Server returns an httptest.Server that replies HTTP 403 to every
+// request. The server is closed via t.Cleanup.
+func new403Server(t *testing.T) *httptest.Server {
+	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 	}))
-	defer srv.Close()
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestStandardExtractHotspotsError(t *testing.T) {
+	srv := new403Server(t)
 
 	p := newSQ99(newTestClient(t, srv.URL))
 	_, err := p.ExtractHotspots(context.Background(), "proj")
@@ -135,10 +143,7 @@ func TestStandardExtractGroups(t *testing.T) {
 }
 
 func TestStandardExtractGroupsError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		http.Error(w, "forbidden", http.StatusForbidden)
-	}))
-	defer srv.Close()
+	srv := new403Server(t)
 
 	p := newSQ100(newTestClient(t, srv.URL))
 	_, err := p.ExtractGroups(context.Background())

--- a/go/internal/report/summary/global_failures.go
+++ b/go/internal/report/summary/global_failures.go
@@ -98,17 +98,28 @@ func applyGlobalGroupPermFailures(runDir string,
 	return keep, partial
 }
 
+// openRequestsLogScanner opens requests.log under runDir and returns a line
+// scanner ready for iteration. The caller must invoke the returned close func
+// when done. Returns (nil, nop, false) when the file cannot be opened.
+func openRequestsLogScanner(runDir string) (*bufio.Scanner, func(), bool) {
+	f, err := os.Open(filepath.Join(runDir, "requests.log"))
+	if err != nil {
+		return nil, func() {}, false
+	}
+	sc := bufio.NewScanner(f)
+	sc.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	return sc, func() { f.Close() }, true
+}
+
 // scanRequestsLogForFailedTemplateIDs returns the set of templateId
 // request-body values from failed POSTs to the given URL suffix.
 func scanRequestsLogForFailedTemplateIDs(runDir, urlSuffix string) map[string]bool {
 	out := map[string]bool{}
-	f, err := os.Open(filepath.Join(runDir, "requests.log"))
-	if err != nil {
+	scanner, close, ok := openRequestsLogScanner(runDir)
+	if !ok {
 		return out
 	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	defer close()
 	for scanner.Scan() {
 		entry, ok := parseConfigLogLine(scanner.Text())
 		if !ok {
@@ -135,13 +146,11 @@ func scanRequestsLogForFailedTemplateIDs(runDir, urlSuffix string) map[string]bo
 func scanRequestsLogForFailedGlobalGroupPerms(runDir string) map[string][]string {
 	out := map[string][]string{}
 	seen := map[string]bool{}
-	f, err := os.Open(filepath.Join(runDir, "requests.log"))
-	if err != nil {
+	scanner, close, ok := openRequestsLogScanner(runDir)
+	if !ok {
 		return out
 	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 0, 1024*1024), 10*1024*1024)
+	defer close()
 	for scanner.Scan() {
 		entry, ok := parseConfigLogLine(scanner.Text())
 		if !ok {


### PR DESCRIPTION
## Summary

Targeting the highest remaining entries in the SonarCloud duplication report:

| File | % Dup | Change |
|------|-------|--------|
| `extract/tasks_templates.go` | 52.1% | Extract `searchTemplatesTask` factory; `getTemplates`/`getDefaultTemplates` reduce from 5 lines to 1 each |
| `migrate/tasks_hotspotsync_test.go` | 12.2% | Replace 5 identical `cloudSrv+apiSrv+dir+executor` blocks with `newCustomCloudTest(t, mux)` |
| `gui/server_test.go` | 22.3% | Extract `startTestServerWithRun(t)` helper; 2 tests shed 11-line identical server+runDir+start+ready setup |
| `pipeline/shared_test.go` | 22.4% | Extract `new403Server(t)` helper; 2 error tests share a 4-line 403 mock server |
| `report/summary/global_failures.go` | 17.1% | Extract `openRequestsLogScanner(runDir)` helper; 2 scan functions share a 7-line open+scanner boilerplate |
| `extract/tasks_system.go` | 21.4% | Extract `serverArrayTask` factory; `getServerSettings`, `getServerSettingsDefinitions`, `getBindings` each reduce from 4 lines to 1 |

## Test plan

- [ ] All tests pass: `go test ./...`
- [ ] Net −40 lines with no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)