### PR TITLE
PREQ-7041: reuse sonarqube-cli Apple signing credentials

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,14 +156,13 @@ jobs:
         id: secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
-          # NOTE: confirm "sonar-migration-tool" is the correct project segment for
-          # this repo's Vault policy (mirrors development/kv/data/sign/sonarqube-cli).
+          # Reuse the shared Apple signing credentials from sonarqube-cli.
           secrets: |
-            development/kv/data/sign/sonar-migration-tool CERTIFICATE | CERTIFICATE;
-            development/kv/data/sign/sonar-migration-tool CSC_KEY_PASSWORD | CSC_KEY_PASSWORD;
-            development/kv/data/sign/sonar-migration-tool APPLE_TEAM_ID | APPLE_TEAM_ID;
-            development/kv/data/sign/sonar-migration-tool APPLE_ID | APPLE_ID;
-            development/kv/data/sign/sonar-migration-tool APPLE_APP_SPECIFIC_PASSWORD | APPLE_APP_SPECIFIC_PASSWORD;
+            development/kv/data/sign/sonarqube-cli CERTIFICATE | CERTIFICATE;
+            development/kv/data/sign/sonarqube-cli CSC_KEY_PASSWORD | CSC_KEY_PASSWORD;
+            development/kv/data/sign/sonarqube-cli APPLE_TEAM_ID | APPLE_TEAM_ID;
+            development/kv/data/sign/sonarqube-cli APPLE_ID | APPLE_ID;
+            development/kv/data/sign/sonarqube-cli APPLE_APP_SPECIFIC_PASSWORD | APPLE_APP_SPECIFIC_PASSWORD;
             development/kv/data/sign key | GPG_SIGNING_KEY;
             development/kv/data/sign passphrase | GPG_SIGNING_PASSPHRASE;
 
@@ -177,7 +176,7 @@ jobs:
           # `fromJSON(...)` in `env:` — an inline `fromJSON('')` on an empty Vault
           # response raises an opaque "template is not valid" error. Fail clearly.
           if [ -z "${VAULT_SECRETS:-}" ]; then
-            echo "::error::No secrets returned from Vault — cannot code-sign/notarize. The repo's Vault role (github-SonarSource-sonar-migration-tool-protected) likely lacks read access to development/kv/data/sign/sonar-migration-tool and/or development/kv/data/cloudflare/warp-github-runner. See docs/RELEASE-SIGNING-SETUP.md."
+            echo "::error::No secrets returned from Vault — cannot code-sign/notarize. The repo's Vault role (github-SonarSource-sonar-migration-tool-protected) likely lacks read access to development/kv/data/sign/sonarqube-cli and/or development/kv/data/cloudflare/warp-github-runner. See docs/RELEASE-SIGNING-SETUP.md."
             exit 1
           fi
           CERTIFICATE="$(jq -er '.CERTIFICATE' <<<"$VAULT_SECRETS")"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,13 +156,13 @@ jobs:
         id: secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
-          # Reuse the shared Apple signing credentials from sonarqube-cli.
+          # Shared Apple signing credentials (development/kv/data/sign/apple).
           secrets: |
-            development/kv/data/sign/sonarqube-cli CERTIFICATE | CERTIFICATE;
-            development/kv/data/sign/sonarqube-cli CSC_KEY_PASSWORD | CSC_KEY_PASSWORD;
-            development/kv/data/sign/sonarqube-cli APPLE_TEAM_ID | APPLE_TEAM_ID;
-            development/kv/data/sign/sonarqube-cli APPLE_ID | APPLE_ID;
-            development/kv/data/sign/sonarqube-cli APPLE_APP_SPECIFIC_PASSWORD | APPLE_APP_SPECIFIC_PASSWORD;
+            development/kv/data/sign/apple CERTIFICATE | CERTIFICATE;
+            development/kv/data/sign/apple CSC_KEY_PASSWORD | CSC_KEY_PASSWORD;
+            development/kv/data/sign/apple APPLE_TEAM_ID | APPLE_TEAM_ID;
+            development/kv/data/sign/apple APPLE_ID | APPLE_ID;
+            development/kv/data/sign/apple APPLE_APP_SPECIFIC_PASSWORD | APPLE_APP_SPECIFIC_PASSWORD;
             development/kv/data/sign key | GPG_SIGNING_KEY;
             development/kv/data/sign passphrase | GPG_SIGNING_PASSPHRASE;
 
@@ -176,7 +176,7 @@ jobs:
           # `fromJSON(...)` in `env:` — an inline `fromJSON('')` on an empty Vault
           # response raises an opaque "template is not valid" error. Fail clearly.
           if [ -z "${VAULT_SECRETS:-}" ]; then
-            echo "::error::No secrets returned from Vault — cannot code-sign/notarize. The repo's Vault role (github-SonarSource-sonar-migration-tool-protected) likely lacks read access to development/kv/data/sign/sonarqube-cli and/or development/kv/data/cloudflare/warp-github-runner. See docs/RELEASE-SIGNING-SETUP.md."
+            echo "::error::No secrets returned from Vault — cannot code-sign/notarize. The repo's Vault role (github-SonarSource-sonar-migration-tool-protected) likely lacks read access to development/kv/data/sign/apple and/or development/kv/data/cloudflare/warp-github-runner. See docs/RELEASE-SIGNING-SETUP.md."
             exit 1
           fi
           CERTIFICATE="$(jq -er '.CERTIFICATE' <<<"$VAULT_SECRETS")"

--- a/docs/RELEASE-SIGNING-SETUP.md
+++ b/docs/RELEASE-SIGNING-SETUP.md
@@ -13,13 +13,13 @@ Cloudflare WARP.
 | Path | Purpose |
 |------|---------|
 | `development/kv/data/cloudflare/warp-github-runner` | WARP tunnel (macOS runner → Vault) |
-| `development/kv/data/sign/sonarqube-cli` | Apple Developer ID + notarization (shared with `sonarqube-cli`) |
+| `development/kv/data/sign/apple` | Apple Developer ID + notarization (shared) |
 | `development/kv/data/sign` | GPG signing key + passphrase |
 | `development/kv/data/sonarcloud` | SonarQube scan token (`test` job) |
 
-macOS code-signing reuses the **same Apple credentials** as
-`SonarSource/sonarqube-cli` (`development/kv/data/sign/sonarqube-cli`). The
-binary is still signed with identifier `sonar-migration-tool`.
+macOS code-signing uses the shared Apple credentials at
+`development/kv/data/sign/apple`. The binary is still signed with identifier
+`sonar-migration-tool`.
 
 Vault policy is managed in
 [`re-terraform-aws-vault`](https://github.com/SonarSource/re-terraform-aws-vault)

--- a/docs/RELEASE-SIGNING-SETUP.md
+++ b/docs/RELEASE-SIGNING-SETUP.md
@@ -1,142 +1,43 @@
-# Release Signing — Vault Access Request & Setup
+# Release Signing — Vault Access & Setup
 
-<!-- updated: 2026-07-03_17:21:06 -->
-
-This document is the actionable request to the Release Engineering / build-infra
-team to provision the Vault access that the tag-triggered release pipeline
-(`.github/workflows/build.yml`) needs in order to code-sign, notarize, and
-publish `sonar-migration-tool` binaries. It also records the evidence and the
-current partial state so the request is self-contained.
-
-## TL;DR for the RE / build-infra team
-
-<!-- updated: 2026-07-03_17:21:06 -->
-
-The GitHub repo `SonarSource/sonar-migration-tool` runs a release workflow on
-`v*` tag pushes that signs macOS binaries on a GitHub-hosted Apple runner. That
-runner reaches internal Vault (`https://vault.sonar.build`) via Cloudflare WARP.
-The repo's Vault role currently **lacks read access to the Cloudflare WARP runner
-secret and (unverified) the Apple signing certificate path**, so the signing job
-fails and no release is published.
-
-Please grant the role below read access to the two paths listed under
-"Access required". This mirrors the setup already in place for
-`SonarSource/sonarqube-cli`, whose `build-binaries` / `sign-macos` jobs this
-workflow was modeled on.
+The tag-triggered release pipeline (`.github/workflows/build.yml`) signs macOS
+binaries on a GitHub-hosted Apple runner that reaches internal Vault via
+Cloudflare WARP.
 
 - **GitHub repo:** `SonarSource/sonar-migration-tool`
 - **Vault URL:** `https://vault.sonar.build`
-- **Vault role (auto-selected for tag/protected refs):** `github-SonarSource-sonar-migration-tool-protected`
+- **Vault role (tag/protected refs):** `github-SonarSource-sonar-migration-tool-protected`
 
-## Access required
+## Vault paths used
 
-<!-- updated: 2026-07-03_17:21:06 -->
+| Path | Purpose |
+|------|---------|
+| `development/kv/data/cloudflare/warp-github-runner` | WARP tunnel (macOS runner → Vault) |
+| `development/kv/data/sign/sonarqube-cli` | Apple Developer ID + notarization (shared with `sonarqube-cli`) |
+| `development/kv/data/sign` | GPG signing key + passphrase |
+| `development/kv/data/sonarcloud` | SonarQube scan token (`test` job) |
 
-The role `github-SonarSource-sonar-migration-tool-protected` needs read
-(`read` capability on the KV v2 data path) for:
+macOS code-signing reuses the **same Apple credentials** as
+`SonarSource/sonarqube-cli` (`development/kv/data/sign/sonarqube-cli`). The
+binary is still signed with identifier `sonar-migration-tool`.
 
-1. `development/kv/data/cloudflare/warp-github-runner`
-   — Cloudflare WARP client credentials so the GitHub-hosted macOS runner can
-   tunnel to internal Vault. Consumed by the `Setup Cloudflare WARP` step
-   (`SonarSource/gh-action_setup-cloudflare-warp`) in the `sign-macos` job.
-   **This is the path that was explicitly DENIED (see Evidence).**
+Vault policy is managed in
+[`re-terraform-aws-vault`](https://github.com/SonarSource/re-terraform-aws-vault)
+(`orders/customer-success-technical-advisory-squad.yaml`).
 
-2. `development/kv/data/sign/sonar-migration-tool`
-   — Apple Developer ID signing + notarization credentials. Keys read by the
-   workflow: `CERTIFICATE`, `CSC_KEY_PASSWORD`, `APPLE_TEAM_ID`, `APPLE_ID`,
-   `APPLE_APP_SPECIFIC_PASSWORD`. Consumed by the `Vault Secrets` →
-   `Code-sign and notarize macOS binaries` steps in the `sign-macos` job.
-   **This path was not reached in the failing run (the WARP step failed first),
-   so its existence/access is UNVERIFIED and should be confirmed as part of this
-   request.** If the correct project segment is not `sonar-migration-tool`,
-   please advise the correct segment and we will update the workflow.
+## Re-triggering a release
 
-## Already working (partial provisioning)
-
-<!-- updated: 2026-07-03_17:21:06 -->
-
-These paths are already accessible to the repo and succeeded in the same run,
-which confirms the repo is partially onboarded to Vault — only the two paths
-above are missing:
-
-- `development/kv/data/sonarcloud token` → used by the `test` job (SonarQube
-  scan). Succeeded.
-- `development/kv/data/sign key` and `development/kv/data/sign passphrase` →
-  GPG signing keys used by the `build-binaries` job. Succeeded; all six
-  platform binaries were GPG-signed.
-
-Note the Linux jobs (`test`, `build-binaries`) reach Vault directly and do not
-need WARP. Only the macOS runner (`macos-latest-xlarge`) requires the WARP path.
-
-## Evidence
-
-<!-- updated: 2026-07-03_17:21:06 -->
-
-First live run of the signing pipeline: tag `v1.0.0`, workflow run
-`28650002595` (event `push`, ref `refs/tags/v1.0.0`), 2026-07-03.
-
-Job results:
-
-- `Test` — success
-- `Build All Binaries` (×6 platforms) — success (cross-compiled + GPG-signed)
-- `Sign and Notarize macOS Binaries` — **failure**
-- `Publish Release` — skipped (depends on the failed job → no release created)
-
-Failing step and error (from the `sign-macos` job log):
-
-```
-Auto-selected role: github-SonarSource-sonar-migration-tool-protected (ref: refs/tags/v1.0.0, protected: true)
-##[error]Response code 403 (Forbidden)
-##[error]  DENIED  development/kv/data/cloudflare/warp-github-runner
-##[error]Vault secret access denied for 1 path(s).
-```
-
-Step trace (root cause is step 3; steps 6/8 were downstream fallout — see
-"Workflow hardening" below):
-
-```
-3  failure  Setup Cloudflare WARP        <- Vault denied cloudflare/warp path (403)
-4  skipped  Download macOS binaries
-5  skipped  Vault Secrets                <- signing certs never fetched
-6  failure  Code-sign and notarize
-8  failure  Re-GPG-sign macOS binaries
-```
-
-## Re-triggering after access is granted
-
-<!-- updated: 2026-07-03_17:21:06 -->
-
-Only a `v*` tag push runs the binary/sign/publish jobs (they are gated on
-`if: startsWith(github.ref, 'refs/tags/v')`). Branch and PR pushes only run
-`test`. To validate end-to-end without polluting the releases page, push a
-pre-release tag first:
+Only `v*` tag pushes run build/sign/publish. To validate end-to-end:
 
 ```bash
-TAG="v1.0.0-rc1"           # or a date-scheme tag, e.g. v$(date +%Y.%m.%d-%H%M%S)
+TAG="v1.0.0-rc2"
 git tag "$TAG" <commit>
 git push origin "$TAG"
 ```
 
-If it goes green, push the real tag. To clean up a failed attempt:
+To clean up a failed attempt:
 
 ```bash
-gh release delete "$TAG" --cleanup-tag --yes   # if a release was created
+gh release delete "$TAG" --cleanup-tag --yes
 git push origin ":refs/tags/$TAG" && git tag -d "$TAG"
 ```
-
-## Workflow hardening (already applied in this repo)
-
-<!-- updated: 2026-07-03_17:21:06 -->
-
-The three signing steps previously inlined `${{ fromJSON(steps.secrets.outputs.vault).X }}`
-in their `env:` blocks. When Vault returns nothing (access denied / step
-skipped), `fromJSON('')` raises an opaque `The template is not valid ... Error
-reading JToken` error that masked the real cause. Those steps now read the raw
-Vault JSON via `jq` inside the script and fail with an actionable
-`::error::` message that names the role and the missing paths and points here.
-Affected steps: `GPG-sign binary` (build-binaries), `Code-sign and notarize
-macOS binaries`, and `Re-GPG-sign macOS binaries` (sign-macos).
-
-Not yet hardened: the `test` job's `SONAR_TOKEN` still uses the inline
-`fromJSON` pattern. It is a separate job on a working Vault path, so it was left
-out of scope; harden it the same way if desired.


### PR DESCRIPTION
## Summary

- Point the `sign-macos` Vault step at `development/kv/data/sign/sonarqube-cli` (existing secret) instead of the non-existent `sign/sonar-migration-tool` path.
- Update `docs/RELEASE-SIGNING-SETUP.md` accordingly.

## Context

- Jira: https://sonarsource.atlassian.net/browse/PREQ-7041
- `v1.0.0-rc1` run failed with: `sign/sonar-migration-tool` not found in Vault (policy OK, secret missing).
- `sonarqube-cli` already has populated Apple signing credentials at `sign/sonarqube-cli`.

## Paired change

Vault policy PR (grants read on `sign/sonarqube-cli`): SonarSource/re-terraform-aws-vault#9404

## Test plan

- [ ] Merge vault PR and apply
- [ ] Merge this PR
- [ ] Push `v1.0.0-rc2` tag and confirm `Sign and Notarize macOS Binaries` + `Publish Release` succeed