### PR TITLE
fix: add SQS migrated project link back to source dashboard

### DIFF
--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -73,7 +73,7 @@ const (
 var transferTargetTasks = []string{
 	// Project configuration (each is scoped to the migrated project).
 	"setProjectProfiles", "setProjectGates", "setProjectGroupPermissions",
-	"setProjectSettings", "setProjectTags", "setProjectLinks",
+	"setProjectSettings", "setProjectTags", "setProjectLinks", "setProjectSourceLink",
 	"setProjectWebhooks", "setNewCodePeriods",
 	// Quality profile rules + quality gate conditions.
 	"restoreProfiles", "addGateConditions",

--- a/go/internal/common/progress.go
+++ b/go/internal/common/progress.go
@@ -119,6 +119,7 @@ var ProgressLogInterval = map[string]int64{
 	"setDefaultGates":                      50,
 	"restoreProfiles":                      50,
 	"setProjectLinks":                      50,
+	"setProjectSourceLink":                 50,
 	"setProjectProfiles":                   50,
 	"addMigrationGroupToTemplates":         50,
 	"createMigrationGroups":                50,

--- a/go/internal/migrate/helpers.go
+++ b/go/internal/migrate/helpers.go
@@ -15,9 +15,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	sqapi "github.com/sonar-solutions/sq-api-go"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+	sqapi "github.com/sonar-solutions/sq-api-go"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -44,6 +44,7 @@ type sortSpec struct {
 var taskSortSpecs = map[string]sortSpec{
 	// Migrate-driven (records carry sonarcloud_org_key).
 	"createProjects":            {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
+	"setProjectSourceLink":      {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
 	"setProjectGates":           {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
 	"setProjectBinding":         {orgField: "sonarcloud_org_key", sortField: "cloud_project_key"},
 	"createProfiles":            {orgField: "sonarcloud_org_key", sortField: "name"},

--- a/go/internal/migrate/sourcelink_test.go
+++ b/go/internal/migrate/sourcelink_test.go
@@ -78,6 +78,37 @@ func TestHotspotSourceLinkURL(t *testing.T) {
 	}
 }
 
+func TestProjectSourceLinkURL(t *testing.T) {
+	cases := []struct {
+		name       string
+		serverURL  string
+		projectKey string
+		want       string
+	}{
+		{
+			name: "basic", serverURL: "https://sq.example.com", projectKey: "my-proj",
+			want: "https://sq.example.com/dashboard?id=my-proj",
+		},
+		{
+			name: "trailing slash trimmed", serverURL: "https://sq.example.com/", projectKey: "p",
+			want: "https://sq.example.com/dashboard?id=p",
+		},
+		{
+			name: "special chars escaped", serverURL: "https://sq.example.com", projectKey: "org:proj",
+			want: "https://sq.example.com/dashboard?id=org%3Aproj",
+		},
+		{name: "missing serverURL", serverURL: "", projectKey: "p", want: ""},
+		{name: "missing projectKey", serverURL: "https://sq", projectKey: "", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := projectSourceLinkURL(tc.serverURL, tc.projectKey); got != tc.want {
+				t.Fatalf("projectSourceLinkURL = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSourceLinkIdempotencyHelpers(t *testing.T) {
 	link := issueSourceLinkURL("https://sq.example.com", "p", "k", "")
 

--- a/go/internal/migrate/tasks_associate.go
+++ b/go/internal/migrate/tasks_associate.go
@@ -9,14 +9,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 
-	"github.com/sonar-solutions/sq-api-go/cloud"
-	"github.com/sonar-solutions/sq-api-go/types"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
 	"github.com/sonar-solutions/sonar-migration-tool/internal/structure"
+	"github.com/sonar-solutions/sq-api-go/cloud"
+	"github.com/sonar-solutions/sq-api-go/types"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -59,6 +60,11 @@ func associateTasks() []TaskDef {
 			Name:         "setProjectLinks",
 			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
 			Run:          runSetProjectLinks,
+		},
+		{
+			Name:         "setProjectSourceLink",
+			Dependencies: []string{"createProjects", "grantMigrationUserProjectPermissions"},
+			Run:          runSetProjectSourceLink,
 		},
 		{
 			Name:         "setProjectWebhooks",
@@ -1063,6 +1069,75 @@ func runSetProjectLinks(ctx context.Context, e *Executor) error {
 				"cloud_project_key": pm.CloudKey,
 			}))
 			return nil
+		})
+	return err
+}
+
+// migratedProjectLinkName is the display name of the synthetic project
+// link added by runSetProjectSourceLink (#418), so Support (and anyone
+// browsing the SonarQube Cloud project page) can immediately tell a
+// project was created by the migration tool and trace it back to its
+// SonarQube Server origin.
+const migratedProjectLinkName = "SQS migrated project"
+
+// projectSourceLinkURL builds the SonarQube Server dashboard deep link
+// back to the original project, or "" when any component is missing.
+// baseURL is the resolved public server base (see resolveSourceBaseURL).
+func projectSourceLinkURL(baseURL, projectKey string) string {
+	if baseURL == "" || projectKey == "" {
+		return ""
+	}
+	base := strings.TrimRight(baseURL, "/")
+	return fmt.Sprintf("%s/dashboard?id=%s", base, url.QueryEscape(projectKey))
+}
+
+// runSetProjectSourceLink adds a "SQS migrated project" link to every
+// migrated SonarQube Cloud project, pointing back to the original
+// SonarQube Server project's dashboard (#418). This lets Support (and
+// anyone else) identify, from the SQC project page, which projects were
+// created by the migration tool and where they came from.
+//
+// Idempotency: before each create call, the task lists existing links
+// on the target project and skips when a link with the same name and
+// URL is already present, so re-runs don't produce duplicates.
+func runSetProjectSourceLink(ctx context.Context, e *Executor) error {
+	counter := TaskCounterFromContext(ctx)
+	err := forEachMigrateItem(ctx, e, "setProjectSourceLink", "createProjects",
+		func(ctx context.Context, item json.RawMessage, w *common.ChunkWriter) error {
+			cloudKey := extractField(item, "cloud_project_key")
+			if cloudKey == "" {
+				return nil
+			}
+			baseURL := resolveSourceBaseURL(e, extractField(item, "server_url"))
+			linkURL := projectSourceLinkURL(baseURL, extractField(item, "key"))
+			if linkURL == "" {
+				return nil
+			}
+			links, err := e.Cloud.Projects.ListLinks(ctx, cloudKey)
+			if err != nil {
+				logAPIWarn(e.Logger, "setProjectSourceLink: list existing failed (will attempt create)", err,
+					"project", cloudKey)
+				links = nil
+			}
+			for _, l := range links {
+				if l.Name == migratedProjectLinkName && l.URL == linkURL {
+					e.Logger.Info("setProjectSourceLink: link already exists, skipping", "project", cloudKey)
+					counter.Success()
+					return w.WriteOne(common.EnrichRaw(item, map[string]any{"was_preexisting": true}))
+				}
+			}
+			params := cloud.CreateLinkParams{
+				ProjectKey: cloudKey,
+				Name:       migratedProjectLinkName,
+				URL:        linkURL,
+			}
+			if err := e.Cloud.Projects.CreateLink(ctx, params); err != nil {
+				counter.Fail()
+				logAPIWarn(e.Logger, "setProjectSourceLink failed", err, "project", cloudKey, "url", linkURL)
+			} else {
+				counter.Success()
+			}
+			return w.WriteOne(item)
 		})
 	return err
 }

--- a/go/internal/migrate/tasks_flow_test.go
+++ b/go/internal/migrate/tasks_flow_test.go
@@ -324,6 +324,105 @@ func TestSetProjectTags(t *testing.T) {
 	}
 }
 
+// TestSetProjectSourceLink asserts the migration adds a "SQS migrated
+// project" link back to the original SonarQube Server dashboard for
+// every migrated project (#418).
+func TestSetProjectSourceLink(t *testing.T) {
+	type call struct {
+		project string
+		name    string
+		url     string
+	}
+	var (
+		mu       sync.Mutex
+		recorded []call
+	)
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/project_links/create", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		mu.Lock()
+		recorded = append(recorded, call{
+			project: r.FormValue("projectKey"),
+			name:    r.FormValue("name"),
+			url:     r.FormValue("url"),
+		})
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("GET /api/project_links/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"links": []map[string]any{}})
+	})
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
+
+	pw, _ := e.Store.Writer("createProjects")
+	data, _ := json.Marshal(map[string]any{
+		"key": "proj1", "server_url": testServerURL,
+		"cloud_project_key": "cloud-org1_proj1", "sonarcloud_org_key": testCloudOrg,
+	})
+	_ = pw.WriteOne(data)
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["setProjectSourceLink"].Run(context.Background(), e); err != nil {
+		t.Fatalf("setProjectSourceLink: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(recorded) != 1 {
+		t.Fatalf("expected 1 project_links/create call, got %d: %+v", len(recorded), recorded)
+	}
+	wantURL := "https://sq.test/dashboard?id=proj1"
+	if got := recorded[0]; got.project != "cloud-org1_proj1" || got.name != migratedProjectLinkName || got.url != wantURL {
+		t.Fatalf("unexpected create call: %+v (want project=cloud-org1_proj1 name=%q url=%q)",
+			got, migratedProjectLinkName, wantURL)
+	}
+}
+
+// TestSetProjectSourceLinkSkipsExisting asserts a re-run doesn't create a
+// duplicate link when one with the same name and URL already exists on
+// the target project.
+func TestSetProjectSourceLinkSkipsExisting(t *testing.T) {
+	var (
+		mu          sync.Mutex
+		createCalls int
+	)
+	cloudMux := http.NewServeMux()
+	cloudMux.HandleFunc("POST /api/project_links/create", func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		createCalls++
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	})
+	cloudMux.HandleFunc("GET /api/project_links/search", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"links": []map[string]any{
+				{"name": migratedProjectLinkName, "url": "https://sq.test/dashboard?id=proj1"},
+			},
+		})
+	})
+	addDefaultCloudHandler(cloudMux)
+	e := newCustomCloudTest(t, cloudMux)
+
+	pw, _ := e.Store.Writer("createProjects")
+	data, _ := json.Marshal(map[string]any{
+		"key": "proj1", "server_url": testServerURL,
+		"cloud_project_key": "cloud-org1_proj1", "sonarcloud_org_key": testCloudOrg,
+	})
+	_ = pw.WriteOne(data)
+
+	reg := BuildMigrateRegistry(RegisterAll())
+	if err := reg["setProjectSourceLink"].Run(context.Background(), e); err != nil {
+		t.Fatalf("setProjectSourceLink: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if createCalls != 0 {
+		t.Fatalf("expected no create call when link already exists, got %d", createCalls)
+	}
+}
+
 func TestCreateMigrationGroups(t *testing.T) {
 	e := newFlowTest(t)
 


### PR DESCRIPTION
## Summary
- Adds a "SQS migrated project" link to every migrated SonarQube Cloud project, pointing back to the original SonarQube Server project's dashboard (`<originalServerURL>/dashboard?id=<originalProjectKey>`), so Support (and anyone else) can identify migrated projects and trace them to their source.
- New `setProjectSourceLink` task, dependent on `createProjects`, registered alongside `setProjectLinks`; also added to the single-project `transfer` command's task list.
- Idempotent: lists existing links before creating, so re-runs don't produce duplicates.
- This completes the second checkbox of #418 — the first (`ci_name=sonar-migration-tool` in `analytics.pb`) was already implemented by #480.

Fixes #418

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] New unit test `TestProjectSourceLinkURL` covering the URL builder
- [x] New integration tests `TestSetProjectSourceLink` (create path) and `TestSetProjectSourceLinkSkipsExisting` (idempotency)
