### PR TITLE
fix(ci): use github-ubuntu-latest-s runner for Vault-accessing jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write
       contents: read
@@ -53,7 +53,7 @@ jobs:
     name: Build All Binaries
     needs: test
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
+    runs-on: github-ubuntu-latest-s
     permissions:
       id-token: write   # Vault OIDC
       contents: read


### PR DESCRIPTION
## Summary

- Switch `test` and `build-binaries` jobs from `ubuntu-latest` to `github-ubuntu-latest-s`
- `ubuntu-latest` draws from a large dynamic IP pool; some IPs (e.g. `52.159.243.16`) are not in Vault's firewall allowlist, causing intermittent `fetch failed` timeouts on tag builds
- `github-ubuntu-latest-s` has a known, stable egress IP that Vault already permits

## Root Cause

Run 28658859117 failed with `tcp_probe vault.sonar.build:443=timeout` — the TCP connection never reached Vault. v1.0.0-rc2 succeeded on the same workflow because a different runner instance with an allowed IP was drawn. Non-deterministic failure.

## Test plan

- [ ] PR CI passes (Vault reachable on `github-ubuntu-latest-s`)
- [ ] Re-tag or push a new tag and confirm test → build-binaries → sign-macos → publish all complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)