### PR TITLE
refactor: sixth round of code deduplication (SonarCloud top files)

### DIFF
--- a/go/internal/extract/tasks_projects_test.go
+++ b/go/internal/extract/tasks_projects_test.go
@@ -109,6 +109,27 @@ func TestExtractTagsArray(t *testing.T) {
 	}
 }
 
+// newGetProjectsEnv builds the standard Executor for getProjects tests wired to
+// srv, with an in-memory store and stderr logger. def is the getProjects task.
+func newGetProjectsEnv(t *testing.T, srv *httptest.Server) (*Executor, *TaskDef) {
+	t.Helper()
+	dir := t.TempDir()
+	store := NewDataStore(dir)
+	raw := common.NewRawClient(srv.Client(), srv.URL+"/")
+	e := &Executor{
+		Raw:       raw,
+		Store:     store,
+		ServerURL: srv.URL + "/",
+		Logger:    slog.New(slog.NewTextHandler(os.Stderr, nil)),
+		Sem:       make(chan struct{}, 1),
+	}
+	def := projectTasks()[0]
+	if def.Name != "getProjects" {
+		t.Fatalf("expected getProjects task, got %s", def.Name)
+	}
+	return e, &def
+}
+
 // TestGetProjectsTaskNoFilter verifies that getProjects sends no `projects`
 // query param when ProjectKeys is empty (full extract).
 func TestGetProjectsTaskNoFilter(t *testing.T) {
@@ -122,20 +143,7 @@ func TestGetProjectsTaskNoFilter(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	dir := t.TempDir()
-	store := NewDataStore(dir)
-	raw := common.NewRawClient(srv.Client(), srv.URL+"/")
-	e := &Executor{
-		Raw:   raw, Store: store,
-		ServerURL: srv.URL + "/",
-		Logger:    slog.New(slog.NewTextHandler(os.Stderr, nil)),
-		Sem:       make(chan struct{}, 1),
-	}
-
-	def := projectTasks()[0] // getProjects is first in the list
-	if def.Name != "getProjects" {
-		t.Fatalf("expected getProjects task, got %s", def.Name)
-	}
+	e, def := newGetProjectsEnv(t, srv)
 	if err := def.Run(context.Background(), e); err != nil {
 		t.Fatalf("getProjects: %v", err)
 	}
@@ -157,21 +165,8 @@ func TestGetProjectsTaskWithFilter(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	dir := t.TempDir()
-	store := NewDataStore(dir)
-	raw := common.NewRawClient(srv.Client(), srv.URL+"/")
-	e := &Executor{
-		Raw:         raw, Store: store,
-		ServerURL:   srv.URL + "/",
-		ProjectKeys: []string{"proj-a", "proj-b"},
-		Logger:      slog.New(slog.NewTextHandler(os.Stderr, nil)),
-		Sem:         make(chan struct{}, 1),
-	}
-
-	def := projectTasks()[0]
-	if def.Name != "getProjects" {
-		t.Fatalf("expected getProjects task, got %s", def.Name)
-	}
+	e, def := newGetProjectsEnv(t, srv)
+	e.ProjectKeys = []string{"proj-a", "proj-b"}
 	if err := def.Run(context.Background(), e); err != nil {
 		t.Fatalf("getProjects: %v", err)
 	}

--- a/go/internal/migrate/eventlog_test.go
+++ b/go/internal/migrate/eventlog_test.go
@@ -21,13 +21,20 @@ func newTestLogger(buf *bytes.Buffer, c *eventCollector, level slog.Level) *slog
 	return slog.New(newEventHandler(base, c))
 }
 
+// newEventLogger creates a logger + buffer + collector wired at LevelInfo — the
+// common setup shared by all eventlog tests.
+func newEventLogger(t *testing.T) (*slog.Logger, *bytes.Buffer, *eventCollector) {
+	t.Helper()
+	var buf bytes.Buffer
+	c := &eventCollector{}
+	return newTestLogger(&buf, c, slog.LevelInfo), &buf, c
+}
+
 // TestEventHandler_Passthrough asserts that an Info log is both forwarded to
 // the inner TextHandler (visible in the buffer) AND captured exactly once by
 // the collector.
 func TestEventHandler_Passthrough(t *testing.T) {
-	var buf bytes.Buffer
-	c := &eventCollector{}
-	logger := newTestLogger(&buf, c, slog.LevelInfo)
+	logger, buf, c := newEventLogger(t)
 
 	logger.Info("hello world", "k", "v")
 
@@ -61,9 +68,7 @@ func TestEventHandler_Passthrough(t *testing.T) {
 // is captured by neither the inner handler nor the collector — the teeing
 // handler delegates Enabled() to the inner handler, so the filter is shared.
 func TestEventHandler_LevelFilterParity(t *testing.T) {
-	var buf bytes.Buffer
-	c := &eventCollector{}
-	logger := newTestLogger(&buf, c, slog.LevelInfo)
+	logger, buf, c := newEventLogger(t)
 
 	logger.Debug("this should be dropped", "k", "v")
 
@@ -95,9 +100,7 @@ func TestEventHandler_Concurrency(t *testing.T) {
 		expectedTotal = goroutines * perGoroutine
 	)
 
-	var buf bytes.Buffer
-	c := &eventCollector{}
-	logger := newTestLogger(&buf, c, slog.LevelInfo)
+	logger, _, c := newEventLogger(t)
 
 	var wg sync.WaitGroup
 	wg.Add(goroutines)
@@ -149,9 +152,7 @@ func TestEventHandler_Concurrency(t *testing.T) {
 // WithAttrs) still tees into the same collector and that the bound attrs
 // appear on the captured events.
 func TestEventHandler_WithAttrsTees(t *testing.T) {
-	var buf bytes.Buffer
-	c := &eventCollector{}
-	logger := newTestLogger(&buf, c, slog.LevelInfo)
+	logger, buf, c := newEventLogger(t)
 
 	derived := logger.With("k", "v")
 	derived.Info("derived message", "extra", "payload")

--- a/go/internal/migrate/gate_conditions_resolver_test.go
+++ b/go/internal/migrate/gate_conditions_resolver_test.go
@@ -13,6 +13,17 @@ import (
 // when multiple source conditions produce target conditions on the same SQC
 // metric, keep one — the most stringent. "More stringent" means "fires the
 // gate for more cases" (lower threshold for GT, higher threshold for LT).
+// blockerExpansion returns the two-condition set produced when
+// software_quality_blocker_issues expands: security_rating GT 4 and
+// reliability_rating GT 4. Several test cases use this pair for both
+// input and expected output, so naming it avoids the inline repetition.
+func blockerExpansion(src string) []targetCondition {
+	return []targetCondition{
+		{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: src},
+		{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: src},
+	}
+}
+
 func TestResolveTargetConditions(t *testing.T) {
 	cases := []struct {
 		name string
@@ -21,25 +32,17 @@ func TestResolveTargetConditions(t *testing.T) {
 	}{
 		{
 			name: "no collision passes through unchanged",
-			in: []targetCondition{
-				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
-				{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
-			},
-			want: []targetCondition{
-				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
-				{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
-			},
+			in:   blockerExpansion("software_quality_blocker_issues"),
+			want: blockerExpansion("software_quality_blocker_issues"),
 		},
 		{
 			// #234 example: blocker_issues expansion (reliability_rating GT 4)
 			// collides with a direct reliability_rating GT 2. The direct
 			// passthrough is more stringent (B < D), so it wins.
 			name: "blocker expansion + direct reliability GT 2 → direct wins",
-			in: []targetCondition{
-				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
-				{Metric: "reliability_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
-				{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "reliability_rating"},
-			},
+			in: append(blockerExpansion("software_quality_blocker_issues"),
+				targetCondition{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "reliability_rating"},
+			),
 			want: []targetCondition{
 				{Metric: "security_rating", Op: "GT", Error: "4", SourceMetric: "software_quality_blocker_issues"},
 				{Metric: "reliability_rating", Op: "GT", Error: "2", SourceMetric: "reliability_rating"},

--- a/go/internal/migrate/gate_metric_mapping.go
+++ b/go/internal/migrate/gate_metric_mapping.go
@@ -36,6 +36,24 @@ func ratingWorseThan(metric string, letter string) ReplacementCondition {
 	return ReplacementCondition{Metric: metric, Op: "GT", Error: v}
 }
 
+// secRelPair returns a [security_rating, reliability_rating] composite where
+// both thresholds are "worse than letter". Used for the software_quality_*_issues
+// composite conditions that expand into two rating conditions.
+func secRelPair(letter string) []ReplacementCondition {
+	return []ReplacementCondition{
+		ratingWorseThan("security_rating", letter),
+		ratingWorseThan("reliability_rating", letter),
+	}
+}
+
+// newSecRelPair is like secRelPair but targets the new_* metrics (issue #232).
+func newSecRelPair(letter string) []ReplacementCondition {
+	return []ReplacementCondition{
+		ratingWorseThan("new_security_rating", letter),
+		ratingWorseThan("new_reliability_rating", letter),
+	}
+}
+
 // metricMapping maps a SonarQube Server quality-gate metric to one or more
 // SonarQube Cloud conditions, following the table maintained in issue #143.
 //
@@ -113,26 +131,11 @@ var metricMapping = map[string][]ReplacementCondition{
 	// unrelated to issue counts — so a source gate with a single
 	// software_quality_blocker_issues condition ended up with a spurious
 	// "Security Review Rating worse than D" on SQC (#232).
-	"software_quality_blocker_issues": {
-		ratingWorseThan("security_rating", "D"),
-		ratingWorseThan("reliability_rating", "D"),
-	},
-	"software_quality_high_issues": {
-		ratingWorseThan("security_rating", "C"),
-		ratingWorseThan("reliability_rating", "C"),
-	},
-	"software_quality_medium_issues": {
-		ratingWorseThan("security_rating", "B"),
-		ratingWorseThan("reliability_rating", "B"),
-	},
-	"software_quality_low_issues": {
-		ratingWorseThan("security_rating", "A"),
-		ratingWorseThan("reliability_rating", "A"),
-	},
-	"software_quality_info_issues": {
-		ratingWorseThan("security_rating", "A"),
-		ratingWorseThan("reliability_rating", "A"),
-	},
+	"software_quality_blocker_issues": secRelPair("D"),
+	"software_quality_high_issues":    secRelPair("C"),
+	"software_quality_medium_issues":  secRelPair("B"),
+	"software_quality_low_issues":     secRelPair("A"),
+	"software_quality_info_issues":    secRelPair("A"),
 
 	// new_software_quality_*_issues — same semantics as the overall-code
 	// composites above, applied to the new_* rating metrics. The earlier
@@ -140,26 +143,11 @@ var metricMapping = map[string][]ReplacementCondition{
 	// is the hotspot-review-percentage metric (unrelated to issue counts)
 	// and a duplicate metric on the same gate is rejected by SQC anyway.
 	// Pair new_security_rating with new_reliability_rating instead (#232).
-	"new_software_quality_blocker_issues": {
-		ratingWorseThan("new_security_rating", "D"),
-		ratingWorseThan("new_reliability_rating", "D"),
-	},
-	"new_software_quality_high_issues": {
-		ratingWorseThan("new_security_rating", "C"),
-		ratingWorseThan("new_reliability_rating", "C"),
-	},
-	"new_software_quality_medium_issues": {
-		ratingWorseThan("new_security_rating", "B"),
-		ratingWorseThan("new_reliability_rating", "B"),
-	},
-	"new_software_quality_low_issues": {
-		ratingWorseThan("new_security_rating", "A"),
-		ratingWorseThan("new_reliability_rating", "A"),
-	},
-	"new_software_quality_info_issues": {
-		ratingWorseThan("new_security_rating", "A"),
-		ratingWorseThan("new_reliability_rating", "A"),
-	},
+	"new_software_quality_blocker_issues": newSecRelPair("D"),
+	"new_software_quality_high_issues":    newSecRelPair("C"),
+	"new_software_quality_medium_issues":  newSecRelPair("B"),
+	"new_software_quality_low_issues":     newSecRelPair("A"),
+	"new_software_quality_info_issues":    newSecRelPair("A"),
 
 	// SonarQube Server 9.9 named the "accepted" issue metric
 	// wont_fix_issues; SQC (and SQS 10.2+) renamed it accepted_issues.

--- a/go/internal/report/migration/generate_test.go
+++ b/go/internal/report/migration/generate_test.go
@@ -43,6 +43,33 @@ func setupExtract(t *testing.T, tasks map[string][]map[string]any) (string, stru
 	return dir, structure.ExtractMapping{testServerURL: testExtractID}
 }
 
+// emptyTaskMap returns the standard set of task names used by both migration
+// report tests, all pre-populated with empty record slices.
+func emptyTaskMap() map[string][]map[string]any {
+	return map[string][]map[string]any{
+		"getServerInfo":          {},
+		"getProjectDetails":      {},
+		"getProjectAnalyses":     {},
+		"getProjectBindings":     {},
+		"getBindings":            {},
+		"getBranches":            {},
+		"getProjectPullRequests": {},
+		"getDefaultTemplates":    {},
+		"getTemplates":           {},
+		"getPlugins":             {},
+		"getRules":               {},
+		"getProfileRules":        {},
+		"getProfiles":            {},
+		"getPortfolioDetails":    {},
+		"getPortfolioProjects":   {},
+		"getGates":               {},
+		"getApplicationDetails":  {},
+		"getUsers":               {},
+		"getProjectSettings":     {},
+		"getUsage":               {},
+	}
+}
+
 func TestFillTemplate(t *testing.T) {
 	tmpl := "Hello {name}, welcome to {place}!"
 	result := fillTemplate(tmpl, map[string]string{"name": "Alice", "place": "Go"})
@@ -60,32 +87,14 @@ func TestFillTemplateUnusedPlaceholder(t *testing.T) {
 }
 
 func TestGenerateMigrationReport(t *testing.T) {
-	dir, mapping := setupExtract(t, map[string][]map[string]any{
-		"getServerInfo": {
-			{"System": map[string]any{"Version": "10.7", "Server ID": testServerID, "Edition": "enterprise", "Lines of Code": float64(5000)}},
-		},
-		"getProjectDetails": {
-			{"key": "proj-1", "name": "Project 1", "qualityProfiles": []any{}, "qualityGate": map[string]any{"name": "Sonar way"}},
-		},
-		"getProjectAnalyses":    {},
-		"getProjectBindings":    {},
-		"getBindings":           {},
-		"getBranches":           {},
-		"getProjectPullRequests": {},
-		"getDefaultTemplates":   {},
-		"getTemplates":          {},
-		"getPlugins":            {},
-		"getRules":              {},
-		"getProfileRules":       {},
-		"getProfiles":           {},
-		"getPortfolioDetails":   {},
-		"getPortfolioProjects":  {},
-		"getGates":              {},
-		"getApplicationDetails": {},
-		"getUsers":              {},
-		"getProjectSettings":    {},
-		"getUsage":              {},
-	})
+	tasks := emptyTaskMap()
+	tasks["getServerInfo"] = []map[string]any{
+		{"System": map[string]any{"Version": "10.7", "Server ID": testServerID, "Edition": "enterprise", "Lines of Code": float64(5000)}},
+	}
+	tasks["getProjectDetails"] = []map[string]any{
+		{"key": "proj-1", "name": "Project 1", "qualityProfiles": []any{}, "qualityGate": map[string]any{"name": "Sonar way"}},
+	}
+	dir, mapping := setupExtract(t, tasks)
 
 	md := GenerateMigrationReport(dir, mapping)
 
@@ -107,28 +116,7 @@ func TestGenerateMigrationReport(t *testing.T) {
 }
 
 func TestGenerateMigrationReportEmpty(t *testing.T) {
-	dir, mapping := setupExtract(t, map[string][]map[string]any{
-		"getServerInfo":          {},
-		"getProjectDetails":      {},
-		"getProjectAnalyses":     {},
-		"getProjectBindings":     {},
-		"getBindings":            {},
-		"getBranches":            {},
-		"getProjectPullRequests": {},
-		"getDefaultTemplates":    {},
-		"getTemplates":           {},
-		"getPlugins":             {},
-		"getRules":               {},
-		"getProfileRules":        {},
-		"getProfiles":            {},
-		"getPortfolioDetails":    {},
-		"getPortfolioProjects":   {},
-		"getGates":               {},
-		"getApplicationDetails":  {},
-		"getUsers":               {},
-		"getProjectSettings":     {},
-		"getUsage":               {},
-	})
+	dir, mapping := setupExtract(t, emptyTaskMap())
 
 	md := GenerateMigrationReport(dir, mapping)
 

--- a/go/internal/report/summary/pdf_projectkey_test.go
+++ b/go/internal/report/summary/pdf_projectkey_test.go
@@ -18,10 +18,17 @@ import (
 // fix routes the no-marker branch through the same width-aware
 // wrap that already handles the marker branch, gaining its
 // hard-break-at-runes fallback for tokens wider than the cell.
-func TestWrapPlainText_LongProjectKeyStaysInCell(t *testing.T) {
+// newTestPDF creates a fresh Letter-format PDF with the migration-tool Unicode
+// font registered and a single blank page ready for rendering.
+func newTestPDF() *fpdf.Fpdf {
 	pdf := fpdf.New("P", "mm", "Letter", "")
 	registerUnicodeFont(pdf)
 	pdf.AddPage()
+	return pdf
+}
+
+func TestWrapPlainText_LongProjectKeyStaysInCell(t *testing.T) {
+	pdf := newTestPDF()
 	pdf.SetFont(pdfFontFamilyBody, "", 6.0)
 
 	longKey := "migration-tool-test-gh_okorach-org_pr-demo:" +
@@ -66,9 +73,7 @@ func TestWrapPlainText_LongProjectKeyStaysInCell(t *testing.T) {
 // cursor's Y must not have advanced — any Y drift means pdf.Write
 // or CellFormat triggered an unintended wrap.
 func TestWriteInlineBoldLine_NoOverflowAtPageRightMargin(t *testing.T) {
-	pdf := fpdf.New("P", "mm", "Letter", "")
-	registerUnicodeFont(pdf)
-	pdf.AddPage()
+	pdf := newTestPDF()
 
 	// Exact cloud key shape from the #345 screenshot.
 	cloudKey := "migration-tool-test_okorach_demo-gitlabci-cli_e81d5112-e681-44b2-aee4-62b56c8ac5cb"
@@ -121,9 +126,7 @@ func absMM(x float64) float64 {
 // cursor must land flush right of the cell at the row's top — any
 // vertical drift means the renderer wrapped to a fresh page row.
 func TestDrawDetailsCell_LongProjectKeyNoOverflow(t *testing.T) {
-	pdf := fpdf.New("P", "mm", "Letter", "")
-	registerUnicodeFont(pdf)
-	pdf.AddPage()
+	pdf := newTestPDF()
 	pdf.SetFont(pdfFontFamilyBody, "", 6.0)
 
 	longKey := "migration-tool-test-gh_okorach-org_pr-demo:" +
@@ -191,9 +194,7 @@ func TestDrawDetailsCell_LongProjectKeyNoOverflow(t *testing.T) {
 // `-`, `/`, `.` as break points lets the wrap split at natural
 // project-key boundaries before any overflow.
 func TestWrapInlineBoldLines_LongProjectKeyStaysInCell(t *testing.T) {
-	pdf := fpdf.New("P", "mm", "Letter", "")
-	registerUnicodeFont(pdf)
-	pdf.AddPage()
+	pdf := newTestPDF()
 
 	// Worst-case key shape — every segment is at the upper end of
 	// what users put in their SonarQube project keys.


### PR DESCRIPTION
## Summary

Targeting the updated SonarCloud duplication report (top files by % × lines):

| File | % Dup | Change |
|------|-------|--------|
| `migrate/gate_conditions_resolver_test.go` | 69.6% | Extract `blockerExpansion(src)` helper; reduces identical in/want struct pairs |
| `migrate/gate_metric_mapping.go` | 20.3% | Extract `secRelPair` and `newSecRelPair` helpers; 10 composite map entries collapse from 3-line struct literals to 1-line calls |
| `report/migration/generate_test.go` | 17.1% | Extract `emptyTaskMap()`; 2 tests shed a full 20-entry `map[string][]map[string]any` literal each |
| `migrate/eventlog_test.go` | 16.7% | Extract `newEventLogger(t)`; all 4 `TestEventHandler_*` tests shed their identical 3-line buf+collector+logger setup |
| `extract/tasks_projects_test.go` | 16.2% | Extract `newGetProjectsEnv(t, srv)`; 2 tests shed identical 7-line executor+task setup |
| `report/summary/pdf_projectkey_test.go` | 10.9% | Extract `newTestPDF()`; 4 tests shed `fpdf.New+registerUnicodeFont+AddPage` |

## Test plan
- [x] All tests pass: `go test ./...`
- Net -24 lines, no logic changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)