### PR TITLE
fix: migrate custom issue tags — stop dropping cross-language analyzer findings from the scan report (#456)

### DIFF
--- a/docs/MIGRATION-CAPABILITIES.md
+++ b/docs/MIGRATION-CAPABILITIES.md
@@ -110,15 +110,24 @@ Automatic handling of projects with more than 10,000 issues, which hit SonarQube
 - Deduplication of results across overlapping date windows
 
 #### Issue Metadata Synchronization (SPEC-008)
+<!-- updated: 2026-07-27_22:37:13 -->
 
 After issues are uploaded via scanner reports, this phase matches each SonarQube Cloud issue back to its Server counterpart and replicates the original lifecycle metadata.
 
 **What it migrates:**
 - **Issue statuses**: OPEN, CONFIRMED, FALSE_POSITIVE, WONTFIX, ACCEPTED, RESOLVED, CLOSED
 - **Issue comments**: All comments with original author attribution (`[Migrated from SonarQube Server - @author]`)
-- **Issue tags**: Custom tags applied by users
+- **Issue tags**: Custom tags applied by users, written as the union of the source issue's full tag list and the tags the Cloud issue already carries (`set_tags` replaces rather than merges, so the union is what preserves both sides)
 - **Issue assignments**: User assignments mapped via `users.csv`
-- Pre-filtering skips issues with no manual changes (60-80% of typical enterprise issues), dramatically reducing API calls
+- Pre-filtering skips issues with no manual changes (60-80% of typical enterprise issues), dramatically reducing API calls. A user-added tag is itself a trigger, so an **OPEN** issue that only carries a custom tag is still synced — no status change is required.
+
+**Prerequisite — the issue must exist on the target.** This phase can only write onto a Cloud counterpart that the replayed scanner report actually produced. If an issue was dropped at report-build time (its rule was not in the report's active-rule set) or by the Compute Engine (its rule does not exist in the target organization), there is nothing to tag or transition. Such issues are counted as `not_found` and reported at WARN, e.g.:
+
+```
+WARN syncIssueMetadata: triaged source issues without a unique Cloud counterpart —
+     their status, comments and tags were NOT migrated
+     project=... actionable=3 synced=2 ambiguous_line=0 not_found=1
+```
 
 #### Hotspot Metadata Synchronization (SPEC-009)
 
@@ -339,7 +348,7 @@ Electron-based desktop application wrapping the CLI and browser GUI.
 | **External Issues** | **Not migrated** | **Full migration with ad-hoc rules** |
 | Issue Statuses | N/A | Synced (OPEN, CONFIRMED, FP, WONTFIX, etc.) |
 | Issue Comments | N/A | Synced with author attribution |
-| Issue Tags | N/A | Synced |
+| Issue Tags | N/A | Synced (full source tag list ∪ existing Cloud tags) |
 | Issue Assignments | N/A | Mapped via users.csv |
 | Hotspot Review Status | N/A | Synced (TO_REVIEW, REVIEWED/SAFE, etc.) |
 | Hotspot Comments | N/A | Synced |

--- a/docs/MIGRATION-FACETS.md
+++ b/docs/MIGRATION-FACETS.md
@@ -4,7 +4,7 @@
 > **Reconciled against the actual Go code on 2026-06-05.** Every row below reflects what the running binary does (`go/`, `lib/sq-api-go/`), not spec/design intent. Claims that previously described unbuilt specs or dead code have been corrected or moved. Full claim-by-claim evidence (file:line) is in [MIGRATION-FACETS-AUDIT.md](MIGRATION-FACETS-AUDIT.md).
 
 ## ✅ What IS Migrated
-<!-- updated: 2026-06-08_23:03:54 -->
+<!-- updated: 2026-07-27_22:37:13 -->
 
 The **Caveats / NOT carried** column is load-bearing — read it before relying on a row.
 
@@ -23,12 +23,12 @@ The **Caveats / NOT carried** column is load-bearing — read it before relying 
 | **Analysis Data** | Source Code | raw file content; language; line count | content rides in `source-{ref}.txt`; **language + line count ride in `component-{ref}.pb`** (not the source file). Part of the project-data migration, which runs by default on both `migrate` and `transfer`; opt out with `--skip_project_data_migration` | `source-{ref}.txt` + `component-{ref}.pb` in report ZIP | 004 |
 | **Analysis Data** | SCM / Blame Data | per-line **date** only, back-dated to oldest issue creation date | **per-line revision is a random-hex stub; author is a hardcoded stub** (`sonar-migration-tool@sonarcloud.io`) — original SCM identity is NOT preserved | Protobuf `Changesets` + `BackdateChangesets()` | 004 |
 | **Analysis Data** | Issue Creation Dates | original creation dates preserved | — (fully accurate) | via SCM changeset backdating | 004 |
-| **Analysis Data** | Active Rules | repo, key, severity, q-profile key (remapped SQ→Cloud) | **params, impacts, and timestamps are NOT migrated** on this path — params default to empty, timestamps fall back to the migration run-time | Protobuf `activerules.pb` | 001 |
+| **Analysis Data** | Active Rules | repo, key, severity, q-profile key (remapped SQ→Cloud); language set = the project's file languages **plus** the languages of rules the findings reference | **params, impacts, and timestamps are NOT migrated** on this path — params default to empty, timestamps fall back to the migration run-time. The rule set is language-filtered and any native issue on a non-surviving rule is dropped from the report, so **cross-language analyzers must be accounted for explicitly**: secret detection owns language `secrets` but raises issues inside `.xml` / `.sh` / language-less files, so filtering on file languages alone silently discarded every secrets finding (fixed in #456 — see the Known Gaps note) | Protobuf `activerules.pb` | 001 |
 | **Analysis Data** | External Issues (3rd-party analyzers) | engineId, ruleId, message, severity, type, textRange | filename is **`external-issues-{ref}.pb`** (hyphenated) | Protobuf `external-issues-{ref}.pb` | 013 |
 | **Analysis Data** | Ad-Hoc Rules | engineId, ruleId, severity, type, cleanCodeAttribute | **`name` = rule key** (not a display name); **`description` = generic placeholder** `"Rule from {engine} plugin"`, not the source rule description | Protobuf `adhocrules.pb` | 013 |
 | **Metadata Sync** | Issue Status | OPEN, CONFIRMED, REOPENED, RESOLVED, FALSE_POSITIVE, WONTFIX, **ACCEPTED** | **`ACCEPTED` maps to the `accept` transition** → lands as ACCEPTED on Cloud (fixed in #322); modern MQR `ACCEPTED` (surfaced over the Server API as status=RESOLVED, resolution=WONTFIX) is detected via the `issueStatus` enum and routed to `accept`, while genuine legacy `WONTFIX` still maps to `wontfix`. **`FIXED`-resolution issues are intentionally excluded** — the fixed code no longer exists, so CE re-analysis of the migrated scanner report won't reproduce them (no Cloud counterpart to transition) | `/api/issues/do_transition` | 008/024 |
 | **Metadata Sync** | Issue Comments | text (Markdown, HTML fallback) + original author + timestamp | prefix is **`[Migrated from {login} on {date}]`** (no literal "SonarQube Server", no `@`); dedup is **plain substring match, not hashing** | `/api/issues/add_comment` | 008/024 |
-| **Metadata Sync** | Issue Tags | all custom tags | — (fully accurate) | `/api/issues/set_tags` | 008/024 |
+| **Metadata Sync** | Issue Tags | the issue's **complete** source tag list (custom + rule-default), unioned with the tags the Cloud issue already carries, plus the `metadata-synchronized` marker | tags are written with `set_tags`, which **REPLACES** the list — the union is what preserves the Cloud analysis's own rule-default tags (fixed in #456; before that only the user-added subset was sent, stripping e.g. `cwe`). **A tag can only be applied if the issue exists on the target**: an issue whose rule is absent from the target org (e.g. a template-instantiated custom rule that profile restore could not create) is never raised on Cloud, so its tags are unreachable — reported at WARN as `not_found` | `/api/issues/set_tags` | 008/024 |
 | **Metadata Sync** | Hotspot Review Status | TO_REVIEW / REVIEWED + resolution SAFE / FIXED | **`ACKNOWLEDGED` is silently downgraded to `SAFE`**; TO_REVIEW makes no API call (Cloud default) | `/api/hotspots/change_status` | 009/024 |
 | **Metadata Sync** | Hotspot Comments | review comments with author attribution | — (fully accurate) | `/api/hotspots/add_comment` | 009/024 |
 | **Scope** | Branches | main + non-main **LONG** branches (main first, blocking CE gate); per-branch issues, source, SCM (backdated), reference-branch mapping (→ main), create-analysis handshake (analysis_uuid field 19) | **only LONG branches migrate** — SHORT branches are skipped, PULL_REQUEST branches are never submitted (all forced to `branchType=LONG`); **per-branch measures are NOT carried** (CE recomputes); **per-branch new-code-period is NOT migrated** | Per-branch report upload | 020 |
@@ -62,10 +62,11 @@ The **Caveats / NOT carried** column is load-bearing — read it before relying 
 | Symbols / syntax-highlighting reference data | Lower-priority, optional (SPEC-004 FR-12/FR-13) | Endpoints never called; proto types unused |
 
 ## ⚠️ Known Gaps (real bugs / partial fidelity, verified in code)
-<!-- updated: 2026-06-08_23:03:54 -->
+<!-- updated: 2026-07-27_22:37:13 -->
 
 | Item | Status | Spec |
 |---|---|---|
+| **Template-instantiated custom rules are not created on the target**, so their issues are never raised on Cloud and carry none of their triage metadata (status, comments, tags). Live-verified on `demo-rules`: `secrets:My_custom_secret_rule` 404s on the target org, so its `action-plan`-tagged issue cannot be migrated. Reported at WARN as `not_found` by `syncIssueMetadata` | Real, unfixed | 456 |
 | **BUG-02** — active rule **params (regex/thresholds), impacts, timestamps** missing from the scanner-report `activerules.pb` path (the XML restore path *does* carry them into the profile definition) | Real, partial | 001 |
 | **BUG-05** — issue **assignee** extracted but the assign call is never invoked (no Cloud assign API) | Real | 010 |
 | **BUG-06** — no source-link / back-reference comment to the original Server issue/hotspot is added | Real | 008/009 |

--- a/docs/TRANSFER-INTERNALS.md
+++ b/docs/TRANSFER-INTERNALS.md
@@ -1,5 +1,5 @@
 # `transfer` Command — Internal Flow (ASCII Chart)
-<!-- updated: 2026-06-09_21:35:54 -->
+<!-- updated: 2026-07-27_22:37:13 -->
 
 How `sonar-migration-tool transfer` works end-to-end, traced from
 [cmd/transfer.go](../go/cmd/transfer.go) down through `extract` → `structure` →
@@ -234,6 +234,9 @@ statement of `runTransfer`.
   |         non-main branches SEQUENTIAL:                                      |
   |           buildBranchReport: load issues / hotspots / components /         |
   |             sources / activeRules ;  skip empty/purged ;                   |
+  |             langs = file languages + langs of rules the findings use       |
+  |               (widenLangsForFindingRules; needs a target profile) #456     |
+  |             filter active rules by lang ;                                  |
   |             remap SQ->SC profile keys ;  dedup active rules ;              |
   |             drop issues on inactive rules ;                                |
   |             BackdateChangesets -> original creation dates                  |
@@ -255,7 +258,10 @@ statement of `runTransfer`.
   |           ISSUES:   search componentKeys=key:file & rules=rule &           |
   |             issueStatuses=...  -> classify by line                         |
   |             (1=sync, 0=miss, >1=ambig)                                     |
-  |             -> transition -> comments -> tags (+metadataSyncTag idem)      |
+  |             -> transition -> comments                                      |
+  |             -> tags = source full tags U cloud tags U metadataSyncTag       |
+  |                (set_tags REPLACES, so union; #456)                         |
+  |             miss/ambig totals reported at WARN (were DEBUG-only)           |
   |           HOTSPOTS: search projectKey & files  (NO rules param)            |
   |             -> classify by (ruleKey, line) -> ChangeStatus -> comments     |
   |                                              => sync*Metadata/*.jsonl      |
@@ -474,8 +480,28 @@ flowchart TB
 ```
 
 ## Key facts the chart encodes
-<!-- updated: 2026-06-09_21:16:18 -->
+<!-- updated: 2026-07-27_22:37:13 -->
 
+- **The report's language set gates which issues survive, so cross-language
+  analyzers need explicit handling.** `buildBranchReport` filters the
+  active-rule set to the project's languages and then *drops every native issue
+  whose rule is not among the survivors* (an orphan rule aborts the whole report
+  in the CE). Deriving that language set from file components alone is not
+  enough: secret detection owns language `secrets` but raises issues inside
+  `.xml` files, shell scripts, and files SonarQube gives no language at all — so
+  `secrets` never appeared, every secrets rule was filtered out, and every
+  secrets finding was silently dropped along with its triage metadata (#456).
+  `widenLangsForFindingRules` therefore adds the languages of the rules the
+  findings actually reference, gated on the target org exposing a quality
+  profile for that language (without one the rules cannot be remapped to a
+  valid qprofile key and the CE would reject the metadata).
+- **The metadata sync can only write onto issues that the report produced.**
+  P6 is strictly downstream of P5: if an issue never materialised on Cloud —
+  dropped at report-build time, or dropped by the CE because its rule does not
+  exist in the target org (template-instantiated custom rules) — its status,
+  comments and tags are unreachable. Those are counted `not_found` and now
+  surfaced at WARN with totals; previously only per-issue at DEBUG, which is
+  why #456 went unnoticed.
 - **Project scoping is carried by exactly one parameter.** `getProjects` is the
   sole consumer of `ProjectKeys`; it sets `projects=<key>` on
   `api/projects/search` so the server returns only the scoped project. Every

--- a/go/internal/migrate/tasks_issuesync.go
+++ b/go/internal/migrate/tasks_issuesync.go
@@ -49,7 +49,15 @@ func issueMetadataSyncTasks() []TaskDef {
 // default tags+sysTags). The raw /api/issues/search response folds
 // rule defaults into every issue's tags array, so the unsubtracted
 // list is useless as a "manual triage" signal — see ruleTagDefaults
-// (#352 follow-up).
+// (#352 follow-up). Tags is the *actionability* signal only.
+//
+// AllTags holds the issue's COMPLETE tag list as the source server
+// reports it (rule defaults included). It is what actually gets
+// written to the Cloud issue: /api/issues/set_tags REPLACES the tag
+// list rather than merging into it, so writing only the user-added
+// subset would strip the rule-default tags the Cloud issue carries
+// from its own analysis (#456). Populated for source-side issues;
+// empty for Cloud-side candidates.
 //
 // ManualSeverity mirrors the `manualSeverity` boolean on the SQ Server
 // API response: true means a user has explicitly overridden the issue's
@@ -82,6 +90,7 @@ type matchableIssue struct {
 	Resolution     string
 	IssueStatus    string
 	Tags           []string
+	AllTags        []string
 	Comments       []issueComment
 	Assignee       string
 	ManualSeverity bool
@@ -555,6 +564,21 @@ func syncProjectIssues(ctx context.Context, e *Executor, cloudKey, orgKey, serve
 	stats.A = a.Load()
 	stats.B = b.Load()
 	stats.C = c.Load()
+	// Surface unmatched triaged issues at WARN. Each unmatched pair means a
+	// manually triaged source issue whose status, comments and tags were NOT
+	// migrated — previously only visible per-issue at DEBUG, which is how #456
+	// (every "secrets" finding dropped from the scan report, so nothing to sync
+	// onto) went unnoticed. The counts make the fidelity loss visible in a
+	// default-verbosity run.
+	if stats.B+stats.C > 0 {
+		e.Logger.Warn("syncIssueMetadata: triaged source issues without a unique Cloud counterpart — their status, comments and tags were NOT migrated (run with --debug for the per-issue rule/file/line)",
+			"project", cloudKey,
+			"actionable", stats.Actionable,
+			"synced", stats.A,
+			"ambiguous_line", stats.B,
+			"not_found", stats.C,
+		)
+	}
 	return stats
 }
 
@@ -716,7 +740,7 @@ func syncOnePair(ctx context.Context, e *Executor, pair issuePair, baseURL, proj
 	// URL-bearing comment body) must NOT fail the pair — the status,
 	// comments and tags have already synced successfully.
 	syncIssueSourceLink(ctx, e, cloudKey, baseURL, projectKey, pair.source.Key, pair.source.Branch, pair.cloud.Comments)
-	tagsFailed := syncIssueTags(ctx, e, cloudKey, pair.source.Tags)
+	tagsFailed := syncIssueTags(ctx, e, cloudKey, pair.source.tagsToApply(), pair.cloud.Tags)
 
 	if transFailed || commentFailed || tagsFailed {
 		counter.Fail()
@@ -909,19 +933,60 @@ func isAlreadyMigratedIssueComment(body string, cloudComments []issueComment) bo
 	return false
 }
 
-// syncIssueTags sets the source tags plus the idempotency marker on the Cloud issue.
+// syncIssueTags writes the source issue's tags onto the Cloud issue, unioned
+// with the tags the Cloud issue already carries, plus the idempotency marker.
 // Returns true if the API call failed.
-func syncIssueTags(ctx context.Context, e *Executor, cloudKey string, sourceTags []string) bool {
-	tags := make([]string, 0, len(sourceTags)+1)
-	tags = append(tags, sourceTags...)
-	if !slices.Contains(tags, metadataSyncTag) {
-		tags = append(tags, metadataSyncTag)
-	}
+//
+// /api/issues/set_tags REPLACES the tag list, so the union matters: sending
+// only the source tags would drop the rule-default tags the Cloud analysis
+// assigned, and sending only the user-added subset would drop both those and
+// the source's own rule-default tags (#456).
+func syncIssueTags(ctx context.Context, e *Executor, cloudKey string, sourceTags, cloudTags []string) bool {
+	tags := mergeIssueTags(sourceTags, cloudTags)
 	if err := e.Cloud.Issues.SetTags(ctx, cloudKey, tags); err != nil {
 		logAPIWarn(e.Logger, "syncIssueMetadata: set tags failed", err, "issue", cloudKey)
 		return true
 	}
 	return false
+}
+
+// mergeIssueTags returns the de-duplicated union of the source issue's tags and
+// the Cloud issue's existing tags, with the metadataSyncTag idempotency marker
+// appended. Blank entries are dropped and the result is sorted so the payload
+// (and therefore the unit tests) is deterministic.
+func mergeIssueTags(sourceTags, cloudTags []string) []string {
+	seen := make(map[string]struct{}, len(sourceTags)+len(cloudTags)+1)
+	out := make([]string, 0, len(sourceTags)+len(cloudTags)+1)
+	add := func(t string) {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			return
+		}
+		if _, dup := seen[t]; dup {
+			return
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	for _, t := range cloudTags {
+		add(t)
+	}
+	for _, t := range sourceTags {
+		add(t)
+	}
+	add(metadataSyncTag)
+	slices.Sort(out)
+	return out
+}
+
+// tagsToApply returns the tag list to write onto the Cloud counterpart: the
+// source issue's complete tag set when available, falling back to the
+// user-added subset for records built before AllTags existed.
+func (m matchableIssue) tagsToApply() []string {
+	if len(m.AllTags) > 0 {
+		return m.AllTags
+	}
+	return m.Tags
 }
 
 // ---------------------------------------------------------------------------
@@ -1044,7 +1109,8 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 
 		comments := parseIssueComments(item.Data)
 		rule := extractField(item.Data, "rule")
-		userTags := ruleDefaults.UserTagsOnly(serverURL, rule, extractStringArray(item.Data, "tags"))
+		allTags := extractStringArray(item.Data, "tags")
+		userTags := ruleDefaults.UserTagsOnly(serverURL, rule, allTags)
 
 		issues = append(issues, matchableIssue{
 			Key:            extractField(item.Data, "key"),
@@ -1055,6 +1121,7 @@ func loadMatchableIssues(e *Executor, serverURL, serverKey string, ruleDefaults 
 			Resolution:     extractField(item.Data, "resolution"),
 			IssueStatus:    extractField(item.Data, "issueStatus"),
 			Tags:           userTags,
+			AllTags:        allTags,
 			Comments:       comments,
 			Assignee:       extractField(item.Data, "assignee"),
 			ManualSeverity: extractBool(item.Data, "manualSeverity"),

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -5,6 +5,14 @@
 package migrate
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -648,5 +656,415 @@ func TestOpenIssueWithCustomTagIsActionableAndNeedsNoTransition(t *testing.T) {
 	want := []string{"action-plan", "cwe", metadataSyncTag}
 	if got := mergeIssueTags(iss.tagsToApply(), nil); !equalStrings(got, want) {
 		t.Errorf("tag payload = %v, want %v", got, want)
+	}
+}
+
+// --- #456: coverage for the tag write path and the not_found accounting ---
+
+// newTagSyncServer returns a cloud stub that records every /api/issues/set_tags
+// payload, plus the recorder itself.
+func newTagSyncServer(t *testing.T, failSetTags bool) (*httptest.Server, *[]string) {
+	t.Helper()
+	var seen []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /api/issues/set_tags", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		seen = append(seen, r.Form.Get("tags"))
+		if failSetTags {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	mux.HandleFunc("POST /api/issues/add_comment", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("POST /api/issues/do_transition", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return httptest.NewServer(mux), &seen
+}
+
+// syncIssueTags sends the union of the source and cloud tag lists. The cloud
+// issue's own rule-default tags must survive, because set_tags REPLACES.
+func TestSyncIssueTagsSendsUnion(t *testing.T) {
+	cloudSrv, seen := newTagSyncServer(t, false)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	failed := syncIssueTags(context.Background(), e, "cloud-1",
+		[]string{"cwe", "action-plan"}, []string{"secret", "cwe"})
+	if failed {
+		t.Fatal("syncIssueTags reported failure on a 200 response")
+	}
+	if len(*seen) != 1 {
+		t.Fatalf("want exactly 1 set_tags call, got %d", len(*seen))
+	}
+	want := "action-plan,cwe,metadata-synchronized,secret"
+	if (*seen)[0] != want {
+		t.Errorf("set_tags payload = %q, want %q", (*seen)[0], want)
+	}
+}
+
+// A non-2xx from set_tags must be reported so the pair counts as failed.
+// Note: the shared HTTP client retries 5xx, so several attempts are expected —
+// what matters is that the exhausted failure is surfaced, not swallowed.
+func TestSyncIssueTagsReportsAPIFailure(t *testing.T) {
+	cloudSrv, seen := newTagSyncServer(t, true)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	if !syncIssueTags(context.Background(), e, "cloud-1", []string{"action-plan"}, nil) {
+		t.Error("syncIssueTags must report failure when the API rejects the call")
+	}
+	if len(*seen) == 0 {
+		t.Fatal("expected at least one set_tags attempt")
+	}
+	// Every attempt must carry the same union payload.
+	want := "action-plan," + metadataSyncTag
+	for i, got := range *seen {
+		if got != want {
+			t.Errorf("attempt %d payload = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// syncOnePair writes the source issue's COMPLETE tag list (AllTags), not the
+// user-added subset that drives actionability.
+func TestSyncOnePairWritesFullSourceTagList(t *testing.T) {
+	cloudSrv, seen := newTagSyncServer(t, false)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	pair := issuePair{
+		source: matchableIssue{
+			Key: "src-1", Rule: "secrets:S7001", Status: "OPEN", IssueStatus: "OPEN",
+			Tags: []string{"action-plan"}, AllTags: []string{"cwe", "action-plan"},
+		},
+		cloud: matchableIssue{Key: "cloud-1", Tags: []string{"secret"}},
+	}
+	counter := NewTaskCounter("test")
+	syncOnePair(context.Background(), e, pair, "", "src-proj", counter)
+
+	if len(*seen) != 1 {
+		t.Fatalf("want 1 set_tags call, got %d", len(*seen))
+	}
+	want := "action-plan,cwe,metadata-synchronized,secret"
+	if (*seen)[0] != want {
+		t.Errorf("set_tags payload = %q, want %q", (*seen)[0], want)
+	}
+	if got := counter.succeeded.Load(); got != 1 {
+		t.Errorf("want 1 success recorded, got %d", got)
+	}
+}
+
+// A cloud issue already carrying the marker short-circuits: no tag rewrite.
+func TestSyncOnePairSkipsAlreadySyncedIssue(t *testing.T) {
+	cloudSrv, seen := newTagSyncServer(t, false)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, t.TempDir())
+
+	pair := issuePair{
+		source: matchableIssue{Key: "src-1", AllTags: []string{"action-plan"}},
+		cloud:  matchableIssue{Key: "cloud-1", Tags: []string{"action-plan", metadataSyncTag}},
+	}
+	syncOnePair(context.Background(), e, pair, "", "src-proj", NewTaskCounter("test"))
+
+	if len(*seen) != 0 {
+		t.Errorf("an already-synced issue must not be re-tagged, got %v", *seen)
+	}
+}
+
+// setupIssueTagExtract writes a getProjectIssuesFull + getRuleDetails extract
+// mirroring the #456 demo-rules shape: OPEN issues whose tags array folds the
+// rule's sysTags ("cwe") together with the user-added tag ("action-plan").
+func setupIssueTagExtract(t *testing.T, dir string) {
+	t.Helper()
+	extractDir := filepath.Join(dir, "extract-01")
+	writeJSON(filepath.Join(extractDir, "extract.json"),
+		map[string]any{"url": testServerURL, "edition": "enterprise"})
+
+	writeJSONL(filepath.Join(extractDir, "getRuleDetails"), []map[string]any{
+		{"key": "secrets:S7001", "tags": []string{}, "sysTags": []string{"cwe"}, "serverUrl": testServerURL},
+	})
+
+	writeJSONL(filepath.Join(extractDir, "getProjectIssuesFull"), []map[string]any{
+		{
+			"key": "src-tagged", "rule": "secrets:S7001", "component": "demo-rules:secrets/az.xml",
+			"projectKey": "demo-rules", "branch": "main", "status": "OPEN", "issueStatus": "OPEN",
+			"tags": []string{"cwe", "action-plan"}, "serverUrl": testServerURL,
+			"textRange": map[string]any{"startLine": 7, "endLine": 7},
+			"line":      7,
+		},
+		{
+			"key": "src-plain", "rule": "secrets:S7001", "component": "demo-rules:secrets/tmp",
+			"projectKey": "demo-rules", "branch": "main", "status": "OPEN", "issueStatus": "OPEN",
+			"tags": []string{"cwe"}, "serverUrl": testServerURL,
+			"line": 11,
+		},
+		{
+			"key": "src-fixed", "rule": "secrets:S7001", "component": "demo-rules:secrets/tmp",
+			"projectKey": "demo-rules", "branch": "main", "status": "RESOLVED", "resolution": "FIXED",
+			"tags": []string{"cwe", "action-plan"}, "serverUrl": testServerURL, "line": 12,
+		},
+	})
+}
+
+// loadMatchableIssues must populate BOTH tag fields: AllTags with the complete
+// source list (what gets written to Cloud) and Tags with the user-added subset
+// (what decides actionability). FIXED issues are excluded.
+func TestLoadMatchableIssuesPopulatesAllTagsAndUserTags(t *testing.T) {
+	dir := t.TempDir()
+	setupIssueTagExtract(t, dir)
+	e := newProjectDataExecutor(t, dir)
+
+	issues := loadMatchableIssues(e, testServerURL, "demo-rules", loadRuleTagDefaults(e))
+	if len(issues) != 2 {
+		t.Fatalf("want 2 issues (FIXED excluded), got %d: %+v", len(issues), issues)
+	}
+
+	byKey := make(map[string]matchableIssue, len(issues))
+	for _, iss := range issues {
+		byKey[iss.Key] = iss
+	}
+
+	tagged, ok := byKey["src-tagged"]
+	if !ok {
+		t.Fatalf("src-tagged missing from %v", byKey)
+	}
+	if !equalStrings(tagged.AllTags, []string{"cwe", "action-plan"}) {
+		t.Errorf("AllTags = %v, want the full source list [cwe action-plan]", tagged.AllTags)
+	}
+	if !equalStrings(tagged.Tags, []string{"action-plan"}) {
+		t.Errorf("Tags = %v, want the user-added subset [action-plan]", tagged.Tags)
+	}
+	if !hasManualChanges(tagged) {
+		t.Error("an OPEN issue with a user-added tag must be actionable")
+	}
+	if !equalStrings(tagged.tagsToApply(), []string{"cwe", "action-plan"}) {
+		t.Errorf("tagsToApply = %v, want the full source list", tagged.tagsToApply())
+	}
+
+	// The rule-default-only issue carries tags but no *user* tags, so it is not
+	// actionable — and must not be, or every issue would be synced.
+	plain := byKey["src-plain"]
+	if !equalStrings(plain.AllTags, []string{"cwe"}) {
+		t.Errorf("AllTags = %v, want [cwe]", plain.AllTags)
+	}
+	if len(plain.Tags) != 0 {
+		t.Errorf("Tags = %v, want empty (cwe is a rule default)", plain.Tags)
+	}
+	if hasManualChanges(plain) {
+		t.Error("a rule-default-only issue must NOT be actionable")
+	}
+}
+
+// syncProjectIssues end-to-end over the mock cloud: the tagged issue that HAS a
+// counterpart is tagged, and the tagged issue that has NONE is accounted as
+// not_found rather than silently ignored (#456 — that silence hid the bug).
+func TestSyncProjectIssuesTagsMatchedAndCountsNotFound(t *testing.T) {
+	dir := t.TempDir()
+	setupIssueTagExtract(t, dir)
+
+	var setTagsPayloads []string
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		// The project-wide indexing probe must report a non-zero total so the
+		// sync proceeds without waiting on the backoff.
+		if r.URL.Query().Get("rules") == "" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"issues": []map[string]any{},
+				"paging": map[string]any{"pageIndex": 1, "pageSize": 1, "total": 2},
+			})
+			return
+		}
+		// Per-source targeted search: only az.xml has a counterpart. The
+		// component-scoped search for secrets/tmp returns nothing, which is
+		// exactly the "rule missing on the target" shape from #456.
+		if strings.Contains(r.URL.Query().Get("componentKeys"), "secrets/az.xml") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"issues": []map[string]any{{
+					"key": "cloud-az", "rule": "secrets:S7001",
+					"component": "cloud-proj:secrets/az.xml", "line": 7,
+					"tags": []string{"secret", "cwe"},
+				}},
+				"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 0},
+		})
+	})
+	mux.HandleFunc("POST /api/issues/set_tags", func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		setTagsPayloads = append(setTagsPayloads, r.Form.Get("tags"))
+	})
+	mux.HandleFunc("POST /api/issues/add_comment", func(w http.ResponseWriter, _ *http.Request) {})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	var logBuf bytes.Buffer
+	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	// Make the second tagged issue actionable-but-unmatchable by giving the
+	// extract a user tag on the secrets/tmp issue too.
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectIssuesFull"), []map[string]any{
+		{
+			"key": "src-tagged", "rule": "secrets:S7001", "component": "demo-rules:secrets/az.xml",
+			"projectKey": "demo-rules", "branch": "main", "status": "OPEN", "issueStatus": "OPEN",
+			"tags": []string{"cwe", "action-plan"}, "serverUrl": testServerURL, "line": 7,
+		},
+		{
+			"key": "src-orphan", "rule": "secrets:S7001", "component": "demo-rules:secrets/tmp",
+			"projectKey": "demo-rules", "branch": "main", "status": "OPEN", "issueStatus": "OPEN",
+			"tags": []string{"cwe", "action-plan"}, "serverUrl": testServerURL, "line": 11,
+		},
+	})
+
+	stats := syncProjectIssues(context.Background(), e, "cloud-proj", "cloud-org",
+		testServerURL, "demo-rules", NewTaskCounter("test"), loadRuleTagDefaults(e))
+
+	if stats.Actionable != 2 {
+		t.Errorf("actionable: want 2, got %d", stats.Actionable)
+	}
+	if stats.A != 1 {
+		t.Errorf("synced: want 1, got %d", stats.A)
+	}
+	if stats.C != 1 {
+		t.Errorf("not_found: want 1, got %d", stats.C)
+	}
+	if stats.B != 0 {
+		t.Errorf("line_mismatch: want 0, got %d", stats.B)
+	}
+
+	// The matched issue keeps the cloud's rule-default tags AND gains the
+	// source's custom tag.
+	if len(setTagsPayloads) != 1 {
+		t.Fatalf("want 1 set_tags call, got %d: %v", len(setTagsPayloads), setTagsPayloads)
+	}
+	want := "action-plan,cwe,metadata-synchronized,secret"
+	if setTagsPayloads[0] != want {
+		t.Errorf("set_tags payload = %q, want %q", setTagsPayloads[0], want)
+	}
+
+	// The unmatched triaged issue is surfaced at WARN with totals.
+	out := logBuf.String()
+	if !strings.Contains(out, "without a unique Cloud counterpart") {
+		t.Errorf("expected the not_found WARN summary; got %q", out)
+	}
+	if !strings.Contains(out, "not_found=1") {
+		t.Errorf("expected not_found=1 in the WARN summary; got %q", out)
+	}
+}
+
+// When every actionable issue matches, the not_found WARN must NOT fire.
+func TestSyncProjectIssuesNoWarnWhenAllMatched(t *testing.T) {
+	dir := t.TempDir()
+	setupIssueTagExtract(t, dir)
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectIssuesFull"), []map[string]any{
+		{
+			"key": "src-tagged", "rule": "secrets:S7001", "component": "demo-rules:secrets/az.xml",
+			"projectKey": "demo-rules", "branch": "main", "status": "OPEN", "issueStatus": "OPEN",
+			"tags": []string{"cwe", "action-plan"}, "serverUrl": testServerURL, "line": 7,
+		},
+	})
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/issues/search", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("rules") == "" {
+			json.NewEncoder(w).Encode(map[string]any{
+				"issues": []map[string]any{},
+				"paging": map[string]any{"pageIndex": 1, "pageSize": 1, "total": 1},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"issues": []map[string]any{{
+				"key": "cloud-az", "rule": "secrets:S7001",
+				"component": "cloud-proj:secrets/az.xml", "line": 7,
+			}},
+			"paging": map[string]any{"pageIndex": 1, "pageSize": 500, "total": 1},
+		})
+	})
+	mux.HandleFunc("POST /api/issues/set_tags", func(w http.ResponseWriter, _ *http.Request) {})
+	mux.HandleFunc("POST /api/issues/add_comment", func(w http.ResponseWriter, _ *http.Request) {})
+	cloudSrv := httptest.NewServer(mux)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+	var logBuf bytes.Buffer
+	e.Logger = slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	stats := syncProjectIssues(context.Background(), e, "cloud-proj", "cloud-org",
+		testServerURL, "demo-rules", NewTaskCounter("test"), loadRuleTagDefaults(e))
+
+	if stats.A != 1 || stats.B != 0 || stats.C != 0 {
+		t.Errorf("want synced=1 ambiguous=0 not_found=0, got a=%d b=%d c=%d", stats.A, stats.B, stats.C)
+	}
+	if strings.Contains(logBuf.String(), "without a unique Cloud counterpart") {
+		t.Errorf("the not_found WARN must not fire when everything matched; got %q", logBuf.String())
+	}
+}
+
+// No source issues at all: the sync returns zeroed stats without touching the
+// network (guards the early return).
+func TestSyncProjectIssuesNoSourceIssues(t *testing.T) {
+	dir := t.TempDir()
+	writeJSON(filepath.Join(dir, "extract-01", "extract.json"),
+		map[string]any{"url": testServerURL, "edition": "enterprise"})
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectIssuesFull"), nil)
+
+	cloudSrv, _ := newTagSyncServer(t, false)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	stats := syncProjectIssues(context.Background(), e, "cloud-proj", "cloud-org",
+		testServerURL, "demo-rules", NewTaskCounter("test"), loadRuleTagDefaults(e))
+	if stats.Actionable != 0 || stats.A != 0 || stats.C != 0 {
+		t.Errorf("want fully zeroed stats, got %+v", stats)
+	}
+}
+
+// Source issues exist but none is actionable: no cloud calls, zero stats
+// (guards the "no actionable" early return distinct from "no issues").
+func TestSyncProjectIssuesNoActionableIssues(t *testing.T) {
+	dir := t.TempDir()
+	setupIssueTagExtract(t, dir)
+	writeJSONL(filepath.Join(dir, "extract-01", "getProjectIssuesFull"), []map[string]any{
+		{
+			"key": "src-plain", "rule": "secrets:S7001", "component": "demo-rules:secrets/tmp",
+			"projectKey": "demo-rules", "branch": "main", "status": "OPEN", "issueStatus": "OPEN",
+			"tags": []string{"cwe"}, "serverUrl": testServerURL, "line": 11,
+		},
+	})
+
+	cloudSrv, seen := newTagSyncServer(t, false)
+	defer cloudSrv.Close()
+	apiSrv := newMockAPIServer()
+	defer apiSrv.Close()
+	e := newTestExecutor(cloudSrv, apiSrv, dir)
+
+	stats := syncProjectIssues(context.Background(), e, "cloud-proj", "cloud-org",
+		testServerURL, "demo-rules", NewTaskCounter("test"), loadRuleTagDefaults(e))
+	if stats.Actionable != 0 {
+		t.Errorf("a rule-default-only issue must not be actionable, got %d", stats.Actionable)
+	}
+	if len(*seen) != 0 {
+		t.Errorf("no set_tags calls expected, got %v", *seen)
 	}
 }

--- a/go/internal/migrate/tasks_issuesync_test.go
+++ b/go/internal/migrate/tasks_issuesync_test.go
@@ -502,3 +502,151 @@ func TestClassifyActionableReasonsIssueStatus(t *testing.T) {
 		t.Errorf("customTags: want 1, got %d", b.customTags)
 	}
 }
+
+// --- #456: custom issue tags must survive the migration ---
+
+// mergeIssueTags backs syncIssueTags. /api/issues/set_tags REPLACES an issue's
+// tag list rather than merging into it, so the payload has to be the union of
+// the source issue's tags and the tags the Cloud issue already carries.
+// Previously only the user-added subset was sent, which stripped the
+// rule-default tags (e.g. "cwe") the Cloud analysis had assigned.
+func TestMergeIssueTags(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceTags []string
+		cloudTags  []string
+		want       []string
+	}{
+		{
+			name:       "source tags unioned with cloud rule-default tags",
+			sourceTags: []string{"cwe", "action-plan"},
+			cloudTags:  []string{"cwe", "secret"},
+			want:       []string{"action-plan", "cwe", metadataSyncTag, "secret"},
+		},
+		{
+			name:       "custom tag from source is added to an untagged cloud issue",
+			sourceTags: []string{"action-plan"},
+			cloudTags:  nil,
+			want:       []string{"action-plan", metadataSyncTag},
+		},
+		{
+			name:       "cloud-only tags are preserved, never clobbered",
+			sourceTags: nil,
+			cloudTags:  []string{"former-hotspot", "secret"},
+			want:       []string{"former-hotspot", metadataSyncTag, "secret"},
+		},
+		{
+			name:       "duplicates across both sides collapse",
+			sourceTags: []string{"cwe", "cwe", "action-plan"},
+			cloudTags:  []string{"cwe", "action-plan"},
+			want:       []string{"action-plan", "cwe", metadataSyncTag},
+		},
+		{
+			name:       "marker already present is not duplicated (idempotent re-run)",
+			sourceTags: []string{"action-plan"},
+			cloudTags:  []string{"action-plan", metadataSyncTag},
+			want:       []string{"action-plan", metadataSyncTag},
+		},
+		{
+			name:       "blank and whitespace-only tags are dropped",
+			sourceTags: []string{"", "   ", "action-plan"},
+			cloudTags:  []string{"\t"},
+			want:       []string{"action-plan", metadataSyncTag},
+		},
+		{
+			name:       "no tags anywhere still writes the marker",
+			sourceTags: nil,
+			cloudTags:  nil,
+			want:       []string{metadataSyncTag},
+		},
+		{
+			name:       "tags are trimmed before comparison",
+			sourceTags: []string{" action-plan "},
+			cloudTags:  []string{"action-plan"},
+			want:       []string{"action-plan", metadataSyncTag},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeIssueTags(tc.sourceTags, tc.cloudTags)
+			if !equalStrings(got, tc.want) {
+				t.Errorf("mergeIssueTags(%v, %v) = %v, want %v",
+					tc.sourceTags, tc.cloudTags, got, tc.want)
+			}
+		})
+	}
+}
+
+// tagsToApply picks what actually gets written to the Cloud issue: the source's
+// COMPLETE tag list, not the user-added subset that drives actionability.
+func TestMatchableIssueTagsToApply(t *testing.T) {
+	tests := []struct {
+		name string
+		iss  matchableIssue
+		want []string
+	}{
+		{
+			name: "full source tag list preferred over the user-only subset",
+			iss:  matchableIssue{Tags: []string{"action-plan"}, AllTags: []string{"cwe", "action-plan"}},
+			want: []string{"cwe", "action-plan"},
+		},
+		{
+			name: "falls back to the user-only subset when AllTags is unset",
+			iss:  matchableIssue{Tags: []string{"action-plan"}},
+			want: []string{"action-plan"},
+		},
+		{
+			name: "no tags at all",
+			iss:  matchableIssue{},
+			want: nil,
+		},
+		{
+			name: "rule-default-only tag list still applied",
+			iss:  matchableIssue{Tags: nil, AllTags: []string{"cwe"}},
+			want: []string{"cwe"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.iss.tagsToApply(); !equalStrings(got, tc.want) {
+				t.Errorf("tagsToApply() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// An OPEN issue carrying a user-added tag must be actionable on its own: tag
+// sync must NOT be gated behind needing a status/resolution transition. This is
+// the property the #456 report suspected was broken; it holds, and the real
+// fault was upstream (the issues were dropped from the scan report entirely) —
+// so lock the property down against regression.
+func TestOpenIssueWithCustomTagIsActionableAndNeedsNoTransition(t *testing.T) {
+	iss := matchableIssue{
+		Key:         "src-1",
+		Rule:        "secrets:S7001",
+		Component:   "demo-rules:secrets/az.xml",
+		Line:        7,
+		Status:      "OPEN",
+		IssueStatus: "OPEN",
+		Tags:        []string{"action-plan"},
+		AllTags:     []string{"cwe", "action-plan"},
+	}
+	if !hasManualChanges(iss) {
+		t.Fatal("an OPEN issue with a user-added tag must be actionable")
+	}
+	if trans, downgraded := resolveTransition(iss, nil); trans != "" || downgraded {
+		t.Errorf("OPEN issue needs no transition: got %q downgraded=%v", trans, downgraded)
+	}
+	if b := classifyActionableReasons([]matchableIssue{iss}); b.customTags != 1 || b.acceptedOrFP != 0 {
+		t.Errorf("want customTags=1 acceptedOrFP=0, got customTags=%d acceptedOrFP=%d",
+			b.customTags, b.acceptedOrFP)
+	}
+	// The payload that would be written keeps both the custom and the
+	// rule-default tag, plus the idempotency marker.
+	want := []string{"action-plan", "cwe", metadataSyncTag}
+	if got := mergeIssueTags(iss.tagsToApply(), nil); !equalStrings(got, want) {
+		t.Errorf("tag payload = %v, want %v", got, want)
+	}
+}

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -410,6 +410,16 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 
 	// Filter profiles and rules to languages present in the project (matches cloudvoyager).
 	projectLangs := collectProjectLanguages(components)
+	// Cross-language analyzers raise findings on files whose own language
+	// differs from the analyzer's — secret detection is the canonical case: a
+	// `secrets:S6292` issue lives in a shell script, an XML file, or a file
+	// SonarQube assigns no language to at all. The component-derived language
+	// set therefore never contains "secrets", filterRulesByLanguage stripped
+	// every secrets active rule, and dropIssuesWithInactiveRules then discarded
+	// every secrets finding — silently losing the issues, and with them their
+	// custom tags (#456). Widen the set with the languages of the active rules
+	// the findings actually reference before filtering.
+	logWidenedLangs(e, input, widenLangsForFindingRules(projectLangs, scProfileByLang, activeRules, issues, hotspotIssues))
 	activeRules = filterRulesByLanguage(activeRules, projectLangs)
 
 	qprofiles := buildProjectQProfiles(projectLangs, scProfileByLang)
@@ -1738,6 +1748,74 @@ func stripNullBytes(s string) string {
 		return s // fast path — most files have no NUL bytes
 	}
 	return strings.ReplaceAll(s, "\x00", "")
+}
+
+// logWidenedLangs reports the languages widenLangsForFindingRules added to the
+// report's language set. No-op when nothing was added.
+func logWidenedLangs(e *Executor, input importBranchInput, added []string) {
+	if len(added) == 0 {
+		return
+	}
+	e.Logger.Info("widened report language set for cross-language analyzer findings",
+		"project", input.CloudKey, "branch", input.Branch, "languages", added)
+}
+
+// widenLangsForFindingRules adds to projectLangs the languages of the active
+// rules referenced by the given findings, so that language-filtering the
+// active-rule set does not strip rules the report's own issues depend on.
+// projectLangs is mutated in place; the sorted list of newly added languages
+// is returned for logging (empty when nothing changed).
+//
+// Motivation (#456): projectLangs is derived from the language SonarQube
+// assigned to each file component. Cross-language analyzers break that
+// assumption — a secret-detection rule (language "secrets") raises issues in
+// `.sh`, `.xml` and extension-less files, so "secrets" is absent from the
+// component-derived set. filterRulesByLanguage then dropped all secrets active
+// rules, and dropIssuesWithInactiveRules dropped every secrets issue, so those
+// issues never reached the target and the tag/status sync had nothing to write
+// onto.
+//
+// rules must be the UNFILTERED active-rule list (that is the only place a
+// rule's language is known). A language is only added when the target
+// organization actually exposes a quality profile for it: without a target
+// profile the rules cannot be remapped to a valid qprofile key
+// (remapActiveRuleProfiles) and the report's metadata would reference a
+// SonarQube Server profile key the Compute Engine rejects. Findings whose
+// language has no target profile keep being dropped by
+// dropIssuesWithInactiveRules, which logs them.
+func widenLangsForFindingRules(
+	projectLangs map[string]bool,
+	scProfileByLang map[string]scanreport.QProfileInfo,
+	rules []scanreport.ActiveRuleInput,
+	findingGroups ...[]scanreport.IssueInput,
+) []string {
+	if projectLangs == nil || len(rules) == 0 {
+		return nil
+	}
+	langByRule := make(map[string]string, len(rules))
+	for _, r := range rules {
+		if r.Language == "" {
+			continue
+		}
+		langByRule[r.RuleRepo+":"+r.RuleKey] = strings.ToLower(r.Language)
+	}
+
+	var added []string
+	for _, group := range findingGroups {
+		for _, f := range group {
+			lang, ok := langByRule[f.RuleRepo+":"+f.RuleKey]
+			if !ok || projectLangs[lang] {
+				continue
+			}
+			if _, hasProfile := scProfileByLang[lang]; !hasProfile {
+				continue
+			}
+			projectLangs[lang] = true
+			added = append(added, lang)
+		}
+	}
+	slices.Sort(added)
+	return added
 }
 
 // filterRulesByLanguage keeps only active rules whose language is in the project.

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -5,6 +5,7 @@
 package migrate
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"log/slog"
@@ -572,6 +573,50 @@ func scProfiles(langs ...string) map[string]scanreport.QProfileInfo {
 	return m
 }
 
+// widenLangCase is one widenLangsForFindingRules scenario. Named (rather than
+// an anonymous struct) so the assertions can live in helpers and keep the test
+// function's cognitive complexity low.
+type widenLangCase struct {
+	name       string
+	langs      map[string]bool
+	scByLang   map[string]scanreport.QProfileInfo
+	issues     []scanreport.IssueInput
+	hotspots   []scanreport.IssueInput
+	wantAdded  []string
+	wantInLang []string
+	wantAbsent []string
+}
+
+// assertLangsPresent fails for every language missing from the widened set.
+func assertLangsPresent(t *testing.T, langs map[string]bool, want []string) {
+	t.Helper()
+	for _, l := range want {
+		if !langs[l] {
+			t.Errorf("language %q missing from widened set %v", l, langs)
+		}
+	}
+}
+
+// assertLangsAbsent fails for every language that must NOT have been added.
+func assertLangsAbsent(t *testing.T, langs map[string]bool, notWant []string) {
+	t.Helper()
+	for _, l := range notWant {
+		if langs[l] {
+			t.Errorf("language %q must NOT be in the set %v", l, langs)
+		}
+	}
+}
+
+// assertWidenCase checks the returned added-language list and the resulting set.
+func assertWidenCase(t *testing.T, tc widenLangCase, got []string) {
+	t.Helper()
+	if strings.Join(got, ",") != strings.Join(tc.wantAdded, ",") {
+		t.Errorf("added languages: want %v, got %v", tc.wantAdded, got)
+	}
+	assertLangsPresent(t, tc.langs, tc.wantInLang)
+	assertLangsAbsent(t, tc.langs, tc.wantAbsent)
+}
+
 func TestWidenLangsForFindingRules(t *testing.T) {
 	// The demo-rules shape from #456: a secret-detection rule (language
 	// "secrets") raising issues inside a shell script and an XML file, neither
@@ -584,16 +629,7 @@ func TestWidenLangsForFindingRules(t *testing.T) {
 		{RuleRepo: "noLang", RuleKey: "S1", Language: ""},
 	}
 
-	tests := []struct {
-		name       string
-		langs      map[string]bool
-		scByLang   map[string]scanreport.QProfileInfo
-		issues     []scanreport.IssueInput
-		hotspots   []scanreport.IssueInput
-		wantAdded  []string
-		wantInLang []string
-		wantAbsent []string
-	}{
+	tests := []widenLangCase{
 		{
 			name:     "secrets finding on a non-secrets file widens the language set",
 			langs:    map[string]bool{"py": true, "xml": true},
@@ -679,21 +715,34 @@ func TestWidenLangsForFindingRules(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := widenLangsForFindingRules(tc.langs, tc.scByLang, rules, tc.issues, tc.hotspots)
-			if strings.Join(got, ",") != strings.Join(tc.wantAdded, ",") {
-				t.Errorf("added languages: want %v, got %v", tc.wantAdded, got)
-			}
-			for _, l := range tc.wantInLang {
-				if !tc.langs[l] {
-					t.Errorf("language %q missing from widened set %v", l, tc.langs)
-				}
-			}
-			for _, l := range tc.wantAbsent {
-				if tc.langs[l] {
-					t.Errorf("language %q must NOT be in the set %v", l, tc.langs)
-				}
-			}
+			assertWidenCase(t, tc,
+				widenLangsForFindingRules(tc.langs, tc.scByLang, rules, tc.issues, tc.hotspots))
 		})
+	}
+}
+
+// logWidenedLangs must stay silent when nothing was widened and emit exactly
+// one line naming the languages when something was.
+func TestLogWidenedLangs(t *testing.T) {
+	var buf bytes.Buffer
+	e := &Executor{Logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
+	input := importBranchInput{CloudKey: "org_proj", Branch: "main"}
+
+	logWidenedLangs(e, input, nil)
+	logWidenedLangs(e, input, []string{})
+	if buf.Len() != 0 {
+		t.Errorf("nothing widened must log nothing, got %q", buf.String())
+	}
+
+	logWidenedLangs(e, input, []string{"secrets", "text"})
+	out := buf.String()
+	for _, want := range []string{"widened report language set", "org_proj", "main", "secrets", "text"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log line missing %q; got %q", want, out)
+		}
+	}
+	if n := strings.Count(out, "widened report language set"); n != 1 {
+		t.Errorf("want exactly 1 log line, got %d: %q", n, out)
 	}
 }
 

--- a/go/internal/migrate/tasks_projectdata_test.go
+++ b/go/internal/migrate/tasks_projectdata_test.go
@@ -560,6 +560,219 @@ func TestDropIssuesWithInactiveRules(t *testing.T) {
 	}
 }
 
+// --- #456: cross-language analyzer findings must keep their active rules ---
+
+// scProfiles is a test helper building the language→target-profile map that
+// widenLangsForFindingRules consults.
+func scProfiles(langs ...string) map[string]scanreport.QProfileInfo {
+	m := make(map[string]scanreport.QProfileInfo, len(langs))
+	for _, l := range langs {
+		m[l] = scanreport.QProfileInfo{Key: "sc-" + l, Name: "Sonar way", Language: l}
+	}
+	return m
+}
+
+func TestWidenLangsForFindingRules(t *testing.T) {
+	// The demo-rules shape from #456: a secret-detection rule (language
+	// "secrets") raising issues inside a shell script and an XML file, neither
+	// of which SonarQube labels as "secrets".
+	rules := []scanreport.ActiveRuleInput{
+		{RuleRepo: "python", RuleKey: "S100", Language: "py"},
+		{RuleRepo: "secrets", RuleKey: "S7001", Language: "secrets"},
+		{RuleRepo: "secrets", RuleKey: "S6292", Language: "secrets"},
+		{RuleRepo: "text", RuleKey: "S1135", Language: "text"},
+		{RuleRepo: "noLang", RuleKey: "S1", Language: ""},
+	}
+
+	tests := []struct {
+		name       string
+		langs      map[string]bool
+		scByLang   map[string]scanreport.QProfileInfo
+		issues     []scanreport.IssueInput
+		hotspots   []scanreport.IssueInput
+		wantAdded  []string
+		wantInLang []string
+		wantAbsent []string
+	}{
+		{
+			name:     "secrets finding on a non-secrets file widens the language set",
+			langs:    map[string]bool{"py": true, "xml": true},
+			scByLang: scProfiles("py", "xml", "secrets"),
+			issues: []scanreport.IssueInput{
+				{RuleRepo: "secrets", RuleKey: "S6292", Component: "p:secrets/run_linters.sh"},
+			},
+			wantAdded:  []string{"secrets"},
+			wantInLang: []string{"py", "xml", "secrets"},
+		},
+		{
+			name:     "language added only once even with many findings",
+			langs:    map[string]bool{"py": true},
+			scByLang: scProfiles("py", "secrets"),
+			issues: []scanreport.IssueInput{
+				{RuleRepo: "secrets", RuleKey: "S7001", Component: "p:a.xml"},
+				{RuleRepo: "secrets", RuleKey: "S6292", Component: "p:b.sh"},
+				{RuleRepo: "secrets", RuleKey: "S7001", Component: "p:c"},
+			},
+			wantAdded:  []string{"secrets"},
+			wantInLang: []string{"py", "secrets"},
+		},
+		{
+			name:     "no target quality profile for the language — not widened",
+			langs:    map[string]bool{"py": true},
+			scByLang: scProfiles("py"), // target org has no "secrets" profile
+			issues: []scanreport.IssueInput{
+				{RuleRepo: "secrets", RuleKey: "S6292", Component: "p:b.sh"},
+			},
+			wantAdded:  nil,
+			wantInLang: []string{"py"},
+			wantAbsent: []string{"secrets"},
+		},
+		{
+			name:     "language already present — nothing added",
+			langs:    map[string]bool{"py": true, "secrets": true},
+			scByLang: scProfiles("py", "secrets"),
+			issues: []scanreport.IssueInput{
+				{RuleRepo: "secrets", RuleKey: "S7001", Component: "p:a.xml"},
+			},
+			wantAdded:  nil,
+			wantInLang: []string{"py", "secrets"},
+		},
+		{
+			name:     "rule not in the active-rule list — nothing added",
+			langs:    map[string]bool{"py": true},
+			scByLang: scProfiles("py", "secrets"),
+			issues: []scanreport.IssueInput{
+				{RuleRepo: "secrets", RuleKey: "My_custom_rule", Component: "p:b.sh"},
+			},
+			wantAdded:  nil,
+			wantInLang: []string{"py"},
+			wantAbsent: []string{"secrets"},
+		},
+		{
+			name:     "active rule with no language is ignored",
+			langs:    map[string]bool{"py": true},
+			scByLang: scProfiles("py"),
+			issues: []scanreport.IssueInput{
+				{RuleRepo: "noLang", RuleKey: "S1", Component: "p:b.sh"},
+			},
+			wantAdded:  nil,
+			wantInLang: []string{"py"},
+		},
+		{
+			name:     "hotspot findings widen the set too",
+			langs:    map[string]bool{"py": true},
+			scByLang: scProfiles("py", "text"),
+			hotspots: []scanreport.IssueInput{
+				{RuleRepo: "text", RuleKey: "S1135", Component: "p:notes.md"},
+			},
+			wantAdded:  []string{"text"},
+			wantInLang: []string{"py", "text"},
+		},
+		{
+			name:       "no findings — nothing added",
+			langs:      map[string]bool{"py": true},
+			scByLang:   scProfiles("py", "secrets"),
+			wantAdded:  nil,
+			wantInLang: []string{"py"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := widenLangsForFindingRules(tc.langs, tc.scByLang, rules, tc.issues, tc.hotspots)
+			if strings.Join(got, ",") != strings.Join(tc.wantAdded, ",") {
+				t.Errorf("added languages: want %v, got %v", tc.wantAdded, got)
+			}
+			for _, l := range tc.wantInLang {
+				if !tc.langs[l] {
+					t.Errorf("language %q missing from widened set %v", l, tc.langs)
+				}
+			}
+			for _, l := range tc.wantAbsent {
+				if tc.langs[l] {
+					t.Errorf("language %q must NOT be in the set %v", l, tc.langs)
+				}
+			}
+		})
+	}
+}
+
+func TestWidenLangsForFindingRulesDegenerateInputs(t *testing.T) {
+	rules := []scanreport.ActiveRuleInput{{RuleRepo: "secrets", RuleKey: "S7001", Language: "secrets"}}
+	issues := []scanreport.IssueInput{{RuleRepo: "secrets", RuleKey: "S7001"}}
+
+	if got := widenLangsForFindingRules(nil, scProfiles("secrets"), rules, issues); got != nil {
+		t.Errorf("nil language map: want nil, got %v", got)
+	}
+	langs := map[string]bool{"py": true}
+	if got := widenLangsForFindingRules(langs, scProfiles("secrets"), nil, issues); got != nil {
+		t.Errorf("no active rules: want nil, got %v", got)
+	}
+	if len(langs) != 1 || !langs["py"] {
+		t.Errorf("language map must be untouched, got %v", langs)
+	}
+}
+
+// TestSecretsFindingSurvivesLanguageFilter is the end-to-end regression test
+// for #456. It replays the exact pipeline order from buildBranchReport —
+// widen → filterRulesByLanguage → dropIssuesWithInactiveRules — over the
+// demo-rules shape, and asserts the secrets issues survive. Without the
+// widening step every secrets active rule is filtered out and all three
+// secrets issues are dropped from the scan report, so they never exist on the
+// target and their custom tags have nothing to be applied to.
+func TestSecretsFindingSurvivesLanguageFilter(t *testing.T) {
+	activeRules := []scanreport.ActiveRuleInput{
+		{RuleRepo: "python", RuleKey: "S100", Language: "py"},
+		{RuleRepo: "xml", RuleKey: "S1778", Language: "xml"},
+		{RuleRepo: "secrets", RuleKey: "S7001", Language: "secrets"},
+		{RuleRepo: "secrets", RuleKey: "S6292", Language: "secrets"},
+	}
+	issues := []scanreport.IssueInput{
+		{RuleRepo: "python", RuleKey: "S100", Component: "p:secrets/hello_world.py"},
+		// az.xml is language "xml"; run_linters.sh has NO language at all.
+		{RuleRepo: "secrets", RuleKey: "S7001", Component: "p:secrets/az.xml"},
+		{RuleRepo: "secrets", RuleKey: "S6292", Component: "p:secrets/run_linters.sh"},
+	}
+	// Component-derived languages: the secrets analyzer's own language is absent.
+	componentLangs := map[string]bool{"py": true, "xml": true}
+	scByLang := scProfiles("py", "xml", "secrets")
+
+	// --- Without the fix (pre-#456 behaviour): both secrets issues are lost.
+	before := map[string]bool{"py": true, "xml": true}
+	rulesBefore := filterRulesByLanguage(activeRules, before)
+	_, droppedBefore := dropIssuesWithInactiveRules(issues, rulesBefore)
+	if droppedBefore != 2 {
+		t.Fatalf("sanity check on pre-fix behaviour: want 2 secrets issues dropped, got %d", droppedBefore)
+	}
+
+	// --- With the fix: nothing is dropped.
+	added := widenLangsForFindingRules(componentLangs, scByLang, activeRules, issues, nil)
+	if strings.Join(added, ",") != "secrets" {
+		t.Fatalf("want [secrets] added, got %v", added)
+	}
+	rulesAfter := filterRulesByLanguage(activeRules, componentLangs)
+	kept, dropped := dropIssuesWithInactiveRules(issues, rulesAfter)
+	if dropped != 0 {
+		t.Errorf("want 0 issues dropped after widening, got %d", dropped)
+	}
+	if len(kept) != len(issues) {
+		t.Fatalf("want all %d issues kept, got %d", len(issues), len(kept))
+	}
+
+	// The report metadata must now declare the secrets quality profile, or the
+	// Compute Engine rejects issues raised on rules from an undeclared profile.
+	qprofiles := buildProjectQProfiles(componentLangs, scByLang)
+	var hasSecrets bool
+	for _, q := range qprofiles {
+		if q.Language == "secrets" {
+			hasSecrets = true
+		}
+	}
+	if !hasSecrets {
+		t.Errorf("report qprofiles must include the secrets profile, got %+v", qprofiles)
+	}
+}
+
 func TestCollectBranchInfoNoMatch(t *testing.T) {
 	dir := t.TempDir()
 	setupProjectDataExtract(t, dir)


### PR DESCRIPTION
## The bug

Custom issue tags set on the source server were missing from the migrated issues. Reported against sample project `demo-rules`, whose three **OPEN** issues carrying the custom tag `action-plan` came out untagged on the target.

`Closes #456`

## Root cause

The issue's own hypothesis — that tag sync only runs for issues that also need a status transition — turned out to be **wrong**. `hasManualChanges` already treats a user-added tag as a standalone trigger, and the live run confirms it fired for exactly the right issues:

```
syncIssueMetadata: syncing pairs  source_total=7 actionable=3 custom_tags=3 accepted_or_false_positive=0
```

The real fault is one stage upstream: **the three issues never reached the target at all**, so there was nothing to tag.

`buildBranchReport` builds the fabricated scanner report in this order:

1. derive the report's language set from the language SonarQube assigned to each **file component**;
2. `filterRulesByLanguage` — filter the active-rule set to those languages;
3. `dropIssuesWithInactiveRules` — drop every native issue whose rule is not among the survivors (an orphan rule aborts the whole report in the Compute Engine, so this guard is necessary).

Cross-language analyzers break step 1's assumption. **Secret detection owns language `secrets`, but raises its issues inside files of other languages** — `demo-rules` has secrets findings in `secrets/az.xml` (language `xml`), `secrets/run_linters.sh` and `secrets/tmp` (SonarQube assigns these **no language at all**). So `secrets` never appeared in the component-derived set, all 359 secrets active rules were filtered out, and all 7 secrets issues were then dropped:

```
WARN dropped native issues referencing inactive rules  project=demo-rules-before-m456 dropped=7
INFO report packaged ... components=5 issues=1 externalIssues=0 activeRules=461
```

`issues=1` — and that one is the migrated Security Hotspot (tagged `former-hotspot`), not a native issue. `syncIssueMetadata` then correctly identified all 3 tagged issues as actionable and logged `no cloud counterpart on source line` for each, at **DEBUG**. That silence is why the loss looked like "tags didn't migrate" rather than "issues didn't migrate".

## Changes

**`go/internal/migrate/tasks_projectdata.go`**
- New `widenLangsForFindingRules()`: before the language filter runs, add to the report's language set the languages of the active rules the findings actually reference (native issues + hotspots). Gated on the **target organization exposing a quality profile for that language** — without one, the rules cannot be remapped to a valid qprofile key and the report metadata would cite a SonarQube Server profile key the CE rejects. Findings whose language has no target profile keep being dropped, with the existing warning.
- New `logWidenedLangs()` helper so the call site stays a single statement (avoids raising `buildBranchReport`'s cognitive complexity).

**`go/internal/migrate/tasks_issuesync.go`**
- `matchableIssue` gains `AllTags` — the issue's **complete** source tag list. `Tags` keeps its existing meaning (user-added subset, the actionability signal).
- `syncIssueTags` now writes `mergeIssueTags(sourceAllTags, cloudTags)`: the de-duplicated union of the source tag list and the tags the cloud issue already carries, plus the `metadata-synchronized` marker. `/api/issues/set_tags` **REPLACES** the tag list, so the previous behaviour of sending only the user-added subset stripped the rule-default tags the cloud analysis had assigned (e.g. `cwe`).
- Unmatched triaged issues are now reported at **WARN with totals** instead of only per-issue at DEBUG.

**`docs/`** — `MIGRATION-FACETS.md` (the Issue Tags row claimed "fully accurate"; corrected, and the Active Rules row now documents the language-filter trap), `TRANSFER-INTERNALS.md` (ASCII pipeline + two new "key facts"), `MIGRATION-CAPABILITIES.md` (SPEC-008).

## Live end-to-end verification

SonarQube Server **2026.3.1** (`http://localhost:9000`) → SonarQube Cloud staging, org `open-digital-society-1`. Both runs held a global mutex so the three concurrent agents could not corrupt each other's org-level profiles.

Source state (unchanged across both runs):

```
$ curl -u $T: "http://localhost:9000/api/issues/search?componentKeys=demo-rules&tags=action-plan"
total=3
7990e7e8-4d6f-48b9-8e60-00c9c4e802e4  secrets:S7001                 secrets/az.xml         L7   OPEN  ['action-plan','cwe']
f8702c46-d9d1-430a-973e-344880fbe005  secrets:S6292                 secrets/run_linters.sh L7   OPEN  ['action-plan','cwe']
08c29033-c30b-4e1e-b974-4d3011a22459  secrets:My_custom_secret_rule secrets/run_linters.sh L16  OPEN  ['action-plan','cwe']
```

### BEFORE — `origin/main` build (381b068), target `demo-rules-before-m456`

```
WARN dropped native issues referencing inactive rules  dropped=7
INFO report packaged ... issues=1 activeRules=461
INFO syncIssueMetadata: syncing pairs  source_total=7 actionable=3 custom_tags=3
DEBUG no cloud counterpart on source line  rule=secrets:S7001 file=secrets/az.xml line=7
DEBUG no cloud counterpart on source line  rule=secrets:S6292 file=secrets/run_linters.sh line=7
DEBUG no cloud counterpart on source line  rule=secrets:My_custom_secret_rule file=secrets/run_linters.sh line=16
```

Target readback — **0 of 7 source issues migrated**, tag absent:

```
TARGET_TOTAL_ISSUES=1
TARGET_TAG_HISTOGRAM={"cwe":1,"former-hotspot":1,"secret":1}
AZ-j8l9H0wiZ1XcMwQaj | python:S2068 | secrets/hello_world.py | 3 | OPEN | ['cwe','former-hotspot','secret']

ACTION_PLAN_TOTAL=0        <-- the bug
```

### AFTER — this branch, target `demo-rules-after-m456`

```
INFO widened report language set for cross-language analyzer findings  languages=[secrets]
INFO report packaged ... issues=8 activeRules=820          (was issues=1 activeRules=461)
     (no "dropped native issues" warning)
INFO syncIssueMetadata: syncing pairs  source_total=7 actionable=3 custom_tags=3
WARN triaged source issues without a unique Cloud counterpart  actionable=3 synced=2 not_found=1
```

Target readback — **all 7 source issues migrated; the tag is present**:

```
TARGET_TOTAL_ISSUES=7
TARGET_TAG_HISTOGRAM={"cwe":7,"secret":7,"former-hotspot":1,"action-plan":2,"metadata-synchronized":2}

AZ-j_-Tz0wiZ1XcMwQj_ | secrets:S7001 | secrets/az.xml         | 7  | OPEN | ['action-plan','cwe','metadata-synchronized','secret']
AZ-j_-WF0wiZ1XcMwQkD | secrets:S6292 | secrets/run_linters.sh | 7  | OPEN | ['action-plan','cwe','metadata-synchronized','secret']
AZ-j_-V80wiZ1XcMwQkA | secrets:S7001 | secrets/hello_world.py | 10 | OPEN | ['cwe','secret']
AZ-j_-V80wiZ1XcMwQkB | secrets:S6292 | secrets/hello_world.py | 22 | OPEN | ['cwe','secret']
AZ-j_-WS0wiZ1XcMwQkE | secrets:S6292 | secrets/tmp            | 3  | OPEN | ['cwe','secret']
AZ-j_-WS0wiZ1XcMwQkF | secrets:S7001 | secrets/tmp            | 11 | OPEN | ['cwe','secret']
AZ-j_-V80wiZ1XcMwQkC | python:S2068  | secrets/hello_world.py | 3  | OPEN | ['cwe','former-hotspot','secret']

ACTION_PLAN_TOTAL=2        <-- was 0
```

Transfer exit code `0`; the CE `REPORT` task for `demo-rules-after-m456` finished `SUCCESS` with `warningCount=0`. Note the `cwe` rule-default tag is retained alongside `action-plan`, which is the `mergeIssueTags` union working — the pre-fix `set_tags` payload would have replaced it.

## Honest scope limit: 2 of 3, and why the third cannot be fixed here

The third tagged issue (`08c29033…`, rule `secrets:My_custom_secret_rule`, `run_linters.sh:16`) still does **not** migrate. That rule is a **template-instantiated custom rule that does not exist in the target organization**:

```
$ GET /api/rules/show?organization=open-digital-society-1&key=secrets:My_custom_secret_rule
HTTP 404
```

`restoreProfiles` created the target's `secrets` profile with 353 of the source's 359 rules; the template-instantiated ones were not created. With no such rule on Cloud the CE cannot raise the issue, so there is no target issue to tag — no change to the tag-sync path can recover it. This is a **separate, pre-existing gap in custom/template rule migration**, now documented under Known Gaps in `MIGRATION-FACETS.md` and surfaced at WARN as `not_found=1` rather than swallowed at DEBUG. Worth its own issue.

Also confirmed: including that non-existent rule in `activerules.pb` does **not** abort the report — the CE drops just that one issue and the task still returns `SUCCESS`.

## Interaction with #474

The agent fixing **#474** is changing the same language / active-rule / quality-profile reconciliation path from the opposite direction: its root cause is that the report stamps every FILE component with its source language while `metadata.qprofiles_per_language` can only carry languages that have a target profile, and the CE rejects the **entire** report on mismatch. It adds `go/internal/migrate/unsupported_languages.go` and touches `migrate.go` (WIP commit `b69dd00`, not yet merged).

- At the time of writing, **#474 has not landed** — `origin/main` is still `381b068`, this branch's base, so there is no textual conflict and my live verification is against current `main`.
- The two fixes are complementary in intent and, importantly, **agree on the gating condition**: my widening only admits a language when `scProfileByLang` has a target profile for it, which is exactly the constraint #474 is enforcing. My change never widens into a language that lacks a target profile, so it cannot reintroduce the `qprofiles_per_language` mismatch #474 fixes.
- **This has not been verified with both fixes applied together.** Whichever PR lands second should re-run the *live* transfer, not just the unit tests — a semantic disagreement about which languages/rules are admitted would not surface as a merge conflict. Happy to rebase and re-verify if #474 merges first.

## Tests

`make build`, `make test` (full suite), and `go vet ./...` all pass. New tests:

- `TestWidenLangsForFindingRules` — 8 cases: widening on a secrets finding in a non-secrets file; idempotence across many findings; **not** widened when the target has no profile for the language; language already present; rule absent from the active-rule list; active rule with no language; hotspot-driven widening; no findings.
- `TestWidenLangsForFindingRulesDegenerateInputs` — nil language map, empty rule list, input map left untouched.
- `TestSecretsFindingSurvivesLanguageFilter` — the end-to-end regression test: replays the real pipeline order (widen → `filterRulesByLanguage` → `dropIssuesWithInactiveRules`) over the `demo-rules` shape, asserts 2 issues are dropped **without** the fix and 0 **with** it, and that the report's `qprofiles` gains the `secrets` profile.
- `TestMergeIssueTags` — 8 cases: union with cloud rule-defaults, custom tag onto an untagged issue, cloud-only tags preserved, duplicate collapse, marker not duplicated on re-run, blank/whitespace tags dropped, marker-only, trimming.
- `TestMatchableIssueTagsToApply` — full list preferred, fallback to the user-only subset, empty.
- `TestOpenIssueWithCustomTagIsActionableAndNeedsNoTransition` — locks down the property the issue suspected was broken (an OPEN issue with only a custom tag is actionable and needs no transition), so it cannot regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
