### PR TITLE
BUILD-11815: Remove SIGNING_PROFILE workaround from release pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# Branch-based release pipeline (aligned with sonarqube-cli / Azure Artifact Signing).
-# build-binaries + signing run on main and branch-* pushes; GitHub Release publish on main only.
-env:
-  SIGNING_PROFILE: ${{ (github.event_name != 'pull_request' && (github.ref_name == github.event.repository.default_branch || startsWith(github.ref_name, 'branch-'))) && 'release' || 'test' }}
-
 jobs:
   test:
     name: Test
@@ -262,7 +257,6 @@ jobs:
         with:
           files: |
             dist/sonar-migration-tool-windows-*.exe
-          signing-profile: ${{ env.SIGNING_PROFILE }}
 
       - name: Vault Secrets
         id: secrets


### PR DESCRIPTION
## Summary

- Remove the workflow-level `SIGNING_PROFILE` env var and explicit `signing-profile` input from the Windows Authenticode signing step
- Rely on [`gh-action_azure-artifact-signing` v1.1.0](https://github.com/SonarSource/gh-action_azure-artifact-signing/releases/tag/1.1.0) auto-detection, which now treats `main` as a release branch alongside `master` and `branch-*`

The workaround was added because the action previously only auto-selected the release profile on `master`. With BUILD-11815 shipped in the action, manual profile selection is no longer needed.

## Test plan

- [ ] Merge and verify `sign-windows` succeeds on a `main` push with release OIDC credentials
- [ ] Confirm the action logs `Using signing profile 'release'` without an explicit `signing-profile` input