### PR TITLE
fix: strip NUL bytes from source text before CE report submission

### DIFF
--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -441,7 +441,14 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	pbSources := make(map[int32]string)
 	for _, s := range sources {
 		if ref, ok := cr.Refs()[s.Component]; ok && s.Source != "" {
-			pbSources[ref] = s.Source
+			// Sanitize source text before embedding in the scanner report.
+			// Files like RCE-demo PHP scripts may contain null bytes (U+0000)
+			// used in null-byte injection exploits. The SonarCloud CE's Java
+			// component visitor and the underlying database both reject null
+			// bytes in text, producing "Visit of Component failed" / "Fail to
+			// process issues of component" CE task failures. Strip them here so
+			// the file still migrates with its issues and measures intact.
+			pbSources[ref] = stripNullBytes(s.Source)
 		}
 	}
 	// #425 — the SonarCloud CE rejects any report containing a FILE component
@@ -1675,6 +1682,20 @@ func filterProfilesByLanguage(profiles []scanreport.QProfileInfo, langs map[stri
 		}
 	}
 	return filtered
+}
+
+// stripNullBytes removes all NUL characters (U+0000) from a source text string.
+// PHP and other languages used in security-research projects (e.g. RCE / null-byte
+// injection demo files) may embed NUL bytes deliberately. The SonarCloud Compute
+// Engine cannot process source-<ref>.txt files that contain NULs: Java's string
+// operations and the underlying database both reject them, producing
+// "Visit of Component failed" CE task errors. Stripping NULs preserves the rest
+// of the file content so issues and measures still migrate correctly.
+func stripNullBytes(s string) string {
+	if !strings.ContainsRune(s, 0) {
+		return s // fast path — most files have no NUL bytes
+	}
+	return strings.ReplaceAll(s, "\x00", "")
 }
 
 // filterRulesByLanguage keeps only active rules whose language is in the project.

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -1452,3 +1452,30 @@ func TestImportSkipsCompletedBranches(t *testing.T) {
 		}
 	}
 }
+
+// TestStripNullBytes verifies that NUL characters are removed from source text
+// (PHP/other security-demo files may embed NUL bytes; the SonarCloud CE rejects
+// source files containing them with "Visit of Component failed").
+func TestStripNullBytes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no NULs — fast path unchanged", in: "normal source\nno issues", want: "normal source\nno issues"},
+		{name: "single NUL stripped", in: "before\x00after", want: "beforeafter"},
+		{name: "multiple NULs stripped", in: "\x00a\x00b\x00", want: "ab"},
+		{name: "PHP null-byte injection demo", in: "<?php\ninclude $_GET[\"f\"]\x00\".php\";\n?>", want: "<?php\ninclude $_GET[\"f\"]\".php\";\n?>"},
+		{name: "empty string unchanged", in: "", want: ""},
+		{name: "only NULs becomes empty", in: "\x00\x00\x00", want: ""},
+		{name: "newlines and tabs preserved", in: "line1\n\tindented\r\nline3", want: "line1\n\tindented\r\nline3"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stripNullBytes(tc.in)
+			if got != tc.want {
+				t.Errorf("stripNullBytes(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Root cause: security-demo PHP files (e.g. RCE-Labs/RCE-2/rce_2.php) embed NUL bytes (U+0000) in source code. When written verbatim into source-<ref>.txt in the scanner-report ZIP, the SonarCloud CE fails with 'Visit of Component failed' / 'Fail to process issues of component'. Fix: strip NUL bytes via strings.ReplaceAll before placing source into pbSources, with a fast-path ContainsRune check for the common NUL-free case. Test: TestStripNullBytes covers the PHP null-byte injection pattern from the bug report.