### PR TITLE
fix: set a clear User-Agent for all SonarQube API calls

### DIFF
--- a/docs/ADVANCED-CONFIG.md
+++ b/docs/ADVANCED-CONFIG.md
@@ -12,6 +12,7 @@ This page lists **every** option `sonar-migration-tool` accepts — JSON config 
 - [Project key renaming strategy](#project-key-renaming-strategy)
 - [Per-command CLI flags](#per-command-cli-flags)
 - [SonarQube Cloud API rate limiting handling](#sonarqube-cloud-api-rate-limiting-handling)
+- [HTTP User-Agent](#http-user-agent)
 - [Legacy config shapes](#legacy-config-shapes)
 - [Security tips](#security-tips)
 
@@ -432,6 +433,18 @@ it paused. An amber rate-limit notice is shown only when rate limiting was *not*
 - a task failed with `429` as its terminal status (re-run with `--run-id` to resume), or
 - a non-standard `429` (Cloudflare / WAF / unclassified) was seen, which may need operator
   action even if it resolved on its own.
+
+---
+
+## HTTP User-Agent
+
+Every API call the tool makes to SonarQube Server or SonarQube Cloud is sent with a fixed
+`User-Agent: sonar-migration-tool` header, instead of Go's default (`Go-http-client/1.1` or
+`/2.0`). This makes the tool's traffic easy to pick out from other API clients in
+server-side/audit logs when diagnosing a migration. The header is not configurable.
+
+When `--debug` is enabled, the request headers logged for each call include this `User-Agent`
+value alongside the (redacted) `Authorization` header.
 
 ---
 

--- a/lib/sq-api-go/client.go
+++ b/lib/sq-api-go/client.go
@@ -112,7 +112,7 @@ func newClient(baseURL, token string, version float64, opts ...Option) *Client {
 
 // buildTransport constructs the layered RoundTripper stack:
 //
-//	authTransport → retryTransport → http.Transport (with optional TLS)
+//	authTransport → retryTransport → userAgentTransport → http.Transport (with optional TLS)
 func buildTransport(cfg *clientConfig, token string, version float64) http.RoundTripper {
 	tlsCfg := cfg.tlsConfig
 	if tlsCfg == nil {
@@ -127,8 +127,10 @@ func buildTransport(cfg *clientConfig, token string, version float64) http.Round
 		IdleConnTimeout: 90 * time.Second,
 	}
 
+	ua := &userAgentTransport{inner: base}
+
 	retry := &retryTransport{
-		inner:         base,
+		inner:         ua,
 		backoff:       defaultBackoff,
 		sqcBackoff:    sqc429Backoff,
 		nonSQCBackoff: nonSQC429Backoff,

--- a/lib/sq-api-go/client.go
+++ b/lib/sq-api-go/client.go
@@ -112,7 +112,14 @@ func newClient(baseURL, token string, version float64, opts ...Option) *Client {
 
 // buildTransport constructs the layered RoundTripper stack:
 //
-//	authTransport → retryTransport → userAgentTransport → http.Transport (with optional TLS)
+//	authTransport → userAgentTransport → debugTransport (optional) → retryTransport → http.Transport (with optional TLS)
+//
+// authTransport and userAgentTransport sit outside debugTransport (rather
+// than the other way around) because both inject their header by cloning
+// the request and setting it on the clone — a clone debugTransport would
+// never see if it wrapped them from the outside. Retry sits innermost so
+// debugTransport still logs exactly once per logical call, using the
+// final response after any retries.
 func buildTransport(cfg *clientConfig, token string, version float64) http.RoundTripper {
 	tlsCfg := cfg.tlsConfig
 	if tlsCfg == nil {
@@ -127,10 +134,8 @@ func buildTransport(cfg *clientConfig, token string, version float64) http.Round
 		IdleConnTimeout: 90 * time.Second,
 	}
 
-	ua := &userAgentTransport{inner: base}
-
 	retry := &retryTransport{
-		inner:         ua,
+		inner:         base,
 		backoff:       defaultBackoff,
 		sqcBackoff:    sqc429Backoff,
 		nonSQCBackoff: nonSQC429Backoff,
@@ -140,12 +145,14 @@ func buildTransport(cfg *clientConfig, token string, version float64) http.Round
 		gate:          &rateLimitGate{},
 	}
 
-	var rt http.RoundTripper = &authTransport{
-		inner:  retry,
-		header: buildAuthHeader(token, version),
-	}
+	var rt http.RoundTripper = retry
 	if cfg.debugLogFn != nil {
 		rt = &debugTransport{inner: rt, fn: cfg.debugLogFn}
+	}
+	rt = &userAgentTransport{inner: rt}
+	rt = &authTransport{
+		inner:  rt,
+		header: buildAuthHeader(token, version),
 	}
 	return rt
 }

--- a/lib/sq-api-go/debug_test.go
+++ b/lib/sq-api-go/debug_test.go
@@ -1,0 +1,47 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package sqapi_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sqapi "github.com/sonar-solutions/sq-api-go"
+)
+
+// TestDebugLoggerSeesAuthAndUserAgent pins that the headers passed to a
+// DebugLogFunc are the ones actually sent on the wire — authTransport and
+// userAgentTransport inject their headers on a cloned request, so
+// debugTransport must sit inside them in the transport stack or it only
+// ever sees the caller's original, unmodified headers.
+func TestDebugLoggerSeesAuthAndUserAgent(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	var gotHeaders map[string][]string
+	var calls int
+	c := sqapi.NewServerClient(ts.URL, "my-token", 10.7, sqapi.WithDebugLogger(
+		func(method, url string, headers map[string][]string, reqBody []byte, respStatus int, respBody []byte, err error) {
+			calls++
+			gotHeaders = headers
+		},
+	))
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/ping", nil)
+	require.NoError(t, err)
+	resp, err := c.HTTPClient().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, []string{"<redacted>"}, gotHeaders["Authorization"])
+	assert.Equal(t, []string{sqapi.UserAgent}, gotHeaders["User-Agent"])
+}

--- a/lib/sq-api-go/phase1_test.go
+++ b/lib/sq-api-go/phase1_test.go
@@ -47,6 +47,25 @@ func TestHTTPClientMakesRequest(t *testing.T) {
 	assert.Equal(t, "Bearer my-token", gotAuth)
 }
 
+func TestHTTPClientSetsUserAgent(t *testing.T) {
+	var gotUA string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	c := sqapi.NewServerClient(ts.URL, "my-token", 10.7)
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/ping", nil)
+	require.NoError(t, err)
+	resp, err := c.HTTPClient().Do(req)
+	require.NoError(t, err)
+	resp.Body.Close()
+
+	assert.Equal(t, sqapi.UserAgent, gotUA)
+	assert.Equal(t, "sonar-migration-tool", gotUA)
+}
+
 // ---- APIError ----
 
 func TestAPIErrorErrorString(t *testing.T) {

--- a/lib/sq-api-go/useragent.go
+++ b/lib/sq-api-go/useragent.go
@@ -1,0 +1,24 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package sqapi
+
+import "net/http"
+
+// UserAgent is sent with every request made through Client, so SMT traffic
+// is distinguishable from other Go HTTP clients in SonarQube/SonarCloud logs.
+const UserAgent = "sonar-migration-tool"
+
+// userAgentTransport is an http.RoundTripper that sets a fixed User-Agent
+// header on every request, overriding Go's default (Go-http-client/1.1).
+type userAgentTransport struct {
+	inner http.RoundTripper
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Clone the request so we never mutate the caller's copy.
+	r2 := req.Clone(req.Context())
+	r2.Header.Set("User-Agent", UserAgent)
+	return t.inner.RoundTrip(r2)
+}


### PR DESCRIPTION
## Summary
- The migration tool previously sent the Go http.Client default User-Agent (Go-http-client/1.1), making SMT activity hard to distinguish in SonarQube Server/Cloud logs.
- Added a userAgentTransport to the shared transport stack in lib/sq-api-go/client.go (same pattern as the existing authTransport), so every request now sends "User-Agent: sonar-migration-tool".
- This is the only place *http.Client is constructed in the repo; all other request-building code paths reuse sqapi.Client.HTTPClient(), so the fix covers all API traffic.

Fixes #479

## Test plan
- [x] go build ./... passes in both lib/sq-api-go and go modules
- [x] go test ./... passes in lib/sq-api-go
- [x] Added TestHTTPClientSetsUserAgent asserting the header is set on outgoing requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)