### PR TITLE
PREQ-7041: staple notarization ticket to macOS binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -203,6 +203,8 @@ jobs:
             zip "$archive" "$binary"
             xcrun notarytool submit "$archive" --apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
             rm "$archive"
+            xcrun stapler staple "$binary"
+            xcrun stapler validate "$binary"
           }
 
           while IFS= read -r -d '' binary; do


### PR DESCRIPTION
## Summary

- After `notarytool submit --wait` succeeds, run `stapler staple` + `stapler validate` on each macOS binary before re-GPG-signing and publish.

## Why

`v1.0.0-rc2` binaries are correctly signed and notarized, but the notarization ticket was not embedded — `stapler validate` reported *"does not have a ticket stapled to it"*. Stapling lets Gatekeeper verify offline.

## Test plan

- [ ] Merge and push a test tag (e.g. `v1.0.0-rc3`)
- [ ] Confirm CI `Sign and Notarize macOS Binaries` passes stapler validate
- [ ] Download release asset and run `xcrun stapler validate` locally