### PR TITLE
fix(shell): replace [ with [[ in all conditional tests

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+set -x
+
+CONFIG=ee
+DO_EXTRACT=false
+DO_MIGRATE=false
+
+usage() {
+  echo "Usage: $0 [-c <config>] [-e] [-m]" >&2
+  echo "  -c <config>  Config name to use (default: ee)" >&2
+  echo "  -e           Run extract, structure, mappings and copy organizations" >&2
+  echo "  -m           Run migrate" >&2
+  echo "  (if neither -e nor -m is given, all steps run)" >&2
+  exit 1
+}
+
+while getopts "c:emh" opt; do
+  case "${opt}" in
+    c) CONFIG="${OPTARG}" ;;
+    e) DO_EXTRACT=true ;;
+    m) DO_MIGRATE=true ;;
+    h) usage ;;
+    *) usage ;;
+  esac
+done
+
+./build.sh
+
+# If no step flag is given, run everything.
+if [[ "${DO_EXTRACT}" = false ]] && [[ "${DO_MIGRATE}" = false ]]; then
+  DO_EXTRACT=true
+  DO_MIGRATE=true
+fi
+
+CONFIG_FILE="config-${CONFIG}.json"
+
+if [[ "${DO_EXTRACT}" = true ]]; then
+  ./sonar-migration-tool extract --config "${CONFIG_FILE}"
+  ./sonar-migration-tool structure --config "${CONFIG_FILE}"
+  ./sonar-migration-tool mappings --config "${CONFIG_FILE}"
+
+  cp organizations-${CONFIG}.csv migration-files-${CONFIG}/organizations.csv
+fi
+
+if [[ "${DO_MIGRATE}" = true ]]; then
+  ./sonar-migration-tool migrate --config "${CONFIG_FILE}"
+fi

--- a/scripts/delete-all-sonarcloud-projects.sh
+++ b/scripts/delete-all-sonarcloud-projects.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Default config is config.json at project root; pass a path as $1 to override.
 CONFIG_FILE="${1:-$(cd "$(dirname "$0")" && pwd)/../config.json}"
 
-if [ ! -f "$CONFIG_FILE" ]; then
+if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Error: config not found at $CONFIG_FILE"
   echo "Usage: $0 [path/to/config.json]"
   exit 1
@@ -31,7 +31,7 @@ while true; do
 
   KEYS=$(echo "$SC_RESPONSE" | jq -r '.components[].key // empty')
 
-  if [ -z "$KEYS" ]; then
+  if [[ -z "$KEYS" ]]; then
     break
   fi
 
@@ -40,7 +40,7 @@ while true; do
   done <<< "$KEYS"
 
   SC_TOTAL=$(echo "$SC_RESPONSE" | jq -r '.paging.total // 0')
-  if [ "${#SC_KEYS[@]}" -ge "$SC_TOTAL" ]; then
+  if [[ "${#SC_KEYS[@]}" -ge "$SC_TOTAL" ]]; then
     break
   fi
 
@@ -50,7 +50,7 @@ done
 echo "Found ${#SC_KEYS[@]} project(s) in SonarCloud."
 echo ""
 
-if [ "${#SC_KEYS[@]}" -eq 0 ]; then
+if [[ "${#SC_KEYS[@]}" -eq 0 ]]; then
   echo "No projects found. Nothing to delete."
   exit 0
 fi
@@ -62,7 +62,7 @@ done
 echo ""
 
 read -r -p "Are you sure you want to permanently delete ALL ${#SC_KEYS[@]} project(s)? [yes/N] " CONFIRM
-if [ "$CONFIRM" != "yes" ]; then
+if [[ "$CONFIRM" != "yes" ]]; then
   echo "Aborted."
   exit 0
 fi
@@ -78,7 +78,7 @@ for KEY in "${SC_KEYS[@]}"; do
       -H "Authorization: Bearer $SC_TOKEN" \
       "$SC_URL/api/projects/delete?project=$KEY")
 
-    if [ "$HTTP_STATUS" = "204" ] || [ "$HTTP_STATUS" = "200" ]; then
+    if [[ "$HTTP_STATUS" = "204" || "$HTTP_STATUS" = "200" ]]; then
       echo "[DELETED] $KEY"
       touch "$WORK_DIR/deleted_${$}_$RANDOM"
     else

--- a/scripts/execute_full_migration.sh
+++ b/scripts/execute_full_migration.sh
@@ -57,22 +57,22 @@ print_warning() {
 }
 
 # Validate required variables
-if [ "$SONARQUBE_TOKEN" = "your-sonarqube-token-here" ]; then
+if [[ "$SONARQUBE_TOKEN" = "your-sonarqube-token-here" ]]; then
     print_error "Please set SONARQUBE_TOKEN in the script"
     exit 1
 fi
 
-if [ "$SONARCLOUD_TOKEN" = "your-sonarcloud-token-here" ]; then
+if [[ "$SONARCLOUD_TOKEN" = "your-sonarcloud-token-here" ]]; then
     print_error "Please set SONARCLOUD_TOKEN in the script"
     exit 1
 fi
 
-if [ "$SONARCLOUD_ENTERPRISE_KEY" = "your-enterprise-key" ]; then
+if [[ "$SONARCLOUD_ENTERPRISE_KEY" = "your-enterprise-key" ]]; then
     print_error "Please set SONARCLOUD_ENTERPRISE_KEY in the script"
     exit 1
 fi
 
-if [ "$SONARCLOUD_ORG_KEY" = "your-target-org" ]; then
+if [[ "$SONARCLOUD_ORG_KEY" = "your-target-org" ]]; then
     print_error "Please set SONARCLOUD_ORG_KEY in the script"
     exit 1
 fi
@@ -139,7 +139,7 @@ print_step "Step 3: Updating organizations.csv"
 
 ORGS_FILE="${EXPORT_DIR_ABS}/organizations.csv"
 
-if [ ! -f "$ORGS_FILE" ]; then
+if [[ ! -f "$ORGS_FILE" ]]; then
     print_error "organizations.csv not found at $ORGS_FILE"
     exit 1
 fi

--- a/transfer.sh
+++ b/transfer.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#set -x
+
+CONFIG=ee
+PK=""
+
+usage() {
+  echo "Usage: $0 [-c <config>] -p <projectKey>" >&2
+  echo "  -c <config>      Config name to use (default: ee)" >&2
+  echo "  -p <projectKey>  Project key to transfer" >&2
+  echo "  -o <org>         SQC org to transfer into" >&2
+  exit 1
+}
+
+while getopts "c:hp:o:" opt; do
+  case "${opt}" in
+    c) CONFIG="${OPTARG}" ;;
+    p) PK="${OPTARG}" ;;
+    o) ORG="${OPTARG}" ;;
+    h) usage ;;
+    *) usage ;;
+  esac
+done
+
+if [[ -z "${PK}" ]]; then
+    echo "-p <projectKey> option is mandatory"
+    usage
+fi
+
+./build.sh
+
+if [[ -z "${ORG}" ]]; then
+    echo "-o <org> option is mandatory"
+    usage
+fi
+
+CONFIG_FILE="config-${CONFIG}.json"
+
+./sonar-migration-tool transfer --config "${CONFIG_FILE}" --project_key $PK --default_organization $ORG --debug


### PR DESCRIPTION
## Summary

Fixes the shellcheck rule **"Use \`[[\` instead of \`[\` for conditional tests"** across all shell scripts.

## Changes

| File | Fixes | Details |
|------|-------|---------|
| `migrate.sh` | 3 | `DO_EXTRACT` and `DO_MIGRATE` flag checks |
| `transfer.sh` | 2 | Empty-string guards upgraded to `[[ -z ]]` |
| `scripts/delete-all-sonarcloud-projects.sh` | 6 | File-exists, `-z`, array-length, confirm, and HTTP-status checks; the two-part `[ ] \|\| [ ]` HTTP status check collapsed into a single `[[ ... \|\| ... ]]` |
| `scripts/execute_full_migration.sh` | 5 | Placeholder-token guards and file-exists check |

**Total: 16 violations fixed across 4 files.**

## Why `[[` is better

- Bash-native — no subprocess fork, faster
- Avoids word-splitting and globbing on unquoted variables
- Supports `&&` and `||` inside the test expression
- Allows `=~` for regex matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)