### PR TITLE
fix: zero column offsets for purged-source files to prevent CE 'Visit of Component failed'

### DIFF
--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -459,7 +459,16 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	// them with blank placeholder source. The branch then lands with its
 	// measures and issues, matching the source server's own post-purge state;
 	// the purged files simply render as empty.
-	ensureFileSourcesPresent(fileComps, pbSources)
+	//
+	// purgedRefs is the set of file component refs that received placeholder
+	// source (i.e. source was unavailable). These refs need special treatment
+	// for issues: their placeholder source consists of empty lines (just "\n"
+	// characters), so any issue whose text range carries a non-zero column
+	// offset would be rejected by the CE with "offset out of range". We zero
+	// out the offsets for those issues below while preserving their line numbers.
+	purgedRefs := ensureFileSourcesPresent(fileComps, pbSources)
+	issues = zeroOffsetsForPurgedComponents(issues, purgedRefs, cr)
+	hotspotIssues = zeroOffsetsForPurgedComponents(hotspotIssues, purgedRefs, cr)
 
 	changesets := buildChangesetMap(cr, components, pbSources, scmByComponent, now)
 
@@ -568,11 +577,17 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 // line — for any file missing real source. Used for #425 purged-source
 // branches: the SonarCloud CE rejects a report containing a file with no
 // source text, so each source-less file is given just enough (empty) lines
-// for the report to be accepted and any issue anchors to fall in range.
+// for the report to be accepted and any issue line anchors to fall in range.
 // Files that already have real source are left untouched; the declared line
 // count of a filled file is clamped to at least 1 so the placeholder source
 // and the component agree. No-op for branches whose files all carry source.
-func ensureFileSourcesPresent(fileComps []*pb.Component, sources map[int32]string) {
+//
+// Returns the set of component refs that received placeholder source. Callers
+// use this to zero out column offsets on issues for those components — the CE
+// validates offsets against the actual source line width and rejects any offset
+// that exceeds the (empty) placeholder line length.
+func ensureFileSourcesPresent(fileComps []*pb.Component, sources map[int32]string) map[int32]struct{} {
+	purged := make(map[int32]struct{})
 	for _, fc := range fileComps {
 		if _, has := sources[fc.GetRef()]; has {
 			continue
@@ -581,7 +596,34 @@ func ensureFileSourcesPresent(fileComps []*pb.Component, sources map[int32]strin
 			fc.Lines = 1
 		}
 		sources[fc.GetRef()] = strings.Repeat("\n", int(fc.Lines)-1)
+		purged[fc.GetRef()] = struct{}{}
 	}
+	return purged
+}
+
+// zeroOffsetsForPurgedComponents returns a copy of issues with StartOff and
+// EndOff set to 0 for any issue whose component has purged (placeholder) source.
+// The CE validates column offsets against the actual source line content; when
+// placeholder source is used every line is empty, so any non-zero offset would
+// cause "Visit of Component failed". Zeroing the offsets preserves line-level
+// positioning while avoiding the out-of-range rejection.
+func zeroOffsetsForPurgedComponents(issues []scanreport.IssueInput, purgedRefs map[int32]struct{}, cr *scanreport.ComponentRef) []scanreport.IssueInput {
+	if len(purgedRefs) == 0 {
+		return issues
+	}
+	out := make([]scanreport.IssueInput, len(issues))
+	copy(out, issues)
+	for i := range out {
+		ref, ok := cr.Refs()[out[i].Component]
+		if !ok {
+			continue
+		}
+		if _, isPurged := purgedRefs[ref]; isPurged {
+			out[i].StartOff = 0
+			out[i].EndOff = 0
+		}
+	}
+	return out
 }
 
 // fixComponentLineCounts sets each component's line count to the best available

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -266,7 +266,20 @@ func TestEnsureFileSourcesPresent(t *testing.T) {
 	}
 	sources := map[int32]string{4: "real\nsource"}
 
-	ensureFileSourcesPresent(fileComps, sources)
+	purged := ensureFileSourcesPresent(fileComps, sources)
+
+	// The function must report exactly the three purged refs (1, 2, 3).
+	if len(purged) != 3 {
+		t.Fatalf("want 3 purged refs, got %d: %v", len(purged), purged)
+	}
+	for _, ref := range []int32{1, 2, 3} {
+		if _, ok := purged[int32(ref)]; !ok {
+			t.Errorf("ref %d must be in purged set", ref)
+		}
+	}
+	if _, ok := purged[4]; ok {
+		t.Error("ref 4 (has real source) must NOT be in purged set")
+	}
 
 	if len(sources) != 4 {
 		t.Fatalf("want a source entry per file (4), got %d", len(sources))
@@ -1477,5 +1490,48 @@ func TestStripNullBytes(t *testing.T) {
 				t.Errorf("stripNullBytes(%q) = %q, want %q", tc.in, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestZeroOffsetsForPurgedComponents verifies that issues on components whose
+// source was purged have their column offsets zeroed while their line numbers
+// are preserved. Issues on components with real source are left untouched.
+// This prevents the SonarCloud CE "Visit of Component failed" error that occurs
+// when placeholder source (empty lines) is submitted for purged-source files and
+// an issue references a column offset beyond the empty line length.
+func TestZeroOffsetsForPurgedComponents(t *testing.T) {
+	cr := scanreport.NewComponentRef()
+	cr.Get("purged-file:App.php")  // ref 1 — will be in purgedRefs
+	cr.Get("real-file:Foo.java")   // ref 2 — not purged
+
+	purgedRefs := map[int32]struct{}{1: {}}
+
+	issues := []scanreport.IssueInput{
+		// Issue on purged file: offsets should be zeroed, line preserved.
+		{Component: "purged-file:App.php", StartLine: 10, EndLine: 10, StartOff: 5, EndOff: 20},
+		// Issue on real file: left completely unchanged.
+		{Component: "real-file:Foo.java", StartLine: 3, EndLine: 5, StartOff: 2, EndOff: 8},
+		// Issue with no component key: unchanged (unmapped).
+		{Component: "unknown:Other.php", StartLine: 1, EndLine: 1, StartOff: 0, EndOff: 10},
+	}
+
+	out := zeroOffsetsForPurgedComponents(issues, purgedRefs, cr)
+
+	// Purged file: line preserved, offsets zeroed.
+	if out[0].StartLine != 10 || out[0].EndLine != 10 {
+		t.Errorf("purged issue: line must be preserved, got %d-%d", out[0].StartLine, out[0].EndLine)
+	}
+	if out[0].StartOff != 0 || out[0].EndOff != 0 {
+		t.Errorf("purged issue: offsets must be zeroed, got start=%d end=%d", out[0].StartOff, out[0].EndOff)
+	}
+
+	// Real file: completely untouched.
+	if out[1].StartOff != 2 || out[1].EndOff != 8 {
+		t.Errorf("real-file issue: offsets must be unchanged, got start=%d end=%d", out[1].StartOff, out[1].EndOff)
+	}
+
+	// Original slice is not mutated.
+	if issues[0].StartOff != 5 {
+		t.Error("original issues slice must not be mutated")
 	}
 }


### PR DESCRIPTION
Root cause: when source is purged, placeholder source consists of empty lines. Any issue with StartOffset>0 triggers CE 'offset out of range' → 'Visit of Component failed' → Partial Migration. rce_2.php failed because PHP vulnerability-demo issues carry character-level text ranges. Fix: ensureFileSourcesPresent returns the purged-ref set; zeroOffsetsForPurgedComponents clears StartOff/EndOff for those issues (line positioning preserved). Tests updated.