### PR TITLE
chore: bump version to v1.0.0

### DIFF
--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -4,6 +4,6 @@
 
 package version
 
-const Version = "v1.0.0-SNAPSHOT"
+const Version = "v1.0.0"
 
 const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary

Remove the `-SNAPSHOT` suffix from the version string — `v1.0.0-SNAPSHOT` → `v1.0.0`.

## Change

`go/internal/version/version.go`: `const Version = "v1.0.0"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)