### PR TITLE
fix(ci): remove stapler from macOS CLI signing (PREQ-7041)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,8 +189,6 @@ jobs:
             zip "$archive" "$binary"
             xcrun notarytool submit "$archive" --apple-id "$APPLE_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
             rm "$archive"
-            xcrun stapler staple "$binary"
-            xcrun stapler validate "$binary"
           }
 
           while IFS= read -r -d '' binary; do


### PR DESCRIPTION
## Summary

- Remove `xcrun stapler staple` / `validate` from the `sign-macos` job
- Codesign + notarization are unaffected; only the stapler step was failing

## Root cause

`xcrun stapler` only supports `.app`, `.dmg`, and `.pkg` — not bare Mach-O CLI binaries. After #468 added stapler and #469 switched to branch-based releases on `main`, every release run failed with:

```
Stapler is incapable of working with Document files.
exit code 66
```

Friday's `v1.0.0-rc2` succeeded because it was built **before** stapler landed (tag release, no stapler step). Mate's #473 (Windows `SIGNING_PROFILE` cleanup) did **not** break macOS — Windows signing works; macOS fails at stapler.

This matches `sonarqube-cli`, which notarizes zipped binaries but does not staple raw executables. Gatekeeper verifies notarization online on first launch.

## Test plan

- [ ] Merge and confirm `sign-macos` passes on a `main` push
- [ ] Confirm `publish` completes and release assets include signed darwin binaries
- [ ] Optional: `codesign --verify` + `spctl -a -t exec -vv` on downloaded darwin binary