### PR TITLE
PREQ-6884: Add CODEOWNERS for customer-success-technical-advisory-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @SonarSource/customer-success-technical-advisory-squad


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` assigning `@SonarSource/customer-success-technical-advisory-squad` as owner for all repository files.

## Test plan
- [x] Verify GitHub recognizes the team as code owners on the PR