### PR TITLE
Update test.yml and build.yml to reference vault secret

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,9 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,7 +44,6 @@ jobs:
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@v8
         env:
-# Reference the token from Vault
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
 
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,17 @@ jobs:
         run: |
           sed 's|github.com/sonar-solutions/sonar-migration-tool/|go/|g' go/coverage.out > go/coverage.sonar.out
           sed 's|github.com/sonar-solutions/sq-api-go/|lib/sq-api-go/|g' lib/sq-api-go/coverage.out > lib/sq-api-go/coverage.sonar.out
+      - name: Fetch Vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/kv/data/sonarcloud token | SONAR_TOKEN;
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+# Reference the token from Vault
+          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
 
   release:
     name: Release Binaries

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,15 @@ jobs:
         working-directory: go
         run: go test $(go list ./... | grep -v '/cmd$') -coverprofile=coverage.out -count=1
 
+      - name: Fetch Vault secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/kv/data/sonarcloud token | SONAR_TOKEN;
+
       - name: SonarQube Cloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7
+        uses: SonarSource/sonarqube-scan-action@v8
         env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # Reference the token from Vault
+          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,7 @@ jobs:
   test-and-analyze:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
     timeout-minutes: 15
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=sonar-solutions_sonar-reports
-sonar.organization=sonar-solutions
+sonar.projectKey=SonarSource_sonar-migration-tool
+sonar.organization=sonarsource
 
 sonar.go.coverage.reportPaths=lib/sq-api-go/coverage.sonar.out,go/coverage.sonar.out
 sonar.sources=lib/sq-api-go,go/cmd,go/internal,go/main.go


### PR DESCRIPTION
# Reference the SONAR_TOKEN from Vault

----
## Summary by Gitar

- **Workflow configuration:**
  - Added `id-token: write` permission to `build.yml` and `test.yml` for OIDC authentication.
  - Integrated `SonarSource/vault-action-wrapper@v3` in both workflows to fetch secrets.
- **Dependency updates:**
  - Upgraded `sonarqube-scan-action` from `v7` to `v8` in CI pipelines.
- **SonarCloud metadata:**
  - Updated `sonar.projectKey` and `sonar.organization` in `sonar-project.properties`.

<sub>This will update automatically on new commits.</sub>