### PR TITLE
Bump version to 1.1-SNAPSHOT

### DIFF
--- a/go/internal/version/version.go
+++ b/go/internal/version/version.go
@@ -4,6 +4,6 @@
 
 package version
 
-const Version = "v1.0.0"
+const Version = "v1.1-SNAPSHOT"
 
 const ToolName = "sonar-migration-tool"


### PR DESCRIPTION
## Summary
- Bumps `version.Version` from `v1.0.0` to `v1.1-SNAPSHOT` ahead of the 1.1 development cycle.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
