### PR TITLE
fix: handle programming languages SonarQube Cloud does not support (#474)

### DIFF
--- a/docs/MIGRATION-CAPABILITIES.md
+++ b/docs/MIGRATION-CAPABILITIES.md
@@ -21,6 +21,25 @@ The following entities are fully migrated today:
 | **Portfolios** | Portfolio structure and project assignments |
 | **Project Data** | Optional protobuf report injection for historical analysis data |
 
+### Languages SonarQube Cloud does not support
+<!-- updated: 2026-07-27_23:16:00 -->
+
+SonarQube Server can analyze languages SonarQube Cloud cannot — anything
+contributed by a 3rd-party (non-SonarSource) plugin has no Cloud analyzer and
+therefore no quality profile there. Such files **cannot** be migrated: the
+Compute Engine rejects any analysis report containing a file whose language has
+no matching quality profile, and it rejects the report as a whole.
+
+`transfer` detects this before submitting and, by default, excludes only those
+files so that every other file, issue, measure and branch still migrates; the
+project is then reported as a **Partial Migration** naming the languages and the
+file count. `--unsupported_languages=skip` declines to migrate the project's
+data at all. See
+[TRANSFER.md](TRANSFER.md#unsupported-programming-languages---unsupported_languages)
+and the troubleshooting entry
+[Project migrated but has no issues and no branches](TROUBLESHOOTING.md#project-migrated-but-has-no-issues-and-no-branches).
+Issue #474.
+
 ---
 
 ## Planned Capabilities (Roadmap)

--- a/docs/TRANSFER-INTERNALS.md
+++ b/docs/TRANSFER-INTERNALS.md
@@ -234,6 +234,13 @@ statement of `runTransfer`.
   |         non-main branches SEQUENTIAL:                                      |
   |           buildBranchReport: load issues / hotspots / components /         |
   |             sources / activeRules ;  skip empty/purged ;                   |
+  |             buildSCProfileMap(org) -> profile per LANGUAGE ;               |
+  |             #474 applyUnsupportedLanguagePolicy(components, profiles):     |
+  |               langs(components) \ langs(profiles) = UNSUPPORTED            |
+  |                 exclude (default) -> drop those file components            |
+  |                 skip              -> return "skipped" + reason, NO submit  |
+  |                 warn              -> submit unchanged (CE will reject)     |
+  |               (empty profile map = API failure -> detection disabled)      |
   |             remap SQ->SC profile keys ;  dedup active rules ;              |
   |             drop issues on inactive rules ;                                |
   |             BackdateChangesets -> original creation dates                  |
@@ -474,7 +481,7 @@ flowchart TB
 ```
 
 ## Key facts the chart encodes
-<!-- updated: 2026-06-09_21:16:18 -->
+<!-- updated: 2026-07-27_23:15:00 -->
 
 - **Project scoping is carried by exactly one parameter.** `getProjects` is the
   sole consumer of `ProjectKeys`; it sets `projects=<key>` on
@@ -503,3 +510,19 @@ flowchart TB
   `GenerateReports` fails the transfer still prints "Transfer complete." and
   exits 0. Both report files are written to the **top-level** export dir, not
   inside `runDir`.
+- **The report's file languages and its quality-profile metadata come from two
+  different places, and the CE cross-checks them.** Component languages come
+  from the source server (`api/measures/component_tree`); `qprofiles_per_language`
+  can only name profiles that exist on the **target** org
+  (`buildSCProfileMap`). A language present in the former but absent from the
+  latter makes the CE reject the *whole* report with `Report contains a file
+  with language 'X' but no matching quality profile` — costing every issue and
+  every branch while the project, permissions and gate survive, because they
+  are created earlier. `applyUnsupportedLanguagePolicy` closes that gap by
+  comparing the two sets before submitting (#474). A failed profile fetch
+  yields an empty map, so detection is disabled in that case rather than
+  treating every language as unsupported.
+- **A rejected report no longer passes as success.** `importProjectData` logs
+  the failure at **ERROR** and counts it (`task summary … failed=1`); the
+  migration report names the offending language and the remedy instead of
+  framing it as "API error when migrating project data" (#474).

--- a/docs/TRANSFER.md
+++ b/docs/TRANSFER.md
@@ -1,5 +1,5 @@
 # Using `transfer` — Transfer One Project
-<!-- updated: 2026-06-05_10:50:51 -->
+<!-- updated: 2026-07-27_23:05:00 -->
 
 `transfer` is the **single-command**, **project-scoped** path. It chains the four phases of a migration — **extract → structure → mappings → migrate** — into one call, then writes a PDF summary on completion. Use it when you have one project (or a small, well-known set of projects) to move across.
 
@@ -148,6 +148,7 @@ Omit `--project_key` to transfer **every** project visible to the token (in whic
 ---
 
 ## Flags
+<!-- updated: 2026-07-27_23:05:00 -->
 
 | Flag | Config key | Description |
 |------|------------|-------------|
@@ -167,8 +168,52 @@ Omit `--project_key` to transfer **every** project visible to the token (in whic
 | `--cert_password` | `source.cert_password` | Password for the source server mTLS client certificate |
 | `--skip_project_data_migration` | top-level `skip_project_data_migration` | Skip the project-data migration (importProjectData + per-issue / per-hotspot sync). Defaults to off — project data is migrated by default. Issue #303. |
 | `--exclude_branches` | `target.exclude_branches` | Glob patterns for non-main branches to skip during project data import. Repeatable. Main branch is never excluded. |
+| `--unsupported_languages` | top-level or `target.unsupported_languages` | How to handle files whose language has no quality profile on the target — typically a language from a 3rd-party SonarQube Server plugin. `exclude` (default) drops those files from the analysis report so the rest of the project still migrates; `skip` does not migrate the project's issues/branches at all; `warn` submits the report unchanged. Issue #474. |
 
 CLI flags override values from the config file when both are provided.
+
+### Unsupported programming languages (`--unsupported_languages`)
+<!-- updated: 2026-07-27_23:05:00 -->
+
+SonarQube Server can analyze languages SonarQube Cloud cannot. A language
+contributed by a 3rd-party (non-SonarSource) plugin has no analyzer on the
+Cloud side, and therefore no quality profile.
+
+The analysis report `transfer` fabricates stamps every file with the language
+the source server reported for it, while the report's metadata can only name
+quality profiles that exist on the target. When a file's language has no target
+profile, the SonarQube Cloud Compute Engine rejects the **entire** report:
+
+```
+Report contains a file with language 'lua' but no matching quality profile
+```
+
+The project, its permissions and its quality gate are created before the report
+is submitted, so the result is a project that looks migrated but has **no issues
+and no branches**.
+
+`transfer` detects this before submitting and prints the affected languages, the
+file count and an example path. Choose the handling with
+`--unsupported_languages`:
+
+| Mode | Behaviour |
+|------|-----------|
+| `exclude` (default) | Drops the unsupported-language files from the report. Everything else — the other files, their issues, measures and all branches — migrates. The project is reported as a **Partial Migration** with the languages and file count listed. |
+| `skip` | Submits no report for the project. Its settings, permissions and quality gate still migrate; its issues and branches do not. Reported as skipped, with the reason. |
+| `warn` | Submits the report unchanged (pre-#474 behaviour). The Compute Engine is expected to reject it; the rejection is reported as such rather than as a generic API error. |
+
+```bash
+# Migrate everything except the unsupported-language files (default)
+sonar-migration-tool transfer -c config.json --project_key my-project
+
+# Do not transfer this project's issues/branches at all
+sonar-migration-tool transfer -c config.json --project_key my-project \
+  --unsupported_languages skip
+```
+
+A failure to read the target organization's quality profiles disables the
+detection entirely rather than treating every language as unsupported, so a
+transient API error can never drop a project's files.
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -142,6 +142,68 @@ sonar-migration-tool reset <TOKEN> <ENTERPRISE_KEY> --export_directory ./files/
 
 ---
 
+## Project migrated but has no issues and no branches
+<!-- updated: 2026-07-27_23:05:00 -->
+
+**Symptom.** `transfer` finishes and reports success. The project is on
+SonarQube Cloud with the right permissions, settings and quality gate — but it
+has no issues, no Security Hotspots, and only a single empty branch (usually
+named `master`, not your source main branch). The migration report says
+*Partial Migration*.
+
+**Cause.** The project contains files in a language that has no quality profile
+on the target organization — almost always a language contributed by a 3rd-party
+(non-SonarSource) SonarQube Server plugin, which SonarQube Cloud has no analyzer
+for. The Compute Engine rejects the **whole** analysis report:
+
+```
+Report contains a file with language 'lua' but no matching quality profile
+  (Visit failed for Component {key=my-project:src/main/Constants.lua,type=FILE} ...)
+```
+
+Because the project, its permissions and its quality gate are created *before*
+the report is submitted, everything except the code, issues and branches lands.
+
+**Confirm it.** Look for `level=ERROR msg="project data NOT migrated: ...` in the
+transfer output, or query the Compute Engine directly:
+
+```bash
+curl -u "$SC_TOKEN:" \
+  "https://sonarcloud.io/api/ce/activity?component=<target-project-key>&ps=10" \
+  | python3 -m json.tool | grep -A2 errorMessage
+```
+
+**Fix.** Choose how the transfer should handle those files with
+`--unsupported_languages` (issue #474):
+
+```bash
+# Default: drop the unsupported-language files, migrate everything else
+sonar-migration-tool transfer -c config.json --project_key my-project
+
+# Or: do not migrate this project's issues/branches at all
+sonar-migration-tool transfer -c config.json --project_key my-project \
+  --unsupported_languages skip
+```
+
+With the default `exclude` mode the affected files (and the issues on them)
+are left behind, and the project is reported as a Partial Migration with the
+languages and file count listed — every other file, issue, measure and branch
+migrates normally. See
+[Unsupported programming languages](TRANSFER.md#unsupported-programming-languages---unsupported_languages).
+
+To see which languages are involved before migrating, compare the source
+project's languages against the target organization's quality profiles:
+
+```bash
+curl -u "$SQ_TOKEN:" \
+  "$SQ_URL/api/measures/component?component=my-project&metricKeys=ncloc_language_distribution"
+curl -u "$SC_TOKEN:" \
+  "https://sonarcloud.io/api/qualityprofiles/search?organization=<org>" \
+  | python3 -c 'import sys,json; print(sorted({p["language"] for p in json.load(sys.stdin)["profiles"]}))'
+```
+
+---
+
 ## CE Task "Issue whilst processing the report" (importProjectData)
 <!-- updated: 2026-06-04_01:14:00.000 by Claude -->
 

--- a/go/cmd/transfer.go
+++ b/go/cmd/transfer.go
@@ -48,6 +48,7 @@ const (
 	flagCertPassword             = "cert_password"
 	flagDebug                    = "debug"
 	flagExcludeBranches          = "exclude_branches"
+	flagUnsupportedLanguages     = "unsupported_languages"
 )
 
 // transferTargetTasks is the explicit set of project-scoped "leaf" migrate
@@ -169,6 +170,10 @@ func init() {
 	f.String(flagCertPassword, "", "Password for the source server mTLS client certificate (maps to source.cert_password)")
 	// --debug is inherited from the persistent root flag; see cmd/root.go.
 	f.StringSlice(flagExcludeBranches, nil, "Glob patterns for non-main branches to skip during project data import (e.g. feature/*,bugfix/*)")
+	f.String(flagUnsupportedLanguages, "", "How to handle files whose language has no quality profile on the target — typically a language from a 3rd-party "+sqServerName+" plugin (#474). "+
+		"\"exclude\" (default) drops those files from the analysis report so the rest of the project still migrates; "+
+		"\"skip\" does not migrate the project's issues/branches at all; "+
+		"\"warn\" submits the report unchanged and lets "+scCloudName+" reject it. (maps to unsupported_languages)")
 }
 
 // transferConfig holds the resolved configuration after merging file and flag values.
@@ -192,6 +197,7 @@ type transferConfig struct {
 	skipProjectDataMigration bool
 	debug                    bool
 	excludeBranches          []string
+	unsupportedLanguages     string
 }
 
 func applyFlagString(cmd *cobra.Command, name string, target *string) {
@@ -281,6 +287,7 @@ func loadTransferFileDefaults(path string) (transferConfig, error) {
 	cfg.skipProjectDataMigration = migrateCfg.SkipProjectDataMigration
 	cfg.debug = migrateCfg.Debug
 	cfg.excludeBranches = migrateCfg.ExcludeBranches
+	cfg.unsupportedLanguages = migrateCfg.UnsupportedLanguages
 	return cfg, nil
 }
 
@@ -332,6 +339,7 @@ func resolveTransferConfig(cmd *cobra.Command) (transferConfig, error) {
 	if cmd.Flags().Changed(flagExcludeBranches) {
 		cfg.excludeBranches, _ = cmd.Flags().GetStringSlice(flagExcludeBranches)
 	}
+	applyFlagString(cmd, flagUnsupportedLanguages, &cfg.unsupportedLanguages)
 
 	if cfg.exportDir == "" {
 		cfg.exportDir = "./migration-files/"
@@ -360,6 +368,11 @@ func validateTransferConfig(cfg transferConfig) error {
 	// of a downstream cascade.
 	if cfg.projectKey == "" {
 		return fmt.Errorf("project key is required (--%s or project_key in config file) — transfer is project-scoped by design", flagProjectKey)
+	}
+	// #474 — reject an unknown handling mode up front rather than silently
+	// falling back to the default after the extract phase has already run.
+	if _, err := migrate.ParseUnsupportedLanguageMode(cfg.unsupportedLanguages); err != nil {
+		return fmt.Errorf("--%s: %w", flagUnsupportedLanguages, err)
 	}
 	return nil
 }
@@ -527,6 +540,7 @@ func runTransferMigrate(ctx context.Context, cfg transferConfig) (string, error)
 		SkipProjectDataMigration: cfg.skipProjectDataMigration,
 		Debug:                    cfg.debug,
 		ExcludeBranches:          cfg.excludeBranches,
+		UnsupportedLanguages:     cfg.unsupportedLanguages,
 		ProjectKeyPattern:        cfg.projectKeyPattern,
 	})
 	if err != nil {

--- a/go/cmd/transfer_test.go
+++ b/go/cmd/transfer_test.go
@@ -259,6 +259,38 @@ func TestValidateTransferConfig_HappyPath(t *testing.T) {
 	}
 }
 
+// #474: --unsupported_languages must be validated before the extract phase
+// runs. A typo'd mode silently falling back to the default would transfer data
+// the operator asked to skip, after a long extract has already completed.
+func TestValidateTransferConfig_UnsupportedLanguages(t *testing.T) {
+	base := transferConfig{
+		sourceURL:           "https://sq.example.com",
+		sourceToken:         "sq-tok",
+		projectKey:          "my-project",
+		targetToken:         "sc-tok",
+		defaultOrganization: "my-org",
+	}
+	for _, mode := range []string{"", "exclude", "skip", "warn", "SKIP"} {
+		cfg := base
+		cfg.unsupportedLanguages = mode
+		if err := validateTransferConfig(cfg); err != nil {
+			t.Errorf("mode %q: expected no error, got %v", mode, err)
+		}
+	}
+	for _, mode := range []string{"skipp", "none", "exclude-all"} {
+		cfg := base
+		cfg.unsupportedLanguages = mode
+		err := validateTransferConfig(cfg)
+		if err == nil {
+			t.Errorf("mode %q: expected a validation error", mode)
+			continue
+		}
+		if !contains(err.Error(), "--"+flagUnsupportedLanguages) {
+			t.Errorf("mode %q: error %q does not name the flag", mode, err.Error())
+		}
+	}
+}
+
 // #383: a misspelled --project_key passes validation but silently
 // returns zero projects from /api/projects/search?projects=<typo>.
 // ensureTransferProjectExtracted closes that gap by checking the

--- a/go/internal/migrate/config_file.go
+++ b/go/internal/migrate/config_file.go
@@ -47,6 +47,10 @@ type configFileShape struct {
 	SkipProjectDataMigration *FlexibleBool `json:"skip_project_data_migration"`
 	Debug                    bool          `json:"debug"`
 	ExcludeBranches          []string      `json:"exclude_branches"`
+	// UnsupportedLanguages selects how projects containing files in a
+	// language with no target quality profile are handled (#474):
+	// "exclude" (default), "skip", or "warn".
+	UnsupportedLanguages string `json:"unsupported_languages"`
 
 	// Shape 2 (command-sectioned).
 	Migrate *configFileShape `json:"migrate"`
@@ -98,6 +102,8 @@ type unifiedTargetBlock struct {
 	DefaultOrganization string   `json:"default_organization"` // #281
 	ProjectKeyPattern   string   `json:"project_key_pattern"`  // #138
 	ExcludeBranches     []string `json:"exclude_branches"`
+	// UnsupportedLanguages — see configFileShape.UnsupportedLanguages (#474).
+	UnsupportedLanguages string `json:"unsupported_languages"`
 }
 
 type sonarCloudBlock struct {
@@ -165,7 +171,11 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			cfg.DefaultOrganization = s.Target.DefaultOrganization
 			cfg.ProjectKeyPattern = s.Target.ProjectKeyPattern
 			cfg.ExcludeBranches = s.Target.ExcludeBranches
+			cfg.UnsupportedLanguages = s.Target.UnsupportedLanguages
 		}
+		// #474 — target.unsupported_languages wins, else the top-level field.
+		cfg.UnsupportedLanguages = resolveUnsupportedLanguages(
+			cfg.UnsupportedLanguages, s.UnsupportedLanguages)
 		if cfg.Concurrency == 0 {
 			cfg.Concurrency = s.Concurrency
 		}
@@ -185,6 +195,8 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		return cfg
 	case s.SonarCloud != nil:
 		cfg := s.SonarCloud.toMigrateConfig(s.Settings)
+		cfg.UnsupportedLanguages = resolveUnsupportedLanguages(
+			cfg.UnsupportedLanguages, s.UnsupportedLanguages)
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value
 		}
@@ -194,6 +206,8 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 		return cfg
 	case s.Migrate != nil:
 		cfg := s.Migrate.toMigrateConfig()
+		cfg.UnsupportedLanguages = resolveUnsupportedLanguages(
+			cfg.UnsupportedLanguages, s.UnsupportedLanguages)
 		// Outer-level skip_issue_sync wins when both outer and inner
 		// set it (#299). If only outer is set, propagate it down.
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
@@ -218,6 +232,8 @@ func (s configFileShape) toMigrateConfig() MigrateConfig {
 			IncludeProjectData: s.IncludeProjectData,
 			Debug:              s.Debug,
 			ExcludeBranches:    s.ExcludeBranches,
+			// #474 — flat shape reads the field directly.
+			UnsupportedLanguages: s.UnsupportedLanguages,
 		}
 		if s.SkipIssueSync != nil && s.SkipIssueSync.Set {
 			cfg.SkipIssueSync = s.SkipIssueSync.Value

--- a/go/internal/migrate/migrate.go
+++ b/go/internal/migrate/migrate.go
@@ -60,6 +60,14 @@ type MigrateConfig struct {
 	// during project data import. Main branch is never excluded.
 	ExcludeBranches []string
 
+	// UnsupportedLanguages selects how a project whose files use a language
+	// with no quality profile on the target organization is handled (#474):
+	// "exclude" (default) drops those files from the scanner report so the
+	// rest of the project migrates, "skip" declines to migrate the project's
+	// data at all, "warn" submits the report unchanged. Empty resolves to
+	// DefaultUnsupportedLanguages.
+	UnsupportedLanguages string
+
 	// ProjectKeyPattern is the template used to derive each target
 	// SonarQube Cloud project key from the source key, the org key, and
 	// the enterprise key. Defaults to DefaultProjectKeyPattern. Issue #138.
@@ -83,6 +91,11 @@ type Executor struct {
 	Sem             chan struct{}
 	Logger          *slog.Logger
 	ExcludeBranches []string
+
+	// UnsupportedLanguages is the resolved handling mode for files whose
+	// language has no quality profile on the target organization (#474):
+	// UnsupportedLanguagesExclude / Skip / Warn.
+	UnsupportedLanguages string
 
 	// ProjectKeyPattern is the resolved target-key template (issue #138),
 	// consumed by every task that derives a SonarQube Cloud project key
@@ -290,22 +303,23 @@ func RunMigrate(ctx context.Context, cfg MigrateConfig) (runIDOut string, retErr
 	plan = filterCompleted(plan, store)
 
 	executor := &Executor{
-		Cloud:             cc,
-		CloudAPI:          apiCC,
-		Raw:               raw,
-		RawAPI:            rawAPI,
-		Extract:           nil, // Will be set per-task based on extract mapping
-		Store:             store,
-		CloudURL:          cloudClient.BaseURL(),
-		APIURL:            apiClient.BaseURL(),
-		EntKey:            cfg.EnterpriseKey,
-		Edition:           edition,
-		ExportDir:         cfg.ExportDirectory,
-		Mapping:           mapping,
-		Sem:               make(chan struct{}, cfg.Concurrency),
-		ExcludeBranches:   cfg.ExcludeBranches,
-		ProjectKeyPattern: cfg.ProjectKeyPattern,
-		Logger:            logger,
+		Cloud:                cc,
+		CloudAPI:             apiCC,
+		Raw:                  raw,
+		RawAPI:               rawAPI,
+		Extract:              nil, // Will be set per-task based on extract mapping
+		Store:                store,
+		CloudURL:             cloudClient.BaseURL(),
+		APIURL:               apiClient.BaseURL(),
+		EntKey:               cfg.EnterpriseKey,
+		Edition:              edition,
+		ExportDir:            cfg.ExportDirectory,
+		Mapping:              mapping,
+		Sem:                  make(chan struct{}, cfg.Concurrency),
+		ExcludeBranches:      cfg.ExcludeBranches,
+		UnsupportedLanguages: cfg.UnsupportedLanguages,
+		ProjectKeyPattern:    cfg.ProjectKeyPattern,
+		Logger:               logger,
 	}
 
 	// Execute phases.
@@ -377,6 +391,14 @@ func (cfg *MigrateConfig) applyDefaults() {
 	}
 	if strings.TrimSpace(cfg.ProjectKeyPattern) == "" {
 		cfg.ProjectKeyPattern = DefaultProjectKeyPattern
+	}
+	// #474 — normalise the unsupported-language handling mode. An invalid
+	// value is rejected at the CLI layer (ValidateUnsupportedLanguages), so
+	// here we only need to fill in the default for an absent value.
+	if mode, err := ParseUnsupportedLanguageMode(cfg.UnsupportedLanguages); err == nil {
+		cfg.UnsupportedLanguages = mode
+	} else {
+		cfg.UnsupportedLanguages = DefaultUnsupportedLanguages
 	}
 	// Ensure trailing slash.
 	if cfg.URL != "" && cfg.URL[len(cfg.URL)-1] != '/' {

--- a/go/internal/migrate/tasks_projectdata.go
+++ b/go/internal/migrate/tasks_projectdata.go
@@ -48,6 +48,7 @@ func runImportProjectData(ctx context.Context, e *Executor) error {
 	}
 
 	completed := loadCompletedBranches(e.Store)
+	counter := TaskCounterFromContext(ctx)
 
 	e.Logger.Info("starting task", "task", "importProjectData", "items", len(projects))
 	prog := common.NewProgressLogger(e.Logger, "importProjectData", len(projects))
@@ -81,9 +82,11 @@ func runImportProjectData(ctx context.Context, e *Executor) error {
 
 			scMainBranch := fetchSCMainBranch(gCtx, e, cloudKey)
 
-			if err := importProjectBranches(gCtx, e, proj, sqBranches, scMainBranch, completed, w); err != nil {
-				e.Logger.Warn("project project data failed", "project", cloudKey, "err", err)
-			}
+			// #474 — a rejected report used to be a Warn that left the task
+			// summary reporting nothing at all, so a transfer that migrated
+			// zero issues and zero branches still looked clean.
+			recordImportOutcome(e, counter, cloudKey,
+				importProjectBranches(gCtx, e, proj, sqBranches, scMainBranch, completed, w))
 			prog.Increment()
 			return nil
 		})
@@ -275,6 +278,10 @@ func recordBranchResult(w *common.ChunkWriter, cloudKey, branchName string, resu
 		"task_id":           result.TaskID,
 		"error":             result.Error,
 		"source_purged":     result.SourcePurged,
+		// #474 — languages with no target quality profile, and how many files
+		// were dropped from the report because of them.
+		"unsupported_languages": result.UnsupportedLanguages,
+		"excluded_files":        result.ExcludedFiles,
 	})
 	w.WriteOne(record) //nolint:errcheck
 }
@@ -300,6 +307,15 @@ type importResult struct {
 	// flag drives the per-project "source code of branch X is missing" note
 	// in the migration report.
 	SourcePurged bool
+	// UnsupportedLanguages lists the languages found in this branch that have
+	// no quality profile on the target organization (#474). Set whether the
+	// branch was skipped, excluded-and-migrated, or submitted as-is, so the
+	// migration report can always explain what happened.
+	UnsupportedLanguages []string
+	// ExcludedFiles is the number of file components dropped from the scanner
+	// report because their language has no target quality profile (#474,
+	// --unsupported_languages=exclude).
+	ExcludedFiles int
 }
 
 func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*importResult, error) {
@@ -336,7 +352,10 @@ func importBranch(ctx context.Context, e *Executor, input importBranchInput) (*i
 		return nil, fmt.Errorf("CE task failed: %w", err)
 	}
 
-	return &importResult{Status: "success", TaskID: result.TaskID, SourcePurged: report.SourcePurged}, nil
+	return &importResult{
+		Status: "success", TaskID: result.TaskID, SourcePurged: report.SourcePurged,
+		UnsupportedLanguages: report.UnsupportedLanguages, ExcludedFiles: report.ExcludedFiles,
+	}, nil
 }
 
 // branchReport is a packaged scanner report for one branch, ready to submit.
@@ -347,6 +366,11 @@ type branchReport struct {
 	// (purged by housekeeping) so the report carries measures + issues but no
 	// source. Propagated to the importResult for #425 reporting.
 	SourcePurged bool
+	// UnsupportedLanguages / ExcludedFiles carry the #474 finding through to
+	// the importResult so the migration report can explain the outcome even
+	// when the branch itself migrated successfully.
+	UnsupportedLanguages []string
+	ExcludedFiles        int
 }
 
 // buildBranchReport loads the extracted data for one branch, applies the
@@ -407,6 +431,20 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 	// Fetch SC quality profiles (CloudVoyager uses SC profile keys, not SQ keys).
 	// The CE validates that qprofile keys in the metadata exist in the SC instance.
 	scProfileByLang := buildSCProfileMap(ctx, e, input.OrgKey)
+
+	// #474 — a file whose language has no target quality profile makes the
+	// SonarQube Cloud CE reject the WHOLE report ("Report contains a file with
+	// language 'X' but no matching quality profile"), which silently costs the
+	// project every issue and every branch. Detect that before submitting,
+	// explain it, and apply the configured handling mode.
+	componentsBeforePolicy := len(components)
+	components, unsupportedLangKeys, unsupportedSkip := applyUnsupportedLanguagePolicy(
+		e, input.CloudKey, input.Branch, components, scProfileByLang)
+	if unsupportedSkip != nil {
+		return nil, unsupportedSkip, nil
+	}
+	// Zero unless mode "exclude" actually dropped components.
+	excludedFiles := componentsBeforePolicy - len(components)
 
 	// Filter profiles and rules to languages present in the project (matches cloudvoyager).
 	projectLangs := collectProjectLanguages(components)
@@ -569,7 +607,10 @@ func buildBranchReport(ctx context.Context, e *Executor, input importBranchInput
 		"activeRules", len(activeRules),
 	)
 
-	return &branchReport{ZIP: zipBytes, ProjectVersion: projectVersion, SourcePurged: sourcePurged}, nil, nil
+	return &branchReport{
+		ZIP: zipBytes, ProjectVersion: projectVersion, SourcePurged: sourcePurged,
+		UnsupportedLanguages: unsupportedLangKeys, ExcludedFiles: excludedFiles,
+	}, nil, nil
 }
 
 // ensureFileSourcesPresent guarantees every FILE component has a source

--- a/go/internal/migrate/unsupported_languages.go
+++ b/go/internal/migrate/unsupported_languages.go
@@ -1,0 +1,390 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/scanreport"
+)
+
+// Unsupported programming languages in the fabricated scanner report (#474).
+//
+// SonarQube Server can analyze languages that SonarQube Cloud cannot: a
+// language contributed by a 3rd-party (non-SonarSource) plugin has no
+// analyzer and therefore no quality profile on the Cloud side. The scanner
+// report this tool fabricates stamps every FILE component with the language
+// the source server reported for it, while metadata.qprofiles_per_language
+// can only carry languages that DO have a target quality profile. When those
+// two disagree the SonarQube Cloud Compute Engine rejects the ENTIRE report:
+//
+//	Report contains a file with language 'X' but no matching quality profile
+//
+// The project itself, its permissions and its quality gate are already on the
+// target by then, so the operator is left with a project that looks migrated
+// but carries no issues and no branches at all.
+//
+// This file provides the detection (which languages in the report have no
+// target quality profile), the operator-facing explanation, and the three
+// handling modes selected by --unsupported_languages.
+
+const (
+	// UnsupportedLanguagesExclude drops the offending files from the scanner
+	// report so every other file — and therefore the project's issues,
+	// measures and branches — still migrates. The default: it turns a total,
+	// silent loss into a reported partial migration.
+	UnsupportedLanguagesExclude = "exclude"
+
+	// UnsupportedLanguagesSkip leaves the project's data un-migrated: no
+	// scanner report is submitted for any of its branches. The project is
+	// reported as skipped with the reason. This is the "option to not
+	// transfer such projects" from #474.
+	UnsupportedLanguagesSkip = "skip"
+
+	// UnsupportedLanguagesWarn submits the report unchanged — the pre-#474
+	// behaviour — but explains up front that the Compute Engine is expected
+	// to reject it, and reports the rejection instead of swallowing it.
+	UnsupportedLanguagesWarn = "warn"
+
+	// DefaultUnsupportedLanguages is the mode used when none is configured.
+	DefaultUnsupportedLanguages = UnsupportedLanguagesExclude
+)
+
+// UnsupportedLanguageModes lists the accepted --unsupported_languages values,
+// in help-text order.
+var UnsupportedLanguageModes = []string{
+	UnsupportedLanguagesExclude, UnsupportedLanguagesSkip, UnsupportedLanguagesWarn,
+}
+
+// ParseUnsupportedLanguageMode normalises and validates a mode string. An
+// empty value resolves to DefaultUnsupportedLanguages so an absent flag and
+// an absent config field behave identically.
+func ParseUnsupportedLanguageMode(value string) (string, error) {
+	mode := strings.ToLower(strings.TrimSpace(value))
+	if mode == "" {
+		return DefaultUnsupportedLanguages, nil
+	}
+	for _, valid := range UnsupportedLanguageModes {
+		if mode == valid {
+			return mode, nil
+		}
+	}
+	return "", fmt.Errorf("invalid unsupported_languages value %q: expected one of %s",
+		value, strings.Join(UnsupportedLanguageModes, ", "))
+}
+
+// resolveUnsupportedLanguages returns the first non-empty value, letting the
+// config-file loader express "section value wins, else top-level value" as a
+// plain assignment.
+func resolveUnsupportedLanguages(values ...string) string {
+	for _, v := range values {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// unsupportedLanguageMode resolves the executor's configured mode, falling
+// back to the default for an unparseable value (RunMigrate validates the
+// value up front, so this only guards direct Executor construction).
+func (e *Executor) unsupportedLanguageMode() string {
+	mode, err := ParseUnsupportedLanguageMode(e.UnsupportedLanguages)
+	if err != nil {
+		return DefaultUnsupportedLanguages
+	}
+	return mode
+}
+
+// unsupportedLangFinding describes the languages present in one branch's
+// components that have no quality profile on the target organization.
+type unsupportedLangFinding struct {
+	// Languages are the offending language keys, sorted for stable output.
+	Languages []string
+	// FileCounts maps each offending language to its file count.
+	FileCounts map[string]int
+	// Samples maps each offending language to one example file path, so the
+	// operator can see which part of the project is affected.
+	Samples map[string]string
+	// TotalFiles is the number of file components across all offending
+	// languages — i.e. how many files mode "exclude" would drop.
+	TotalFiles int
+}
+
+// detectUnsupportedLanguages returns the languages carried by the report's
+// file components that are absent from the target organization's quality
+// profiles, or nil when every language is covered.
+//
+// This mirrors exactly what the Compute Engine validates: it compares each
+// component's language against metadata.qprofiles_per_language, which
+// buildProjectQProfiles derives from targetProfileByLang.
+func detectUnsupportedLanguages(components []scanreport.ComponentInput,
+	targetProfileByLang map[string]scanreport.QProfileInfo) *unsupportedLangFinding {
+
+	finding := &unsupportedLangFinding{
+		FileCounts: make(map[string]int),
+		Samples:    make(map[string]string),
+	}
+	for _, c := range components {
+		lang := strings.ToLower(strings.TrimSpace(c.Language))
+		if lang == "" {
+			// A component with no language is not attributed to any quality
+			// profile, so the CE never looks one up for it.
+			continue
+		}
+		if _, ok := targetProfileByLang[lang]; ok {
+			continue
+		}
+		finding.FileCounts[lang]++
+		finding.TotalFiles++
+		if _, seen := finding.Samples[lang]; !seen {
+			sample := c.Path
+			if sample == "" {
+				sample = c.Key
+			}
+			finding.Samples[lang] = sample
+		}
+	}
+	if finding.TotalFiles == 0 {
+		return nil
+	}
+	for lang := range finding.FileCounts {
+		finding.Languages = append(finding.Languages, lang)
+	}
+	sort.Strings(finding.Languages)
+	return finding
+}
+
+// languageSet returns the offending languages as a lookup set.
+func (f *unsupportedLangFinding) languageSet() map[string]bool {
+	set := make(map[string]bool, len(f.Languages))
+	for _, l := range f.Languages {
+		set[l] = true
+	}
+	return set
+}
+
+// summary renders the offending languages as a compact, human-readable list:
+//
+//	lua (1 file, e.g. src/main/Constants.lua); delphi (12 files, e.g. app/Main.pas)
+func (f *unsupportedLangFinding) summary() string {
+	parts := make([]string, 0, len(f.Languages))
+	for _, lang := range f.Languages {
+		n := f.FileCounts[lang]
+		unit := "files"
+		if n == 1 {
+			unit = "file"
+		}
+		part := fmt.Sprintf("%s (%d %s", lang, n, unit)
+		if sample := f.Samples[lang]; sample != "" {
+			part += ", e.g. " + sample
+		}
+		parts = append(parts, part+")")
+	}
+	return strings.Join(parts, "; ")
+}
+
+// explanation is the operator-facing "what happened and why" (#474). It is
+// deliberately self-contained: it names the languages, says why the target has
+// no profile for them, states the consequence, and names the remedy for the
+// mode in force.
+func (f *unsupportedLangFinding) explanation(projectKey, branch, mode string) string {
+	return fmt.Sprintf(
+		"project %q branch %q contains %d file(s) in language(s) that have no quality profile "+
+			"on the target SonarQube Cloud organization: %s. "+
+			"SonarQube Cloud only provides quality profiles for languages its own analyzers support, "+
+			"so a language contributed by a 3rd-party SonarQube Server plugin has none. "+
+			"The Compute Engine rejects an entire scanner report that contains a file whose language "+
+			"has no matching quality profile, which would leave this project on SonarQube Cloud with "+
+			"its settings, permissions and quality gate but with NO issues and NO branches. %s",
+		projectKey, branch, f.TotalFiles, f.summary(), unsupportedLanguageAction(mode))
+}
+
+// unsupportedLanguageAction describes what the tool is doing about the finding
+// and how to choose differently.
+func unsupportedLanguageAction(mode string) string {
+	switch mode {
+	case UnsupportedLanguagesSkip:
+		return "Skipping this project's data as requested by --unsupported_languages=skip: " +
+			"no scanner report is submitted for any of its branches. " +
+			"Use --unsupported_languages=exclude to migrate everything except the unsupported files."
+	case UnsupportedLanguagesWarn:
+		return "Submitting the report unchanged as requested by --unsupported_languages=warn; " +
+			"expect the Compute Engine to reject it. " +
+			"Use --unsupported_languages=exclude to migrate everything except the unsupported files, " +
+			"or --unsupported_languages=skip to skip this project's data entirely."
+	default:
+		return "Excluding those files from the scanner report (--unsupported_languages=exclude, the default) " +
+			"so the rest of the project — its other files, issues, measures and branches — still migrates. " +
+			"Use --unsupported_languages=skip to skip this project's data entirely, " +
+			"or --unsupported_languages=warn to submit the report unchanged."
+	}
+}
+
+// skipReason is the short, report-facing sentence recorded on every branch
+// when mode "skip" declines to submit a report.
+func (f *unsupportedLangFinding) skipReason() string {
+	return "Project data not migrated: the project contains files in language(s) with no quality profile " +
+		"on the target organization — " + f.summary() +
+		" (typically a language provided by a 3rd-party SonarQube Server plugin). " +
+		"Skipped by --unsupported_languages=skip."
+}
+
+// allFilesExcludedReason is recorded when mode "exclude" removed every file in
+// the branch, leaving nothing to submit.
+func (f *unsupportedLangFinding) allFilesExcludedReason() string {
+	return "Project data not migrated: every file in the branch is in a language with no quality profile " +
+		"on the target organization — " + f.summary() +
+		" (typically a language provided by a 3rd-party SonarQube Server plugin)."
+}
+
+// excludeComponentsByLanguage returns the components whose language is not in
+// langs, plus the number dropped. Issues, measures, source text, SCM blame and
+// syntax highlighting all resolve through the component-ref map built from the
+// returned slice, so dropping a component drops everything attached to it.
+func excludeComponentsByLanguage(components []scanreport.ComponentInput,
+	langs map[string]bool) ([]scanreport.ComponentInput, int) {
+
+	kept := make([]scanreport.ComponentInput, 0, len(components))
+	dropped := 0
+	for _, c := range components {
+		if langs[strings.ToLower(strings.TrimSpace(c.Language))] {
+			dropped++
+			continue
+		}
+		kept = append(kept, c)
+	}
+	return kept, dropped
+}
+
+// applyUnsupportedLanguagePolicy detects unsupported languages in one branch's
+// components, explains the situation to the operator, and applies the mode
+// selected by --unsupported_languages.
+//
+// It returns the components that should go into the scanner report (unchanged
+// except in "exclude" mode), the offending language keys (nil when every
+// language is covered), and a non-nil importResult when the branch must NOT be
+// submitted at all.
+func applyUnsupportedLanguagePolicy(e *Executor, projectKey, branch string,
+	components []scanreport.ComponentInput,
+	targetProfileByLang map[string]scanreport.QProfileInfo,
+) ([]scanreport.ComponentInput, []string, *importResult) {
+
+	// An empty profile map means the target-side quality-profile lookup failed
+	// (buildSCProfileMap logs the error and returns an empty map) or no Cloud
+	// client is configured. Every language would then look unsupported, so
+	// detection must not run: a transient API error must never drop a whole
+	// project's files.
+	if len(targetProfileByLang) == 0 {
+		return components, nil, nil
+	}
+
+	finding := detectUnsupportedLanguages(components, targetProfileByLang)
+	if finding == nil {
+		return components, nil, nil
+	}
+
+	mode := e.unsupportedLanguageMode()
+	// Logged at WARN so it appears without --debug: this is the "meaningful
+	// explanation of what happened and why" #474 asks for.
+	e.Logger.Warn("unsupported programming language: "+finding.explanation(projectKey, branch, mode),
+		"project", projectKey, "branch", branch,
+		"languages", strings.Join(finding.Languages, ","),
+		"files", finding.TotalFiles, "mode", mode)
+
+	switch mode {
+	case UnsupportedLanguagesSkip:
+		return components, finding.Languages, &importResult{
+			Status:               "skipped",
+			Error:                finding.skipReason(),
+			UnsupportedLanguages: finding.Languages,
+		}
+	case UnsupportedLanguagesWarn:
+		return components, finding.Languages, nil
+	default:
+		kept, dropped := excludeComponentsByLanguage(components, finding.languageSet())
+		if len(kept) == 0 {
+			return kept, finding.Languages, &importResult{
+				Status:               "skipped",
+				Error:                finding.allFilesExcludedReason(),
+				UnsupportedLanguages: finding.Languages,
+				ExcludedFiles:        dropped,
+			}
+		}
+		e.Logger.Warn("excluded unsupported-language files from the scanner report so the rest of the branch migrates",
+			"project", projectKey, "branch", branch,
+			"excludedFiles", dropped, "remainingFiles", len(kept),
+			"languages", strings.Join(finding.Languages, ","))
+		return kept, finding.Languages, nil
+	}
+}
+
+// ceUnsupportedLanguagePattern matches the Compute Engine's rejection message
+// for a file whose language has no quality profile, e.g.
+//
+//	Report contains a file with language 'lua' but no matching quality profile
+var ceUnsupportedLanguagePattern = regexp.MustCompile(`language '([^']+)'`)
+
+// UnsupportedLanguageFromCEError extracts the language key from a Compute
+// Engine "no matching quality profile" rejection, or returns "" when the
+// message is a different failure. Used by the migration report to explain a
+// CE rejection instead of framing it as a generic API error (#474).
+func UnsupportedLanguageFromCEError(errMsg string) string {
+	lower := strings.ToLower(errMsg)
+	if !strings.Contains(lower, "quality profile") {
+		return ""
+	}
+	if !strings.Contains(lower, "no matching") && !strings.Contains(lower, "not found") {
+		return ""
+	}
+	if m := ceUnsupportedLanguagePattern.FindStringSubmatch(errMsg); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// IsUnsupportedLanguageCEFailure reports whether a failure came from the
+// Compute Engine rejecting a report because a file's language has no
+// matching quality profile on the target.
+func IsUnsupportedLanguageCEFailure(errMsg string) bool {
+	return UnsupportedLanguageFromCEError(errMsg) != ""
+}
+
+// recordImportOutcome logs and counts one project's data-import outcome, so the
+// end-of-task summary reports `failed=N` instead of staying silent (#474).
+func recordImportOutcome(e *Executor, counter *TaskCounter, cloudKey string, err error) {
+	if err == nil {
+		counter.Success()
+		return
+	}
+	logImportProjectDataFailure(e, cloudKey, err)
+	counter.Fail()
+}
+
+// logImportProjectDataFailure reports a project whose data import failed.
+//
+// Before #474 this was a single Warn line that the operator could easily miss:
+// the project had already been created on the target with its permissions and
+// quality gate, the transfer exited 0, and nothing said that every issue and
+// every branch had been dropped. It is now an ERROR, and a Compute Engine
+// rejection caused by a language with no target quality profile is named as
+// such together with the remedy.
+func logImportProjectDataFailure(e *Executor, cloudKey string, err error) {
+	if lang := UnsupportedLanguageFromCEError(err.Error()); lang != "" {
+		e.Logger.Error("project data NOT migrated: SonarQube Cloud rejected the analysis report because the "+
+			"project contains files in language '"+lang+"', which has no quality profile in the target "+
+			"organization (typically a language contributed by a 3rd-party SonarQube Server plugin). "+
+			"NO issues and NO branches were migrated for this project, even though the project itself, its "+
+			"permissions and its quality gate were. Re-run with --unsupported_languages=exclude to migrate "+
+			"everything except those files, or --unsupported_languages=skip to skip the project's data.",
+			"project", cloudKey, "language", lang, "err", err)
+		return
+	}
+	e.Logger.Error("project data NOT migrated: no issues and no branches were migrated for this project",
+		"project", cloudKey, "err", err)
+}

--- a/go/internal/migrate/unsupported_languages_test.go
+++ b/go/internal/migrate/unsupported_languages_test.go
@@ -394,6 +394,36 @@ func TestLogImportProjectDataFailure(t *testing.T) {
 	}
 }
 
+// The task summary is the operator's at-a-glance signal. Before #474 a project
+// whose report was rejected incremented nothing, so importProjectData reported
+// no outcome at all and a transfer that migrated zero issues looked clean.
+func TestRecordImportOutcome(t *testing.T) {
+	newExec := func(buf *bytes.Buffer) *Executor {
+		return &Executor{Logger: slog.New(slog.NewTextHandler(buf, nil))}
+	}
+
+	var okBuf bytes.Buffer
+	okCounter := NewTaskCounter("importProjectData")
+	recordImportOutcome(newExec(&okBuf), okCounter, "org_proj", nil)
+	if s, f := okCounter.succeeded.Load(), okCounter.failed.Load(); s != 1 || f != 0 {
+		t.Errorf("success: succeeded=%d failed=%d, want 1/0", s, f)
+	}
+	if okBuf.Len() != 0 {
+		t.Errorf("success must not log: %s", okBuf.String())
+	}
+
+	var failBuf bytes.Buffer
+	failCounter := NewTaskCounter("importProjectData")
+	recordImportOutcome(newExec(&failBuf), failCounter, "org_proj",
+		errors.New("CE task failed: Report contains a file with language 'lua' but no matching quality profile"))
+	if s, f := failCounter.succeeded.Load(), failCounter.failed.Load(); s != 0 || f != 1 {
+		t.Errorf("failure: succeeded=%d failed=%d, want 0/1", s, f)
+	}
+	if !strings.Contains(failBuf.String(), "level=ERROR") {
+		t.Errorf("failure must be logged at ERROR: %s", failBuf.String())
+	}
+}
+
 func TestResolveUnsupportedLanguages(t *testing.T) {
 	if got := resolveUnsupportedLanguages("", "skip"); got != "skip" {
 		t.Errorf("got %q, want the first non-empty value \"skip\"", got)

--- a/go/internal/migrate/unsupported_languages_test.go
+++ b/go/internal/migrate/unsupported_languages_test.go
@@ -1,0 +1,407 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package migrate
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/scanreport"
+)
+
+// discardExecutor returns an Executor with a silent logger and the given
+// unsupported-language handling mode.
+func discardExecutor(mode string) *Executor {
+	return &Executor{
+		Logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		UnsupportedLanguages: mode,
+	}
+}
+
+// targetProfiles builds the SC-profile-by-language map the CE validates
+// against, one profile per given language.
+func targetProfiles(langs ...string) map[string]scanreport.QProfileInfo {
+	m := make(map[string]scanreport.QProfileInfo, len(langs))
+	for _, l := range langs {
+		m[l] = scanreport.QProfileInfo{Key: "qp-" + l, Name: "Sonar way", Language: l}
+	}
+	return m
+}
+
+func TestParseUnsupportedLanguageMode(t *testing.T) {
+	cases := []struct {
+		in      string
+		want    string
+		wantErr bool
+	}{
+		{in: "", want: DefaultUnsupportedLanguages},
+		{in: "exclude", want: UnsupportedLanguagesExclude},
+		{in: "skip", want: UnsupportedLanguagesSkip},
+		{in: "warn", want: UnsupportedLanguagesWarn},
+		// Operators type flags by hand: tolerate case and stray whitespace.
+		{in: "SKIP", want: UnsupportedLanguagesSkip},
+		{in: "  Warn  ", want: UnsupportedLanguagesWarn},
+		// An unknown mode must be rejected, never silently defaulted — a
+		// typo'd --unsupported_languages=skipp would otherwise transfer
+		// data the operator asked to skip.
+		{in: "skipp", wantErr: true},
+		{in: "none", wantErr: true},
+	}
+	for _, c := range cases {
+		got, err := ParseUnsupportedLanguageMode(c.in)
+		if c.wantErr {
+			if err == nil {
+				t.Errorf("ParseUnsupportedLanguageMode(%q): expected error, got %q", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseUnsupportedLanguageMode(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("ParseUnsupportedLanguageMode(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// The default must be "exclude": with no flag, a project carrying a 3rd-party
+// plugin language should still migrate everything it can.
+func TestDefaultUnsupportedLanguagesIsExclude(t *testing.T) {
+	if DefaultUnsupportedLanguages != UnsupportedLanguagesExclude {
+		t.Errorf("default mode = %q, want %q", DefaultUnsupportedLanguages, UnsupportedLanguagesExclude)
+	}
+	cfg := MigrateConfig{}
+	cfg.applyDefaults()
+	if cfg.UnsupportedLanguages != UnsupportedLanguagesExclude {
+		t.Errorf("applyDefaults left mode = %q, want %q", cfg.UnsupportedLanguages, UnsupportedLanguagesExclude)
+	}
+}
+
+// applyDefaults must not preserve an invalid value — it is the last line of
+// defence if a config file smuggled one past the CLI validation.
+func TestApplyDefaultsNormalizesUnsupportedLanguages(t *testing.T) {
+	cfg := MigrateConfig{UnsupportedLanguages: "SKIP"}
+	cfg.applyDefaults()
+	if cfg.UnsupportedLanguages != UnsupportedLanguagesSkip {
+		t.Errorf("mode = %q, want %q", cfg.UnsupportedLanguages, UnsupportedLanguagesSkip)
+	}
+	bad := MigrateConfig{UnsupportedLanguages: "garbage"}
+	bad.applyDefaults()
+	if bad.UnsupportedLanguages != DefaultUnsupportedLanguages {
+		t.Errorf("invalid mode = %q, want fallback %q", bad.UnsupportedLanguages, DefaultUnsupportedLanguages)
+	}
+}
+
+func TestDetectUnsupportedLanguages(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Path: "src/a.java", Language: "java"},
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+		{Key: "p:c.lua", Path: "src/c.lua", Language: "lua"},
+		// Language casing from the source API must not defeat the lookup.
+		{Key: "p:d.pas", Path: "app/d.pas", Language: "Delphi"},
+		// Files SonarQube assigns no language to are never matched against a
+		// quality profile by the CE, so they must not be flagged.
+		{Key: "p:LICENSE", Path: "LICENSE", Language: ""},
+	}
+
+	got := detectUnsupportedLanguages(components, targetProfiles("java", "xml"))
+	if got == nil {
+		t.Fatal("expected a finding, got nil")
+	}
+	if want := []string{"delphi", "lua"}; strings.Join(got.Languages, ",") != strings.Join(want, ",") {
+		t.Errorf("Languages = %v, want %v (sorted)", got.Languages, want)
+	}
+	if got.FileCounts["lua"] != 2 {
+		t.Errorf("lua file count = %d, want 2", got.FileCounts["lua"])
+	}
+	if got.FileCounts["delphi"] != 1 {
+		t.Errorf("delphi file count = %d, want 1", got.FileCounts["delphi"])
+	}
+	if got.TotalFiles != 3 {
+		t.Errorf("TotalFiles = %d, want 3 (the empty-language file must not count)", got.TotalFiles)
+	}
+	if got.Samples["lua"] != "src/b.lua" {
+		t.Errorf("lua sample = %q, want the first matching path src/b.lua", got.Samples["lua"])
+	}
+}
+
+func TestDetectUnsupportedLanguagesAllCovered(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Path: "src/a.java", Language: "java"},
+		{Key: "p:b.xml", Path: "src/b.xml", Language: "xml"},
+		{Key: "p:LICENSE", Path: "LICENSE", Language: ""},
+	}
+	if got := detectUnsupportedLanguages(components, targetProfiles("java", "xml")); got != nil {
+		t.Errorf("expected nil finding when every language has a target profile, got %+v", got)
+	}
+}
+
+func TestUnsupportedLangFindingSummary(t *testing.T) {
+	one := detectUnsupportedLanguages(
+		[]scanreport.ComponentInput{{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"}},
+		targetProfiles("java"))
+	if got, want := one.summary(), "lua (1 file, e.g. src/b.lua)"; got != want {
+		t.Errorf("summary = %q, want %q", got, want)
+	}
+
+	many := detectUnsupportedLanguages([]scanreport.ComponentInput{
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+		{Key: "p:c.lua", Path: "src/c.lua", Language: "lua"},
+	}, targetProfiles("java"))
+	if got, want := many.summary(), "lua (2 files, e.g. src/b.lua)"; got != want {
+		t.Errorf("summary = %q, want %q", got, want)
+	}
+}
+
+// The explanation is the operator's only chance to understand a silent data
+// loss, so assert it carries the four things it must: the languages, the
+// reason, the consequence, and the remedy flag.
+func TestUnsupportedLangFindingExplanation(t *testing.T) {
+	f := detectUnsupportedLanguages(
+		[]scanreport.ComponentInput{{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"}},
+		targetProfiles("java"))
+	msg := f.explanation("org_proj", "main", UnsupportedLanguagesExclude)
+	for _, want := range []string{
+		"org_proj", "main", "lua", "quality profile",
+		"3rd-party", "NO issues and NO branches", "--unsupported_languages=skip",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("explanation missing %q\ngot: %s", want, msg)
+		}
+	}
+}
+
+func TestExcludeComponentsByLanguage(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Language: "java"},
+		{Key: "p:b.lua", Language: "lua"},
+		{Key: "p:c.java", Language: "java"},
+		{Key: "p:d.lua", Language: "LUA"},
+		{Key: "p:LICENSE", Language: ""},
+	}
+	kept, dropped := excludeComponentsByLanguage(components, map[string]bool{"lua": true})
+	if dropped != 2 {
+		t.Errorf("dropped = %d, want 2", dropped)
+	}
+	if len(kept) != 3 {
+		t.Fatalf("kept = %d components, want 3", len(kept))
+	}
+	for _, c := range kept {
+		if strings.EqualFold(c.Language, "lua") {
+			t.Errorf("kept a lua component: %+v", c)
+		}
+	}
+}
+
+func TestApplyUnsupportedLanguagePolicyExclude(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Path: "src/a.java", Language: "java"},
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+	}
+	kept, langs, skip := applyUnsupportedLanguagePolicy(
+		discardExecutor(UnsupportedLanguagesExclude), "org_proj", "main", components, targetProfiles("java"))
+
+	if skip != nil {
+		t.Fatalf("exclude mode must still submit the branch, got skip=%+v", skip)
+	}
+	if strings.Join(langs, ",") != "lua" {
+		t.Errorf("languages = %v, want [lua]", langs)
+	}
+	if len(kept) != 1 || kept[0].Key != "p:a.java" {
+		t.Errorf("kept = %+v, want only the java component", kept)
+	}
+}
+
+func TestApplyUnsupportedLanguagePolicySkip(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Path: "src/a.java", Language: "java"},
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+	}
+	kept, langs, skip := applyUnsupportedLanguagePolicy(
+		discardExecutor(UnsupportedLanguagesSkip), "org_proj", "main", components, targetProfiles("java"))
+
+	if skip == nil {
+		t.Fatal("skip mode must return a skip result so no report is submitted")
+	}
+	if skip.Status != "skipped" {
+		t.Errorf("skip.Status = %q, want \"skipped\"", skip.Status)
+	}
+	if !strings.Contains(skip.Error, "lua") {
+		t.Errorf("skip reason must name the language, got %q", skip.Error)
+	}
+	if strings.Join(skip.UnsupportedLanguages, ",") != "lua" {
+		t.Errorf("skip.UnsupportedLanguages = %v, want [lua]", skip.UnsupportedLanguages)
+	}
+	// Skip must not silently mutate the component set.
+	if len(kept) != 2 {
+		t.Errorf("kept = %d components, want 2 (unchanged)", len(kept))
+	}
+	if strings.Join(langs, ",") != "lua" {
+		t.Errorf("languages = %v, want [lua] alongside the skip result", langs)
+	}
+}
+
+func TestApplyUnsupportedLanguagePolicyWarn(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Path: "src/a.java", Language: "java"},
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+	}
+	kept, langs, skip := applyUnsupportedLanguagePolicy(
+		discardExecutor(UnsupportedLanguagesWarn), "org_proj", "main", components, targetProfiles("java"))
+
+	if skip != nil {
+		t.Fatalf("warn mode must submit the report unchanged, got skip=%+v", skip)
+	}
+	if len(kept) != 2 {
+		t.Errorf("warn mode changed the component set: kept %d, want 2", len(kept))
+	}
+	if strings.Join(langs, ",") != "lua" {
+		t.Errorf("warn mode must still report the languages, got %v", langs)
+	}
+}
+
+// Every file being in an unsupported language leaves nothing to submit; the
+// branch must be skipped with a reason rather than sending an empty report.
+func TestApplyUnsupportedLanguagePolicyExcludeEverything(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.lua", Path: "src/a.lua", Language: "lua"},
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+	}
+	_, _, skip := applyUnsupportedLanguagePolicy(
+		discardExecutor(UnsupportedLanguagesExclude), "org_proj", "main", components, targetProfiles("java"))
+
+	if skip == nil {
+		t.Fatal("expected a skip result when every file is excluded")
+	}
+	if skip.Status != "skipped" {
+		t.Errorf("Status = %q, want \"skipped\"", skip.Status)
+	}
+	if skip.ExcludedFiles != 2 {
+		t.Errorf("ExcludedFiles = %d, want 2", skip.ExcludedFiles)
+	}
+	if !strings.Contains(skip.Error, "every file") {
+		t.Errorf("reason should say every file was excluded, got %q", skip.Error)
+	}
+}
+
+// Safety guard: buildSCProfileMap returns an EMPTY map when the target-side
+// quality-profile lookup fails. Detection must then be a no-op — otherwise a
+// transient API error would make every language look unsupported and drop the
+// project's entire file set.
+func TestApplyUnsupportedLanguagePolicyEmptyProfileMapIsNoop(t *testing.T) {
+	components := []scanreport.ComponentInput{
+		{Key: "p:a.java", Path: "src/a.java", Language: "java"},
+		{Key: "p:b.lua", Path: "src/b.lua", Language: "lua"},
+	}
+	kept, langs, skip := applyUnsupportedLanguagePolicy(
+		discardExecutor(UnsupportedLanguagesExclude), "org_proj", "main",
+		components, map[string]scanreport.QProfileInfo{})
+
+	if skip != nil {
+		t.Fatalf("must not skip on an empty profile map, got %+v", skip)
+	}
+	if langs != nil {
+		t.Errorf("must not report languages on an empty profile map, got %v", langs)
+	}
+	if len(kept) != 2 {
+		t.Errorf("must not drop components on an empty profile map: kept %d, want 2", len(kept))
+	}
+}
+
+func TestUnsupportedLanguageFromCEError(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "verbatim CE rejection",
+			in:   "CE task failed: Report contains a file with language 'lua' but no matching quality profile",
+			want: "lua",
+		},
+		{
+			name: "wrapped with trailing detail",
+			in: "main branch CE failed for org_proj: CE task failed: Report contains a file with " +
+				"language 'delphi' but no matching quality profile. Please check the analysis logs.",
+			want: "delphi",
+		},
+		{
+			name: "unrelated CE failure",
+			in:   "CE task failed: There was an issue whilst processing the report",
+			want: "",
+		},
+		{
+			name: "profile mentioned but not a language mismatch",
+			in:   "quality profile could not be restored",
+			want: "",
+		},
+		{name: "empty", in: "", want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := UnsupportedLanguageFromCEError(c.in); got != c.want {
+				t.Errorf("UnsupportedLanguageFromCEError(%q) = %q, want %q", c.in, got, c.want)
+			}
+			if got, want := IsUnsupportedLanguageCEFailure(c.in), c.want != ""; got != want {
+				t.Errorf("IsUnsupportedLanguageCEFailure(%q) = %v, want %v", c.in, got, want)
+			}
+		})
+	}
+}
+
+// A rejected report used to be a Warn that left the transfer looking clean.
+// It must now be an ERROR, and an unsupported-language rejection must name the
+// language and the remedy.
+func TestLogImportProjectDataFailure(t *testing.T) {
+	capture := func(err error) string {
+		var buf bytes.Buffer
+		e := &Executor{Logger: slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))}
+		logImportProjectDataFailure(e, "org_proj", err)
+		return buf.String()
+	}
+
+	got := capture(errors.New(
+		"main branch CE failed for org_proj: CE task failed: Report contains a file with " +
+			"language 'lua' but no matching quality profile"))
+	if !strings.Contains(got, "level=ERROR") {
+		t.Errorf("must log at ERROR, got: %s", got)
+	}
+	for _, want := range []string{
+		"project data NOT migrated", "'lua'", "3rd-party",
+		"--unsupported_languages=exclude", "--unsupported_languages=skip", "language=lua",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("log missing %q\ngot: %s", want, got)
+		}
+	}
+
+	generic := capture(errors.New("CE task failed: HTTP 500"))
+	if !strings.Contains(generic, "level=ERROR") {
+		t.Errorf("generic failure must also log at ERROR, got: %s", generic)
+	}
+	if !strings.Contains(generic, "no issues and no branches were migrated") {
+		t.Errorf("generic failure must still state the impact, got: %s", generic)
+	}
+	if strings.Contains(generic, "unsupported_languages") {
+		t.Errorf("generic failure must not suggest the language remedy, got: %s", generic)
+	}
+}
+
+func TestResolveUnsupportedLanguages(t *testing.T) {
+	if got := resolveUnsupportedLanguages("", "skip"); got != "skip" {
+		t.Errorf("got %q, want the first non-empty value \"skip\"", got)
+	}
+	if got := resolveUnsupportedLanguages("warn", "skip"); got != "warn" {
+		t.Errorf("got %q, want the section value \"warn\" to win", got)
+	}
+	if got := resolveUnsupportedLanguages("  ", ""); got != "" {
+		t.Errorf("got %q, want \"\" when nothing is set", got)
+	}
+}

--- a/go/internal/report/summary/collect.go
+++ b/go/internal/report/summary/collect.go
@@ -71,6 +71,9 @@ func CollectSummary(runDir, exportDir string) (*MigrationSummary, error) {
 			// from the data-migration tasks' JSONL output.
 			projectFailures := collectProjectFailures(runDir)
 			projectFailures = append(projectFailures, collectProjectSyncSkips(store, projectDataMap)...)
+			// #474 — projects whose report had unsupported-language files
+			// excluded imported successfully but are not full migrations.
+			projectFailures = append(projectFailures, collectUnsupportedLanguageExclusions(store)...)
 			section.Succeeded, section.NearPerfect, section.Partial = applyProjectFailures(
 				section.Succeeded, section.NearPerfect, section.Partial, projectFailures)
 			// #356 — append a per-project "x/y issues synced (z%)"
@@ -919,9 +922,20 @@ func projectDataSkipReason(errMsg string) string {
 // with the operator-friendly framing the issue spec uses ("API error
 // when migrating project data"). Empty errors fall back to the bare
 // framing so we never lose the signal entirely.
+//
+// #474 — a Compute Engine rejection caused by a file whose language has no
+// quality profile on the target is not an API error, and framing it as one hid
+// the real cause from the operator. Name the language and the remedy instead.
 func projectDataFailureReason(errMsg string) string {
 	if errMsg == "" {
 		return "API error when migrating project data"
+	}
+	if lang := migrate.UnsupportedLanguageFromCEError(errMsg); lang != "" {
+		return "No issues or branches were migrated: the analysis report was rejected because the project " +
+			"contains files in language '" + lang + "', which has no quality profile in the target " +
+			"organization — typically a language provided by a 3rd-party SonarQube Server plugin. " +
+			"Re-run with --unsupported_languages=exclude to migrate everything except those files, " +
+			"or --unsupported_languages=skip to skip this project's data."
 	}
 	return "API error when migrating project data: " + errMsg
 }

--- a/go/internal/report/summary/project_failures.go
+++ b/go/internal/report/summary/project_failures.go
@@ -6,6 +6,7 @@ package summary
 
 import (
 	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -290,6 +291,106 @@ func applyProjectFailures(succeeded, nearPerfect, partial []EntityItem,
 	return keep, nearPerfect, partial
 }
 
+// collectUnsupportedLanguageExclusions returns one Partial failure per project
+// whose scanner report had file components dropped because their language has
+// no quality profile on the target organization (#474,
+// --unsupported_languages=exclude).
+//
+// Those branches import successfully, so without this the project would be
+// reported as a full migration even though some of its files — and every issue
+// on them — never left the source. The project is routed to Partial with an
+// Issues line naming the languages and the file count.
+func collectUnsupportedLanguageExclusions(store *common.DataStore) []projectFailure {
+	items, err := store.ReadAll("importProjectData")
+	if err != nil || len(items) == 0 {
+		return nil
+	}
+	by, order := aggregateLanguageExclusions(items)
+
+	out := make([]projectFailure, 0, len(order))
+	for _, key := range order {
+		bucket := by[key]
+		out = append(out, projectFailure{
+			CloudProjectKey: key,
+			Bucket:          projectBucketPartial,
+			Operation:       "Files in unsupported languages not migrated",
+			Detail:          languageExclusionDetail(bucket),
+			Error: "the target organization has no quality profile for these languages — typically " +
+				"languages provided by 3rd-party SonarQube Server plugins. The files were excluded from the " +
+				"analysis report so the rest of the project could migrate; issues on them were not migrated",
+		})
+	}
+	return out
+}
+
+// languageExclusionAcc accumulates one project's excluded-file data across all
+// of its branch records.
+type languageExclusionAcc struct {
+	langs map[string]bool
+	files int
+}
+
+// aggregateLanguageExclusions folds the per-branch importProjectData records
+// into one accumulator per project, preserving first-seen project order.
+func aggregateLanguageExclusions(items []json.RawMessage) (map[string]*languageExclusionAcc, []string) {
+	by := make(map[string]*languageExclusionAcc)
+	var order []string
+	for _, raw := range items {
+		key := jsonStr(raw, "cloud_project_key")
+		excluded := jsonInt(raw, "excluded_files")
+		if key == "" || excluded <= 0 {
+			continue
+		}
+		bucket := by[key]
+		if bucket == nil {
+			bucket = &languageExclusionAcc{langs: map[string]bool{}}
+			by[key] = bucket
+			order = append(order, key)
+		}
+		// Every branch of a project drops the same files, so the per-project
+		// count is the worst branch's count — not the sum across branches.
+		if excluded > bucket.files {
+			bucket.files = excluded
+		}
+		for _, lang := range jsonStrSlice(raw, "unsupported_languages") {
+			bucket.langs[lang] = true
+		}
+	}
+	return by, order
+}
+
+// languageExclusionDetail renders "lua, delphi (13 files)".
+func languageExclusionDetail(bucket *languageExclusionAcc) string {
+	langs := make([]string, 0, len(bucket.langs))
+	for l := range bucket.langs {
+		langs = append(langs, l)
+	}
+	sort.Strings(langs)
+	unit := "files"
+	if bucket.files == 1 {
+		unit = "file"
+	}
+	return fmt.Sprintf("%s (%d %s)", strings.Join(langs, ", "), bucket.files, unit)
+}
+
+// jsonStrSlice reads a JSON array of strings from raw, returning nil when the
+// key is absent or is not an array of strings.
+func jsonStrSlice(raw json.RawMessage, key string) []string {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return nil
+	}
+	nested, ok := obj[key]
+	if !ok {
+		return nil
+	}
+	var out []string
+	if err := json.Unmarshal(nested, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
 // collectProjectSyncSkips reads the per-project status JSONL produced
 // by the data-migration tasks and returns a synthetic []projectFailure
 // covering #228's orange criteria plus #356's yellow criteria:
@@ -419,4 +520,3 @@ func collectSyncOutcome(store *common.DataStore, taskName, errorOp string) []pro
 	}
 	return out
 }
-

--- a/go/internal/report/summary/unsupported_languages_test.go
+++ b/go/internal/report/summary/unsupported_languages_test.go
@@ -1,0 +1,139 @@
+// Copyright (C) SonarSource Sàrl
+// For more information, see https://sonarsource.com/legal/
+// mailto:info AT sonarsource DOT com
+
+package summary
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sonar-solutions/sonar-migration-tool/internal/common"
+)
+
+// #474 — a Compute Engine rejection caused by a file whose language has no
+// target quality profile must be explained, not framed as a generic API error.
+// The old wording ("API error when migrating project data: CE task failed: ...")
+// gave the operator nothing to act on.
+func TestProjectDataFailureReasonUnsupportedLanguage(t *testing.T) {
+	got := projectDataFailureReason(
+		"main branch CE failed for org_proj: CE task failed: Report contains a file with " +
+			"language 'lua' but no matching quality profile")
+
+	for _, want := range []string{
+		"No issues or branches were migrated",
+		"'lua'",
+		"no quality profile in the target organization",
+		"3rd-party SonarQube Server plugin",
+		"--unsupported_languages=exclude",
+		"--unsupported_languages=skip",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("reason missing %q\ngot: %s", want, got)
+		}
+	}
+	if strings.Contains(got, "API error") {
+		t.Errorf("must not frame a report rejection as an API error\ngot: %s", got)
+	}
+}
+
+// Unrelated failures must keep the existing framing so #474 does not change
+// how every other project-data failure reads.
+func TestProjectDataFailureReasonUnchangedForOtherErrors(t *testing.T) {
+	got := projectDataFailureReason("CE task failed: HTTP 500")
+	if want := "API error when migrating project data: CE task failed: HTTP 500"; got != want {
+		t.Errorf("reason = %q, want %q", got, want)
+	}
+	if got := projectDataFailureReason(""); got != "API error when migrating project data" {
+		t.Errorf("empty error reason = %q", got)
+	}
+}
+
+// Projects whose report had unsupported-language files excluded import
+// successfully, so without this collector they would be reported as full
+// migrations despite having lost files and every issue on them.
+func TestCollectUnsupportedLanguageExclusions(t *testing.T) {
+	dir := t.TempDir()
+	writeTaskJSONL(t, dir, "importProjectData", []map[string]any{
+		// Two branches of the same project drop the SAME file — the
+		// per-project count must be the worst branch, not the sum.
+		{"cloud_project_key": "org_excluded", "branch": "main", "status": "success",
+			"unsupported_languages": []string{"lua"}, "excluded_files": 1},
+		{"cloud_project_key": "org_excluded", "branch": "develop", "status": "success",
+			"unsupported_languages": []string{"lua"}, "excluded_files": 1},
+		// Multiple languages across branches must be unioned and sorted.
+		{"cloud_project_key": "org_multi", "branch": "main", "status": "success",
+			"unsupported_languages": []string{"lua"}, "excluded_files": 3},
+		{"cloud_project_key": "org_multi", "branch": "develop", "status": "success",
+			"unsupported_languages": []string{"delphi", "lua"}, "excluded_files": 5},
+		// A clean project must not be routed anywhere.
+		{"cloud_project_key": "org_clean", "branch": "main", "status": "success"},
+		// A project skipped by --unsupported_languages=skip excluded nothing;
+		// the |scan: marker already carries its reason.
+		{"cloud_project_key": "org_skipped", "branch": "main", "status": "skipped",
+			"unsupported_languages": []string{"lua"}, "excluded_files": 0,
+			"error": "Project data not migrated: ..."},
+	})
+
+	got := collectUnsupportedLanguageExclusions(common.NewDataStore(dir))
+
+	if len(got) != 2 {
+		t.Fatalf("expected 2 routed projects, got %d: %+v", len(got), got)
+	}
+	byKey := map[string]projectFailure{}
+	for _, f := range got {
+		byKey[f.CloudProjectKey] = f
+	}
+
+	excluded, ok := byKey["org_excluded"]
+	if !ok {
+		t.Fatal("org_excluded not routed")
+	}
+	if excluded.Bucket != projectBucketPartial {
+		t.Errorf("bucket = %v, want Partial", excluded.Bucket)
+	}
+	if want := "lua (1 file)"; excluded.Detail != want {
+		t.Errorf("detail = %q, want %q (worst branch, not the sum)", excluded.Detail, want)
+	}
+	if excluded.Operation == "" {
+		t.Error("Operation must be set so the report renders an Issues line")
+	}
+	if !strings.Contains(excluded.Error, "3rd-party SonarQube Server plugins") {
+		t.Errorf("Error must explain the cause, got %q", excluded.Error)
+	}
+
+	multi := byKey["org_multi"]
+	if want := "delphi, lua (5 files)"; multi.Detail != want {
+		t.Errorf("multi detail = %q, want %q", multi.Detail, want)
+	}
+
+	if _, routed := byKey["org_clean"]; routed {
+		t.Error("a project with no exclusions must not be routed")
+	}
+	if _, routed := byKey["org_skipped"]; routed {
+		t.Error("a skipped project excluded no files and must not be routed here")
+	}
+}
+
+func TestCollectUnsupportedLanguageExclusionsNoData(t *testing.T) {
+	if got := collectUnsupportedLanguageExclusions(common.NewDataStore(t.TempDir())); got != nil {
+		t.Errorf("expected nil with no importProjectData, got %+v", got)
+	}
+}
+
+func TestJSONStrSlice(t *testing.T) {
+	raw := []byte(`{"langs":["lua","delphi"],"n":3,"s":"x"}`)
+	if got := jsonStrSlice(raw, "langs"); strings.Join(got, ",") != "lua,delphi" {
+		t.Errorf("got %v", got)
+	}
+	if got := jsonStrSlice(raw, "missing"); got != nil {
+		t.Errorf("missing key = %v, want nil", got)
+	}
+	// Wrong type must degrade to nil rather than panicking.
+	if got := jsonStrSlice(raw, "n"); got != nil {
+		t.Errorf("non-array = %v, want nil", got)
+	}
+	if got := jsonStrSlice([]byte(`not json`), "langs"); got != nil {
+		t.Errorf("invalid json = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## The gap

Transferring a project that was analyzed with a **3rd-party (non-SonarSource) language plugin** produced a project on SonarQube Cloud with the right permissions, settings and quality gate — but with **no issues, no code and no branches**. The transfer printed `Transfer complete.` and exited `0`.

## Root cause

The fabricated scanner report describes languages in two places, and the Compute Engine cross-checks them:

| | source of truth |
|---|---|
| every FILE component's `language` | the **source** server (`api/measures/component_tree`) |
| `metadata.qprofiles_per_language` | quality profiles that exist on the **target** org (`buildSCProfileMap`) |

SonarQube Cloud has no analyzer — and therefore no quality profile — for a language contributed by a 3rd-party Server plugin. The two sets disagree and the CE rejects the **entire** report:

```
Report contains a file with language 'lua' but no matching quality profile
  (Visit failed for Component {key=...:src/main/java/demo/security/servlet/FileServlet.java,type=FILE} ...)
```

The project, permissions and gate are created in earlier phases, so they survive. Everything the report carries does not. Because the main-branch import is a blocking gate, the non-main branches were skipped as well.

Three things then hid it:
1. the rejection was logged at **WARN**;
2. `importProjectData` tracked no per-project outcome, so the task summary said nothing;
3. the report rendered it as `API error when migrating project data: <raw CE dump>` — no cause, no remedy.

## Changes

| File | Change |
|---|---|
| `go/internal/migrate/unsupported_languages.go` **(new, 390 L)** | `detectUnsupportedLanguages` compares the report's component languages against the target org's quality-profile languages — exactly the CE's own check. `applyUnsupportedLanguagePolicy` explains the finding and applies the mode. Also holds the CE-error classifier and the ERROR-level failure log. |
| `go/internal/migrate/tasks_projectdata.go` | One decision point in `buildBranchReport` (before `collectProjectLanguages`); `importResult`/`branchReport` carry the languages and excluded-file count; `recordImportOutcome` logs at ERROR and counts failures. |
| `go/cmd/transfer.go` | `--unsupported_languages`, validated **before** the extract phase so a typo'd mode fails fast instead of silently defaulting. |
| `go/internal/migrate/migrate.go`, `config_file.go` | `UnsupportedLanguages` on `MigrateConfig`/`Executor`, normalised in `applyDefaults`, readable from all four config shapes. |
| `go/internal/report/summary/collect.go` | `projectDataFailureReason` names the language, cause and remedy instead of "API error". |
| `go/internal/report/summary/project_failures.go` | `collectUnsupportedLanguageExclusions` routes a project whose files were excluded to **Partial** with an Issues line, so it is never reported as a full migration. |

### `--unsupported_languages`

| Mode | Behaviour |
|---|---|
| `exclude` **(default)** | Drops only the offending file components. Every other file, issue, measure and branch migrates. Reported as Partial, naming the languages and file count. |
| `skip` | Submits no report for the project at all — the *"option to not transfer such projects"* the issue asks for. |
| `warn` | Submits the report unchanged (previous behaviour), but the rejection is now explained. |

Excluding components is sufficient to drop everything attached to them — issues, measures, source, SCM blame and syntax highlighting all resolve through the component-ref map built from the surviving components.

**Safety guard:** `buildSCProfileMap` returns an *empty* map when the target-side profile lookup fails. Detection is disabled in that case rather than treating every language as unsupported, so a transient API error can never drop a project's whole file set. Unit-tested.

## Live end-to-end verification

SonarQube Server **2026.3.1** → SonarQube Cloud **staging**, org `open-digital-society-1`, source project `checkstyle-issues` (2 branches; **237** issues / 10 hotspots / 449 ncloc / 14 files on `main`, **375** / 13 / 590 / 20 on `develop`).

No 3rd-party plugin is installed on the test server, so one was simulated at the API boundary: a reverse proxy in front of the source rewrote **one** file's `language` from `java` to `lua` in `api/measures/component_tree` (and added `lua` to `api/languages/list`). Verified surgical — same component count and `paging.total`, only the `language` field of `FileServlet.java` differs, all measures identical, other endpoints byte-identical. Everything downstream — report fabrication, submission, CE polling, the real CE rejection — is genuine.

### BEFORE — `origin/main` binary (`381b068`)

```
EXIT CODE: 0                                    ... "Transfer complete."
level=WARN msg="CE task failed" errorMessage="Report contains a file with
  language 'lua' but no matching quality profile ..."
level=WARN msg="project project data failed"
Task importProjectData: Duration 00:00:09.380   ... no failure count
```
Target `checkstyle-issues-b4-m474`:
```
branches: 1  -> master (empty, not even the source main branch name)
issues=0  hotspots=0  ncloc=-  files=-
CE tasks: 1 -> FAILED
```
Report: `Partial Migration | ... API error when migrating project data: CE task failed: ... Report contains a file with language 'lua' ...`
It then spent **8m30s** in `syncIssueMetadata` syncing 81 issues onto a project that had none.

### AFTER — this branch, default (`exclude`)

```
level=WARN msg="unsupported programming language: project \"checkstyle-issues-ex-m474\"
  branch \"main\" contains 1 file(s) in language(s) that have no quality profile on the
  target SonarQube Cloud organization: lua (1 file, e.g. src/main/java/demo/security/
  servlet/FileServlet.java). SonarQube Cloud only provides quality profiles for languages
  its own analyzers support, so a language contributed by a 3rd-party SonarQube Server
  plugin has none. The Compute Engine rejects an entire scanner report that contains a
  file whose language has no matching quality profile, which would leave this project on
  SonarQube Cloud with its settings, permissions and quality gate but with NO issues and
  NO branches. Excluding those files from the scanner report ..." languages=lua files=1 mode=exclude
level=WARN msg="excluded unsupported-language files ..." excludedFiles=1 remainingFiles=13
level=WARN ... branch="develop" ...                excludedFiles=1 remainingFiles=19
task summary task=importProjectData succeeded=1 failed=0
```
Target `checkstyle-issues-ex-m474`:
```
branches: 2
  - develop  main=False type=LONG  issues=160  ncloc=574  files=19
  - main     main=True  type=LONG  issues=226  ncloc=433  files=13
TOTAL issues: 386        CE tasks: 2 -> SUCCESS, SUCCESS
```
`main` went from 449→**433** ncloc and 14→**13** files — down by exactly the one excluded file (16 ncloc), which is the precise proof that only the `lua` file was dropped. Whole transfer: **1m16s** (vs 9m14s).

Report: `Partial Migration | ... Files in unsupported languages not migrated: lua (1 file) — the target organization has no quality profile for these languages — typically languages provided by 3rd-party SonarQube Server plugins. The files were excluded from the analysis report so the rest of the project could migrate; issues on them were not migrated`

### AFTER — `--unsupported_languages skip`

```
level=WARN msg="unsupported programming language: ... Skipping this project's data as
  requested by --unsupported_languages=skip: no scanner report is submitted for any of
  its branches. ..." branch=main  languages=lua files=1 mode=skip
... same for branch=develop
task summary task=importProjectData succeeded=1 failed=0
```
Target `checkstyle-issues-sk-m474`: **`CE tasks: 0`** — no report was ever submitted, versus 1 FAILED at baseline. Project, permissions and gate migrated; issues/branches deliberately not.

Report: `Partial Migration | ... Project data migration skipped: Project data not migrated: the project contains files in language(s) with no quality profile on the target organization — lua (1 file, e.g. src/main/java/demo/security/servlet/FileServlet.java) (typically a language provided by a 3rd-party SonarQube Server plugin). Skipped by --unsupported_languages=skip.`

## Tests

18 new unit tests (`go/internal/migrate/unsupported_languages_test.go`, `go/internal/report/summary/unsupported_languages_test.go`, `go/cmd/transfer_test.go`): mode parsing/validation/defaults, detection (language casing, empty-language files, per-language counts and sample paths), component exclusion, all three modes, the all-files-excluded edge case, the empty-profile-map safety guard, CE error classification, the ERROR log content, the report reason, and the Partial routing.

`make build`, `make test` (17 packages) and `go vet ./...` all pass. New code is at 100% function coverage except `detectUnsupportedLanguages` (95%), `applyUnsupportedLanguagePolicy` (93%) and `UnsupportedLanguageFromCEError` (88%). Cognitive complexity checked against the baseline: `runImportProjectData` was refactored back **below** its pre-change value so no new `go:S3776` violation is introduced; no new function or test exceeds 10.

## Interaction with #456

#456 (`fix/issue-456`, not yet merged) touches `buildBranchReport` from the other direction: `widenLangsForFindingRules` **adds** to the report's language set the languages of active rules the findings reference, so cross-language analyzers (e.g. `secrets`) are not stripped.

The two compose safely and there is no semantic conflict:

- This PR's decision point runs **before** `collectProjectLanguages`, subtracting file components whose language has no target profile. #456's widening runs **after**, adding rule languages.
- Both are gated on the **same** invariant — the target org must expose a quality profile for the language (`scProfileByLang`). #456 can therefore never re-add a language this PR removed, and this PR never removes a language #456 needs.
- A textual conflict is likely on the adjacent lines around `projectLangs := collectProjectLanguages(components)`. Correct resolution keeps the order: **#474 policy → `collectProjectLanguages` → #456 widen → `filterRulesByLanguage`**.

Whichever lands second should re-run its live verification. Happy to rebase onto #456 if it merges first.

## Honest limitations

- The unsupported language was simulated at the source API boundary (no 3rd-party plugin is installed on the test server, and installing one requires a restart that would have disrupted other agents sharing it). The CE rejection, the detection and all three modes were exercised against the real SonarQube Cloud CE.
- Target hotspots came back `0` in both the before and after runs. This is a **pre-existing** gap unrelated to this PR (also observed on `main` in the #480 review) — not a regression introduced here.
- Detection happens when the branch report is built, which is early enough to precede any submission for that project, but not a separate pre-flight before the extract phase.

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
