### PR TITLE
feat: add GPG signing for binaries and update CI to sign and publish releases

### DIFF
--- a/.github/scripts/gpg-sign.sh
+++ b/.github/scripts/gpg-sign.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Create a detached, ASCII-armored GPG signature (<binary>.asc) for a binary.
+#
+# Usage: .github/scripts/gpg-sign.sh <path-to-binary>
+#
+# Required environment variables:
+#   GPG_SIGNING_KEY         ASCII-armored private key (see note below if base64)
+#   GPG_SIGNING_PASSPHRASE  passphrase protecting the private key
+#
+# Mirrors the `bun build-scripts/sign.ts <binary>` step used by the
+# SonarSource/sonarqube-cli build workflow.
+set -euo pipefail
+
+binary="${1:?usage: gpg-sign.sh <binary>}"
+
+: "${GPG_SIGNING_KEY:?GPG_SIGNING_KEY is required}"
+: "${GPG_SIGNING_PASSPHRASE:?GPG_SIGNING_PASSPHRASE is required}"
+
+# Use a throwaway GnuPG home so the runner keyring is never polluted.
+GNUPGHOME="$(mktemp -d)"
+export GNUPGHOME
+chmod 700 "$GNUPGHOME"
+echo "allow-loopback-pinentry" > "$GNUPGHOME/gpg-agent.conf"
+trap 'rm -rf "$GNUPGHOME"' EXIT
+
+# Import the signing key, accepting either an ASCII-armored key or a
+# base64-encoded one (Vault may store it in either form).
+import_signing_key() {
+  if printf '%s' "$GPG_SIGNING_KEY" | gpg --batch --import 2>/dev/null; then
+    echo "gpg-sign: imported ASCII-armored signing key"
+    return 0
+  fi
+  if printf '%s' "$GPG_SIGNING_KEY" | base64 --decode 2>/dev/null | gpg --batch --import 2>/dev/null; then
+    echo "gpg-sign: imported base64-encoded signing key"
+    return 0
+  fi
+  echo "gpg-sign: could not import GPG_SIGNING_KEY (expected ASCII-armored or base64)" >&2
+  return 1
+}
+import_signing_key
+
+printf '%s' "$GPG_SIGNING_PASSPHRASE" | gpg --batch --yes --pinentry-mode loopback \
+  --passphrase-fd 0 --detach-sign --armor --output "${binary}.asc" "$binary"
+
+gpg --verify "${binary}.asc" "$binary"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,13 +46,17 @@ jobs:
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
 
-  release:
-    name: Release Binaries
+  # Cross-compile every platform binary on Linux and GPG-sign each one, mirroring
+  # the `build-binaries` job in SonarSource/sonarqube-cli. macOS binaries are
+  # re-signed after notarization in the sign-macos job below.
+  build-binaries:
+    name: Build All Binaries
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      id-token: write   # Vault OIDC
+      contents: read
     strategy:
       matrix:
         include:
@@ -87,7 +91,152 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: '0'
         run: go build -o ../sonar-migration-tool-${{ matrix.suffix }} .
-      - name: Upload release artifact
+
+      - name: Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/kv/data/sign key | GPG_SIGNING_KEY;
+            development/kv/data/sign passphrase | GPG_SIGNING_PASSPHRASE;
+
+      - name: GPG-sign binary
+        env:
+          GPG_SIGNING_KEY: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_PASSPHRASE }}
+        run: .github/scripts/gpg-sign.sh sonar-migration-tool-${{ matrix.suffix }}
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binary-${{ matrix.suffix }}
+          path: |
+            sonar-migration-tool-${{ matrix.suffix }}
+            sonar-migration-tool-${{ matrix.suffix }}.asc
+          if-no-files-found: error
+
+  # Code-sign + notarize the macOS binaries on an Apple runner, then re-GPG-sign
+  # them (codesign mutates the binary, invalidating the earlier signature).
+  # Mirrors the `sign-macos` job in SonarSource/sonarqube-cli.
+  sign-macos:
+    name: Sign and Notarize macOS Binaries
+    needs: build-binaries
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: macos-latest-xlarge
+    permissions:
+      id-token: write   # Vault OIDC
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      # GitHub-hosted macOS runners reach internal Vault via Cloudflare WARP.
+      - name: Setup Cloudflare WARP
+        uses: SonarSource/gh-action_setup-cloudflare-warp@fe31a2b2f31595cffdef290985700732cb3469d6 # v2.1.0
+
+      - name: Download macOS binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binary-darwin-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          # NOTE: confirm "sonar-migration-tool" is the correct project segment for
+          # this repo's Vault policy (mirrors development/kv/data/sign/sonarqube-cli).
+          secrets: |
+            development/kv/data/sign/sonar-migration-tool CERTIFICATE | CERTIFICATE;
+            development/kv/data/sign/sonar-migration-tool CSC_KEY_PASSWORD | CSC_KEY_PASSWORD;
+            development/kv/data/sign/sonar-migration-tool APPLE_TEAM_ID | APPLE_TEAM_ID;
+            development/kv/data/sign/sonar-migration-tool APPLE_ID | APPLE_ID;
+            development/kv/data/sign/sonar-migration-tool APPLE_APP_SPECIFIC_PASSWORD | APPLE_APP_SPECIFIC_PASSWORD;
+            development/kv/data/sign key | GPG_SIGNING_KEY;
+            development/kv/data/sign passphrase | GPG_SIGNING_PASSPHRASE;
+
+      - name: Code-sign and notarize macOS binaries
+        env:
+          CERTIFICATE: ${{ fromJSON(steps.secrets.outputs.vault).CERTIFICATE }}
+          CSC_KEY_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).CSC_KEY_PASSWORD }}
+          APPLE_TEAM_ID: ${{ fromJSON(steps.secrets.outputs.vault).APPLE_TEAM_ID }}
+          APPLE_ID: ${{ fromJSON(steps.secrets.outputs.vault).APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ fromJSON(steps.secrets.outputs.vault).APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          echo "$CERTIFICATE" | base64 --decode > /tmp/certificate.p12
+          security create-keychain -p "" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "" build.keychain
+          security import /tmp/certificate.p12 -k build.keychain -P "$CSC_KEY_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple: -s -k "" build.keychain
+          rm /tmp/certificate.p12
+
+          sign_macos_binary() {
+            local binary="$1"
+            local archive="/tmp/$(basename "$binary").zip"
+
+            codesign --sign "Developer ID Application: SonarSource SA ($APPLE_TEAM_ID)" --identifier sonar-migration-tool --options runtime --timestamp "$binary"
+            codesign --verify --verbose "$binary"
+
+            zip "$archive" "$binary"
+            xcrun notarytool submit "$archive" --apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+            rm "$archive"
+          }
+
+          while IFS= read -r -d '' binary; do
+            sign_macos_binary "$binary"
+          done < <(find dist -maxdepth 1 -type f -name 'sonar-migration-tool-darwin-*' ! -name '*.asc' -print0)
+
+      - name: Clean up build keychain
+        if: always()
+        run: |
+          security default-keychain -s ~/Library/Keychains/login.keychain-db 2>/dev/null || true
+          security delete-keychain build.keychain 2>/dev/null || true
+
+      - name: Re-GPG-sign macOS binaries
+        env:
+          GPG_SIGNING_KEY: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSPHRASE: ${{ fromJSON(steps.secrets.outputs.vault).GPG_SIGNING_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r -d '' binary; do
+            .github/scripts/gpg-sign.sh "$binary"
+          done < <(find dist -maxdepth 1 -type f -name 'sonar-migration-tool-darwin-*' ! -name '*.asc' -print0)
+
+      - name: Upload signed macOS binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries-macos-signed
+          path: dist/sonar-migration-tool-darwin-*
+          if-no-files-found: error
+
+  # Collect all artifacts (with the signed macOS binaries overwriting the
+  # unsigned ones) and attach them to the GitHub Release for the tag.
+  publish:
+    name: Publish Release
+    needs: [build-binaries, sign-macos]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # create/update the GitHub Release
+    steps:
+      - name: Download all binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binary-*
+          path: dist/
+          merge-multiple: true
+
+      # Overwrites the unsigned macOS binaries + signatures from the step above.
+      - name: Download signed macOS binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binaries-macos-signed
+          path: dist/
+
+      - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: sonar-migration-tool-${{ matrix.suffix }}
+          files: dist/sonar-migration-tool-*


### PR DESCRIPTION
Referencing https://github.com/SonarSource/sonarqube-cli/blob/5274ec8a59d4818215886d0cf72230773e3ef262/.github/workflows/build.yml#L126

Introduce a new GPG signing script and extend the CI workflow to sign Linux/macOS binaries, securely fetch signing keys from Vault, re-sign macOS after notarization, and publish signed artifacts to GitHub Releases. This aligns signing steps with the SonarSource workflow and ensures verified binaries in releases.