### PR TITLE
PREQ-7041: align release pipeline to branch-based signing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,16 +3,21 @@
 ## Active Workflows
 
 ### 1. `build.yml` - Test + Release
+
 **Triggers:**
-- Push to `main` or `kilo` branches — runs tests and SonarQube scan
-- Push of a version tag (`v*`) — runs tests, then builds and publishes cross-platform binaries
+- Push to `main` or `branch-*` — tests, build, sign, and (on `main` only) GitHub Release publish
+- Push to `kilo` — tests and SonarQube scan only
+- Pull requests — tests and SonarQube scan only
 
 **What it does:**
 - Runs Go library and migration tool tests with coverage
 - Runs SonarQube Cloud analysis
-- On tagged releases: builds static binaries for 6 platform/arch combinations and uploads them as GitHub Release assets
+- On `main` / `branch-*` pushes: cross-compiles 6 platform binaries, GPG-signs all,
+  Apple code-signs + notarizes macOS, Authenticode-signs Windows (Azure Artifact Signing),
+  and publishes a GitHub Release on **`main` only**
 
-**Release binaries produced:**
+**Release binaries:**
+
 | Platform | Architecture | Filename |
 |----------|-------------|----------|
 | Linux    | x64         | `sonar-migration-tool-linux-amd64` |
@@ -22,6 +27,11 @@
 | Windows  | x64         | `sonar-migration-tool-windows-amd64.exe` |
 | Windows  | ARM64       | `sonar-migration-tool-windows-arm64.exe` |
 
+Each binary has a matching `.asc` GPG signature.
+
+See [docs/RELEASE-SIGNING-SETUP.md](../../docs/RELEASE-SIGNING-SETUP.md) for Vault and Azure onboarding.
+
 ### 2. `test.yml` - Manual Test Run
-**Trigger:** Manual dispatch (`workflow_dispatch`)
+
+**Trigger:** Manual dispatch (`workflow_dispatch`)  
 **Purpose:** On-demand test run with SonarQube Cloud scan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,17 @@ on:
   push:
     branches:
       - main
+      - branch-*
       - kilo
-    tags:
-      - 'v*'
   pull_request:
     types: [opened, synchronize, reopened]
+
+# Branch-based release pipeline (aligned with sonarqube-cli / Azure Artifact Signing).
+# build-binaries + signing run on main and branch-* pushes; GitHub Release publish on main only.
+env:
+  IS_RELEASE_BRANCH: ${{ github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-')) }}
+  IS_MAIN_RELEASE: ${{ github.event_name != 'pull_request' && github.ref_name == github.event.repository.default_branch }}
+  SIGNING_PROFILE: ${{ (github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))) && 'release' || 'test' }}
 
 jobs:
   test:
@@ -46,13 +52,10 @@ jobs:
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
 
-  # Cross-compile every platform binary on Linux and GPG-sign each one, mirroring
-  # the `build-binaries` job in SonarSource/sonarqube-cli. macOS binaries are
-  # re-signed after notarization in the sign-macos job below.
   build-binaries:
     name: Build All Binaries
     needs: test
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: env.IS_RELEASE_BRANCH == 'true'
     runs-on: ubuntu-latest
     permissions:
       id-token: write   # Vault OIDC
@@ -100,17 +103,13 @@ jobs:
             development/kv/data/sign key | GPG_SIGNING_KEY;
             development/kv/data/sign passphrase | GPG_SIGNING_PASSPHRASE;
 
-      # Read secrets from the raw Vault JSON via jq inside the script rather than
-      # inlining `fromJSON(...)` in `env:`. When Vault access is denied the JSON is
-      # empty, and an inline `fromJSON('')` raises an opaque "template is not valid"
-      # error; this guard fails with an actionable message instead.
       - name: GPG-sign binary
         env:
           VAULT_SECRETS: ${{ steps.secrets.outputs.vault }}
         run: |
           set -euo pipefail
           if [ -z "${VAULT_SECRETS:-}" ]; then
-            echo "::error::No secrets returned from Vault — cannot GPG-sign. The repo's Vault role (github-SonarSource-sonar-migration-tool-protected) likely lacks read access to development/kv/data/sign. See docs/RELEASE-SIGNING-SETUP.md."
+            echo "::error::No secrets returned from Vault — cannot GPG-sign. The repo's Vault role likely lacks read access to development/kv/data/sign. See docs/RELEASE-SIGNING-SETUP.md."
             exit 1
           fi
           GPG_SIGNING_KEY="$(jq -er '.GPG_SIGNING_KEY' <<<"$VAULT_SECRETS")"
@@ -127,13 +126,10 @@ jobs:
             sonar-migration-tool-${{ matrix.suffix }}.asc
           if-no-files-found: error
 
-  # Code-sign + notarize the macOS binaries on an Apple runner, then re-GPG-sign
-  # them (codesign mutates the binary, invalidating the earlier signature).
-  # Mirrors the `sign-macos` job in SonarSource/sonarqube-cli.
   sign-macos:
     name: Sign and Notarize macOS Binaries
     needs: build-binaries
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: env.IS_RELEASE_BRANCH == 'true'
     runs-on: macos-latest-xlarge
     permissions:
       id-token: write   # Vault OIDC
@@ -141,7 +137,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # GitHub-hosted macOS runners reach internal Vault via Cloudflare WARP.
       - name: Setup Cloudflare WARP
         uses: SonarSource/gh-action_setup-cloudflare-warp@fe31a2b2f31595cffdef290985700732cb3469d6 # v2.1.0
 
@@ -156,7 +151,6 @@ jobs:
         id: secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
-          # Shared Apple signing credentials (development/kv/data/sign/apple).
           secrets: |
             development/kv/data/sign/apple CERTIFICATE | CERTIFICATE;
             development/kv/data/sign/apple CSC_KEY_PASSWORD | CSC_KEY_PASSWORD;
@@ -171,12 +165,8 @@ jobs:
           VAULT_SECRETS: ${{ steps.secrets.outputs.vault }}
         run: |
           set -euo pipefail
-
-          # Extract secrets from the raw Vault JSON via jq rather than inlining
-          # `fromJSON(...)` in `env:` — an inline `fromJSON('')` on an empty Vault
-          # response raises an opaque "template is not valid" error. Fail clearly.
           if [ -z "${VAULT_SECRETS:-}" ]; then
-            echo "::error::No secrets returned from Vault — cannot code-sign/notarize. The repo's Vault role (github-SonarSource-sonar-migration-tool-protected) likely lacks read access to development/kv/data/sign/apple and/or development/kv/data/cloudflare/warp-github-runner. See docs/RELEASE-SIGNING-SETUP.md."
+            echo "::error::No secrets returned from Vault — cannot code-sign/notarize. See docs/RELEASE-SIGNING-SETUP.md."
             exit 1
           fi
           CERTIFICATE="$(jq -er '.CERTIFICATE' <<<"$VAULT_SECRETS")"
@@ -240,16 +230,83 @@ jobs:
           path: dist/sonar-migration-tool-darwin-*
           if-no-files-found: error
 
-  # Collect all artifacts (with the signed macOS binaries overwriting the
-  # unsigned ones) and attach them to the GitHub Release for the tag.
-  publish:
-    name: Publish Release
-    needs: [build-binaries, sign-macos]
-    if: startsWith(github.ref, 'refs/tags/v')
+  sign-windows:
+    name: Sign Windows Binaries
+    needs: build-binaries
+    if: env.IS_RELEASE_BRANCH == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # create/update the GitHub Release
+      id-token: write   # Azure Artifact Signing OIDC
+      contents: read
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Download Windows binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: binary-windows-*
+          path: dist/
+          merge-multiple: true
+
+      - name: Authenticode-sign Windows binaries
+        uses: SonarSource/gh-action_azure-artifact-signing@v1
+        with:
+          files: |
+            dist/sonar-migration-tool-windows-*.exe
+          signing-profile: ${{ env.SIGNING_PROFILE }}
+
+      - name: Vault Secrets
+        id: secrets
+        uses: SonarSource/vault-action-wrapper@v3
+        with:
+          secrets: |
+            development/kv/data/sign key | GPG_SIGNING_KEY;
+            development/kv/data/sign passphrase | GPG_SIGNING_PASSPHRASE;
+
+      - name: Re-GPG-sign Windows binaries
+        env:
+          VAULT_SECRETS: ${{ steps.secrets.outputs.vault }}
+        run: |
+          set -euo pipefail
+          if [ -z "${VAULT_SECRETS:-}" ]; then
+            echo "::error::No secrets returned from Vault — cannot GPG-sign. See docs/RELEASE-SIGNING-SETUP.md."
+            exit 1
+          fi
+          GPG_SIGNING_KEY="$(jq -er '.GPG_SIGNING_KEY' <<<"$VAULT_SECRETS")"
+          GPG_SIGNING_PASSPHRASE="$(jq -er '.GPG_SIGNING_PASSPHRASE' <<<"$VAULT_SECRETS")"
+          export GPG_SIGNING_KEY GPG_SIGNING_PASSPHRASE
+          while IFS= read -r -d '' binary; do
+            .github/scripts/gpg-sign.sh "$binary"
+          done < <(find dist -maxdepth 1 -type f -name 'sonar-migration-tool-windows-*.exe' ! -name '*.asc' -print0)
+
+      - name: Upload signed Windows binaries
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: binaries-windows-signed
+          path: dist/sonar-migration-tool-windows-*
+          if-no-files-found: error
+
+  publish:
+    name: Publish Release
+    needs: [build-binaries, sign-macos, sign-windows]
+    if: env.IS_MAIN_RELEASE == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Set release tag
+        id: release
+        run: |
+          TAG="v$(date -u +%Y.%m.%d)-${GITHUB_RUN_NUMBER}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Release tag: ${TAG}"
+
       - name: Download all binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -257,14 +314,23 @@ jobs:
           path: dist/
           merge-multiple: true
 
-      # Overwrites the unsigned macOS binaries + signatures from the step above.
       - name: Download signed macOS binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: binaries-macos-signed
           path: dist/
 
+      - name: Download signed Windows binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: binaries-windows-signed
+          path: dist/
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.release.outputs.tag }}
+          name: ${{ steps.release.outputs.tag }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
           files: dist/sonar-migration-tool-*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     permissions:
       id-token: write
       contents: read
@@ -56,7 +56,7 @@ jobs:
     name: Build All Binaries
     needs: test
     if: env.IS_RELEASE_BRANCH == 'true'
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     permissions:
       id-token: write   # Vault OIDC
       contents: read
@@ -234,7 +234,7 @@ jobs:
     name: Sign Windows Binaries
     needs: build-binaries
     if: env.IS_RELEASE_BRANCH == 'true'
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     permissions:
       id-token: write   # Azure Artifact Signing OIDC
       contents: read
@@ -296,7 +296,7 @@ jobs:
     name: Publish Release
     needs: [build-binaries, sign-macos, sign-windows]
     if: env.IS_MAIN_RELEASE == 'true'
-    runs-on: ubuntu-latest
+    runs-on: sonar-xs
     permissions:
       contents: write
     steps:

--- a/docs/RELEASE-SIGNING-SETUP.md
+++ b/docs/RELEASE-SIGNING-SETUP.md
@@ -1,43 +1,59 @@
-# Release Signing — Vault Access & Setup
+# Release Signing — Setup
 
-The tag-triggered release pipeline (`.github/workflows/build.yml`) signs macOS
-binaries on a GitHub-hosted Apple runner that reaches internal Vault via
-Cloudflare WARP.
+Branch-based release pipeline (`.github/workflows/build.yml`), aligned with
+`sonarqube-cli` and Azure Artifact Signing federated-credential patterns.
 
 - **GitHub repo:** `SonarSource/sonar-migration-tool`
 - **Vault URL:** `https://vault.sonar.build`
-- **Vault role (tag/protected refs):** `github-SonarSource-sonar-migration-tool-protected`
+- **Vault role (protected refs):** `github-SonarSource-sonar-migration-tool-protected`
 
-## Vault paths used
+## When jobs run
+
+| Trigger | Test | Build + sign | GitHub Release |
+|---------|------|--------------|----------------|
+| Pull request | yes | no | no |
+| Push to `main` | yes | yes (release profile) | yes |
+| Push to `branch-*` | yes | yes (release profile) | no |
+| Push to `kilo` | yes | no | no |
+
+Release signing uses **branch** OIDC subjects (`refs/heads/main`, `refs/heads/branch-*`),
+not git tags. Tags are created by the publish job on `main` pushes
+(e.g. `v2026.07.03-123`).
+
+## Vault paths (GPG + macOS)
 
 | Path | Purpose |
 |------|---------|
 | `development/kv/data/cloudflare/warp-github-runner` | WARP tunnel (macOS runner → Vault) |
-| `development/kv/data/sign/apple` | Apple Developer ID + notarization (shared) |
+| `development/kv/data/sign/apple` | Apple Developer ID + notarization |
 | `development/kv/data/sign` | GPG signing key + passphrase |
-| `development/kv/data/sonarcloud` | SonarQube scan token (`test` job) |
+| `development/kv/data/sonarcloud` | SonarQube scan token |
 
-macOS code-signing uses the shared Apple credentials at
-`development/kv/data/sign/apple`. The binary is still signed with identifier
-`sonar-migration-tool`.
+## Windows Authenticode (Azure Artifact Signing)
 
-Vault policy is managed in
-[`re-terraform-aws-vault`](https://github.com/SonarSource/re-terraform-aws-vault)
-(`orders/customer-success-technical-advisory-squad.yaml`).
+Windows `.exe` files are signed via
+[`gh-action_azure-artifact-signing@v1`](https://github.com/SonarSource/gh-action_azure-artifact-signing)
+using GitHub OIDC → Entra federated credentials.
+
+**Prerequisites (infra, not in this repo):**
+
+1. [BUILD-11815](https://sonarsource.atlassian.net/browse/BUILD-11815) — second release signing identity (pool B)
+2. Onboard `sonar-migration-tool` in
+   [`re-service-config/azure_artifact_signing`](https://github.com/SonarSource/re-service-config/tree/master/azure_artifact_signing)
+   with `release_branches = ["main", "branch-*"]` on pool B
+
+Until onboarding is applied, the `sign-windows` job will fail OIDC authentication.
 
 ## Re-triggering a release
 
-Only `v*` tag pushes run build/sign/publish. To validate end-to-end:
+Merge to `main` (or push a signed `branch-*` build for validation without publishing):
 
 ```bash
-TAG="v1.0.0-rc2"
-git tag "$TAG" <commit>
-git push origin "$TAG"
+git push origin main
 ```
 
-To clean up a failed attempt:
+To delete a failed GitHub Release:
 
 ```bash
 gh release delete "$TAG" --cleanup-tag --yes
-git push origin ":refs/tags/$TAG" && git tag -d "$TAG"
 ```


### PR DESCRIPTION
## Summary

Aligns the full release pipeline with the standard SonarSource branch-based model (sonarqube-cli, sonar-dotnet-*, Azure Artifact Signing).

- **Removed** `v*` tag trigger — signing OIDC uses `refs/heads/main` and `refs/heads/branch-*`, not tags
- **Build + sign** on `main` and `branch-*` pushes (not PRs)
- **Publish** GitHub Release on `main` only; auto-creates tag `vYYYY.MM.DD-<run_number>`
- **Added** `sign-windows` job: Authenticode via `gh-action_azure-artifact-signing@v1`, then re-GPG-sign

## Signing matrix

| Platform | Mechanism |
|----------|-----------|
| Linux | GPG (`development/kv/data/sign`) |
| macOS | Apple codesign + notarize + stapler (`sign/apple`) + re-GPG |
| Windows | Azure Artifact Signing + re-GPG |

## Infra prerequisite (not in this PR)

`sign-windows` requires Azure onboarding in `re-service-config/azure_artifact_signing`:

- [BUILD-11815](https://sonarsource.atlassian.net/browse/BUILD-11815) — pool B release identity
- `sonar-migration-tool` module with `release_branches = ["main", "branch-*"]`

Until applied, `sign-windows` will fail OIDC; other jobs unaffected on `branch-*` if we skip windows or merge after infra.

## Test plan

- [ ] PR: test job only
- [ ] Merge + push to `branch-*`: build + sign jobs run, no GitHub Release
- [ ] Merge to `main`: full pipeline including publish (after Azure onboarding for Windows)

[BUILD-11815]: https://sonarsource.atlassian.net/browse/BUILD-11815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ