### PR TITLE
fix: strip module key prefix in monorepo issue/hotspot sync matching

### DIFF
--- a/go/internal/migrate/tasks_hotspotsync.go
+++ b/go/internal/migrate/tasks_hotspotsync.go
@@ -371,11 +371,11 @@ func syncProjectHotspots(ctx context.Context, e *Executor, input syncHotspotInpu
 // hotspot's file, then resolves by (ruleKey, line). Returns the case
 // a/b/c/lookup outcome.
 func resolveAndSyncHotspot(ctx context.Context, e *Executor, cloudKey, orgKey, baseURL, sourceKey string, src matchableHotspot, counter *TaskCounter) syncOutcome {
-	filePath := src.Component
-	prefix := sourceKey + ":"
-	if strings.HasPrefix(filePath, prefix) {
-		filePath = filePath[len(prefix):]
-	}
+	// Strip "projectKey:" and any trailing "moduleKey:" segments so the bare
+	// file path can be used in the cloud search. Multi-module (monorepo)
+	// projects add a module key after the project key; SonarCloud has no
+	// module layer so only the plain file path matches the cloud component.
+	filePath := stripProjectKeyPrefix(src.Component)
 	if filePath == "" || src.RuleKey == "" || src.Line <= 0 {
 		e.Logger.Debug("syncHotspotMetadata: source hotspot not matchable", "key", src.Key, "rule", src.RuleKey, "component", src.Component, "line", src.Line)
 		return syncOutcomeNotFound

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -107,14 +107,33 @@ type issuePair struct {
 // Matching helpers
 // ---------------------------------------------------------------------------
 
-// stripProjectKeyPrefix removes the leading "projectKey:" segment from a
-// SonarQube component path, returning the bare file path. SonarQube
-// formats components as "projectKey:src/main/java/Foo.java"; the
-// project key is environment-specific but the file path part is the
-// same on source and cloud.
+// stripProjectKeyPrefix removes all leading colon-separated key segments
+// from a SonarQube component path, returning the bare file path. SonarQube
+// formats components as either:
+//
+//   - "projectKey:src/main/java/Foo.java"              (single-module), or
+//   - "projectKey:moduleKey:src/main/java/Foo.java"    (multi-module / monorepo)
+//
+// SonarCloud has no module layer, so the cloud componentKeys search parameter
+// must use only the bare file path. Segments are stripped left-to-right as
+// long as the part before the ":" contains no "/" — a "/" means we have
+// already reached the file path, which always starts with a directory name.
+// This fixes matching failures for monorepo projects where the SQS extract
+// records the module key as part of the component identifier but SonarCloud
+// stores the issue at the plain file path.
 func stripProjectKeyPrefix(component string) string {
-	if idx := strings.Index(component, ":"); idx >= 0 {
-		return component[idx+1:]
+	for {
+		idx := strings.Index(component, ":")
+		if idx < 0 {
+			break
+		}
+		prefix := component[:idx]
+		if strings.Contains(prefix, "/") {
+			// Reached the file path — the prefix is a directory segment, stop.
+			break
+		}
+		// prefix looks like a project/module key (no path separators); strip it.
+		component = component[idx+1:]
 	}
 	return component
 }

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -243,6 +243,11 @@ func equalStrings(a, b []string) bool {
 // SonarQube component identifier. The substitution is essential for
 // the targeted cloud search: we send componentKeys=<cloudKey>:<file>
 // derived from the source's <sourceKey>:<file> string.
+//
+// For multi-module (monorepo) projects the component key has TWO
+// colon-separated prefixes: "projectKey:moduleKey:filePath". SonarCloud
+// has no module layer, so both prefixes must be stripped to obtain the
+// bare file path that matches the cloud component key.
 func TestStripProjectKeyPrefix(t *testing.T) {
 	tests := []struct {
 		name string
@@ -250,7 +255,8 @@ func TestStripProjectKeyPrefix(t *testing.T) {
 		want string
 	}{
 		{name: "leading project key", in: "myproject:src/main/java/Foo.java", want: "src/main/java/Foo.java"},
-		{name: "nested colon stays after first", in: "myproject:com:foo/Bar.java", want: "com:foo/Bar.java"},
+		{name: "monorepo: project + module key both stripped", in: "myproject:mymodule:src/main/java/Foo.java", want: "src/main/java/Foo.java"},
+		{name: "monorepo: real-world github-actions example", in: "github-actions-monorepo:github-actions-mono-gradle:src/main/java/com/acme/App.java", want: "src/main/java/com/acme/App.java"},
 		{name: "no project prefix", in: "src/main/java/Foo.java", want: "src/main/java/Foo.java"},
 		{name: "empty", in: "", want: ""},
 		{name: "colon only", in: "myproject:", want: ""},


### PR DESCRIPTION
Root cause: for monorepo (multi-module) SQS projects, component keys include a module key segment that SonarCloud does not have. stripProjectKeyPrefix only stripped the first colon prefix (project key), leaving the module key, causing cloud issue searches to return nothing and accepted/false-positive issues to remain unsynced. Fix: strip all leading colon-separated segments that have no slash until reaching the bare file path. Applied to both tasks_issuesync.go and tasks_hotspotsync.go.