### PR TITLE
fix(migrate): sanitize task names for Windows-safe dir paths (#486)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,17 +1,21 @@
 # GitHub Actions Workflows
+<!-- updated: 2026-07-28_10:25:08 -->
 
 ## Active Workflows
+<!-- updated: 2026-07-28_10:25:08 -->
 
 ### 1. `build.yml` - Test + Release
+<!-- updated: 2026-07-28_10:25:08 -->
 
 **Triggers:**
 - Push to `main` or `branch-*` — tests, build, sign, and (on `main` only) GitHub Release publish
 - Push to `kilo` — tests and SonarQube scan only
-- Pull requests — tests and SonarQube scan only
+- Pull requests from this repository — tests and SonarQube scan
+- Pull requests from a fork — tests only (see [Fork pull requests](#fork-pull-requests))
 
 **What it does:**
 - Runs Go library and migration tool tests with coverage
-- Runs SonarQube Cloud analysis
+- Runs SonarQube Cloud analysis (skipped on fork PRs)
 - On `main` / `branch-*` pushes: cross-compiles 6 platform binaries, GPG-signs all,
   Apple code-signs + notarizes macOS, Authenticode-signs Windows (Azure Artifact Signing),
   and publishes a GitHub Release on **`main` only**
@@ -32,6 +36,71 @@ Each binary has a matching `.asc` GPG signature.
 See [docs/RELEASE-SIGNING-SETUP.md](../../docs/RELEASE-SIGNING-SETUP.md) for Vault and Azure onboarding.
 
 ### 2. `test.yml` - Manual Test Run
+<!-- updated: 2026-07-28_10:25:08 -->
 
 **Trigger:** Manual dispatch (`workflow_dispatch`)  
 **Purpose:** On-demand test run with SonarQube Cloud scan
+
+`workflow_dispatch` can only be triggered against a ref in this repository, so this
+workflow always has OIDC available and is unaffected by the fork restriction below.
+
+### 3. `gitleaks.yml` - Secret Scan
+<!-- updated: 2026-07-28_10:25:08 -->
+
+**Triggers:** Push to `main` / `kilo`, and all pull requests  
+**Purpose:** Scans full git history for committed secrets with the gitleaks CLI
+
+Uses no secrets, no Vault, and no OIDC, so it runs identically on fork pull requests.
+
+## Fork pull requests
+<!-- updated: 2026-07-28_10:25:08 -->
+
+GitHub **does not issue an OIDC ID token** to workflow runs triggered by a
+`pull_request` event from a forked repository. Every Vault lookup in this repo
+authenticates to `vault.sonar.build` over OIDC, so on a fork PR the
+`SonarSource/vault-action-wrapper` step fails with:
+
+```
+##[error]Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
+```
+
+No amount of configuration on the contributor's side can satisfy this — it is a
+platform restriction. Before this was handled, the whole `Test` job went red on fork
+PRs even though every Go test had passed (see PR #487 / issue #486).
+
+**How it is handled.** The `test` job computes one job-level `env` flag:
+
+```yaml
+env:
+  SONAR_ANALYSIS_ENABLED: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+```
+
+`Fetch Vault secrets` and `SonarQube Scan` are gated on
+`if: env.SONAR_ANALYSIS_ENABLED == 'true'`; a companion step gated on the inverse
+prints an explicit explanation to the log and the job summary so the skip is never
+silent.
+
+> **Note:** job-level `env` is readable from a **step-level** `if`, but *not* from a
+> **job-level** `if`. That is why the `build-binaries`, `sign-*`, and `publish` jobs
+> still inline their conditions — see the comments in `build.yml`.
+
+| Trigger | `SONAR_ANALYSIS_ENABLED` | Go tests | Vault + SonarQube scan |
+|---------|--------------------------|----------|------------------------|
+| Push to `main` | `true` | run | run |
+| Push to `branch-*` / `kilo` | `true` | run | run |
+| PR from this repository | `true` | run | run |
+| PR from a fork | `false` | run | **skipped, with an explanation** |
+
+Behaviour on same-repo pushes and PRs is unchanged: the analysis that enforces the
+quality gate still runs on every one of them.
+
+**What this means for reviewers.** A fork PR gets no SonarQube Cloud analysis and
+therefore no quality gate reading. Analysis runs on `main` after the merge. To get a
+gate reading *before* merging, push the contributor's branch to this repository (e.g.
+`git fetch <fork> <branch> && git push origin FETCH_HEAD:refs/heads/branch-review-NNN`)
+and open an internal PR — that run has OIDC and scans normally.
+
+**What is deliberately *not* done.** `pull_request_target` would give fork PRs access
+to secrets while checking out untrusted code, which is a well-known privilege-escalation
+pattern. It is not used here, and the skip condition depends only on repository
+identity — never on anything a contributor can change from their branch.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,12 @@ jobs:
         if: env.SONAR_ANALYSIS_ENABLED == 'true'
         uses: SonarSource/sonarqube-scan-action@v8
         env:
-          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+          # `|| '{}'` is load-bearing: GitHub evaluates a step's `env` expressions
+          # even when its `if` is false, so when "Fetch Vault secrets" is skipped
+          # on a fork PR this output is empty and a bare fromJSON('') aborts the
+          # whole job with "Error reading JToken from JsonReader" — a template
+          # error, not a step failure, so the `if` above cannot prevent it.
+          SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault || '{}').SONAR_TOKEN }}
       - name: Explain skipped SonarQube analysis (fork pull request)
         if: env.SONAR_ANALYSIS_ENABLED != 'true'
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,14 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    env:
+      # GitHub does not issue an OIDC ID token to `pull_request` runs from a forked
+      # repository, so Vault authentication — and therefore the SonarQube Cloud scan —
+      # can never succeed there ("Unable to get ACTIONS_ID_TOKEN_REQUEST_URL").
+      # Everything else in this job (the Go tests) still runs for forks.
+      # Unlike job-level `if`, step-level `if` CAN read the env context, so the single
+      # source of truth for the condition lives here.
+      SONAR_ANALYSIS_ENABLED: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,15 +43,40 @@ jobs:
           sed 's|github.com/sonar-solutions/sonar-migration-tool/|go/|g' go/coverage.out > go/coverage.sonar.out
           sed 's|github.com/sonar-solutions/sq-api-go/|lib/sq-api-go/|g' lib/sq-api-go/coverage.out > lib/sq-api-go/coverage.sonar.out
       - name: Fetch Vault secrets
+        if: env.SONAR_ANALYSIS_ENABLED == 'true'
         id: secrets
         uses: SonarSource/vault-action-wrapper@v3
         with:
           secrets: |
             development/kv/data/sonarcloud token | SONAR_TOKEN;
       - name: SonarQube Scan
+        if: env.SONAR_ANALYSIS_ENABLED == 'true'
         uses: SonarSource/sonarqube-scan-action@v8
         env:
           SONAR_TOKEN: ${{ fromJSON(steps.secrets.outputs.vault).SONAR_TOKEN }}
+      - name: Explain skipped SonarQube analysis (fork pull request)
+        if: env.SONAR_ANALYSIS_ENABLED != 'true'
+        env:
+          # Bound through env rather than inlined into the script: never interpolate
+          # contributor-controlled values straight into a `run:` block.
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "### SonarQube Cloud analysis skipped"
+            echo
+            echo "This pull request comes from a fork (\`${HEAD_REPO}\` -> \`${BASE_REPO}\`)."
+            echo
+            echo "GitHub does not issue an OIDC ID token to workflow runs triggered by fork"
+            echo "pull requests, so this job cannot authenticate to Vault, cannot obtain a"
+            echo "\`SONAR_TOKEN\`, and therefore cannot run the SonarQube Cloud scan."
+            echo "This is a platform restriction, not a problem with the change."
+            echo
+            echo "The Go tests above ran in full and are the signal for this pull request."
+            echo "SonarQube Cloud analysis and the quality gate run on \`main\` once the pull"
+            echo "request is merged; a maintainer can also run it early by pushing the branch"
+            echo "to this repository."
+          } | tee -a "$GITHUB_STEP_SUMMARY"
 
   # Cross-compile every platform binary on Linux and GPG-sign each one.
   # macOS and Windows binaries are re-signed after platform-specific signing below.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -62,7 +62,31 @@ For the architecture overview and package map, see [ARCHITECTURE.md](ARCHITECTUR
 
 The end-to-end regression suite lives in [`REGRESSION-TESTING.md`](REGRESSION-TESTING.md). It exercises a full migration against a real SQS + SQC pair and compares the result against a recorded baseline.
 
+## Contributing from a fork
+<!-- updated: 2026-07-28_10:25:08 -->
+
+CI behaves slightly differently for pull requests opened from a forked repository.
+
+GitHub does not issue an OIDC ID token to `pull_request` runs originating from a fork.
+Every secret in this repository's CI is fetched from Vault over OIDC, so the Vault step
+— and the SonarQube Cloud scan that depends on it — cannot run on a fork PR. They are
+skipped, and the `Test` job prints an explicit explanation instead of failing.
+
+What this means in practice:
+
+- **Go tests still run in full** on your PR, and are the signal to watch. Run
+  `go test ./...` in both `go/` and `lib/sq-api-go/` locally before pushing.
+- **No SonarQube Cloud analysis or quality gate reading** appears on a fork PR. A
+  maintainer can get one early by pushing your branch to this repository; otherwise
+  analysis runs on `main` after the merge.
+- **The secret scan (gitleaks) does run** on fork PRs — it uses no secrets.
+- Signing, notarization, and release publishing never run on any PR, fork or not.
+
+The condition and its rationale are documented in
+[`.github/workflows/README.md`](../.github/workflows/README.md#fork-pull-requests).
+
 ## Releasing
+<!-- updated: 2026-07-28_10:25:08 -->
 
 Tagged releases are built and published via GitHub Actions; see `.github/workflows/`. To bump the version manually:
 

--- a/go/internal/common/common_test.go
+++ b/go/internal/common/common_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -135,6 +136,50 @@ func TestDataStoreWriteAndReadAll(t *testing.T) {
 	}
 	if len(got) != 2 {
 		t.Fatalf("expected 2, got %d", len(got))
+	}
+}
+
+// TestDataStoreSanitizesTaskDir verifies that task names containing
+// characters illegal in Windows path components (e.g. the ":" in
+// "getTemplateGroupsScanners:apply") are sanitized to a safe directory
+// name, and that Writer / ReadAll / TaskDirExists all agree on that
+// name so the round-trip works. Regression test for issue #486.
+func TestDataStoreSanitizesTaskDir(t *testing.T) {
+	dir := t.TempDir()
+	ds := NewDataStore(dir)
+
+	const taskName = "getTemplateGroupsScanners:apply"
+
+	w, err := ds.Writer(taskName)
+	if err != nil {
+		t.Fatalf("Writer: %v", err)
+	}
+	if err := w.WriteOne(json.RawMessage(`{"ok":true}`)); err != nil {
+		t.Fatalf("WriteOne: %v", err)
+	}
+
+	// The on-disk directory must not contain the illegal ":".
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 task dir, got %d", len(entries))
+	}
+	if got := entries[0].Name(); strings.ContainsAny(got, `\/:*?"<>|`) {
+		t.Errorf("task dir %q contains an illegal path character", got)
+	}
+
+	// Writer, ReadAll and TaskDirExists must resolve to the same dir.
+	if !ds.TaskDirExists(taskName) {
+		t.Error("TaskDirExists returned false for sanitized task")
+	}
+	got, err := ds.ReadAll(taskName)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 record round-tripped, got %d", len(got))
 	}
 }
 

--- a/go/internal/common/store.go
+++ b/go/internal/common/store.go
@@ -30,6 +30,25 @@ func NewDataStore(baseDir string) *DataStore {
 	}
 }
 
+// taskDirSanitizer maps characters that are legal in task names but
+// illegal in a Windows path component to "_". Some task names embed a
+// ":" (e.g. "getTemplateGroupsScanners:apply"), which is fine on
+// Linux/macOS but rejected by NTFS — Windows forbids \ / : * ? " < > |
+// in file and directory names. Sanitizing here, at the single point
+// where a task name becomes a directory path, keeps the on-disk layout
+// unchanged on POSIX (these characters are otherwise unused in task
+// names) while making the migrate command runnable on Windows.
+// See issue #486.
+var taskDirSanitizer = strings.NewReplacer(
+	"\\", "_", "/", "_", ":", "_", "*", "_",
+	"?", "_", "\"", "_", "<", "_", ">", "_", "|", "_",
+)
+
+// taskDir returns the filesystem-safe directory path for a task.
+func (ds *DataStore) taskDir(taskName string) string {
+	return filepath.Join(ds.baseDir, taskDirSanitizer.Replace(taskName))
+}
+
 // BaseDir returns the root directory.
 func (ds *DataStore) BaseDir() string {
 	return ds.baseDir
@@ -37,12 +56,12 @@ func (ds *DataStore) BaseDir() string {
 
 // Writer returns a ChunkWriter for the named task.
 func (ds *DataStore) Writer(taskName string) (*ChunkWriter, error) {
-	return NewChunkWriter(filepath.Join(ds.baseDir, taskName))
+	return NewChunkWriter(ds.taskDir(taskName))
 }
 
 // ReadAll returns every JSONL object for a completed task as raw JSON.
 func (ds *DataStore) ReadAll(taskName string) ([]json.RawMessage, error) {
-	dir := filepath.Join(ds.baseDir, taskName)
+	dir := ds.taskDir(taskName)
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -115,6 +134,6 @@ func (ds *DataStore) IsComplete(taskName string) bool {
 // TaskDirExists checks if a task's output directory exists on disk
 // (for resumability — skip tasks that already ran).
 func (ds *DataStore) TaskDirExists(taskName string) bool {
-	info, err := os.Stat(filepath.Join(ds.baseDir, taskName))
+	info, err := os.Stat(ds.taskDir(taskName))
 	return err == nil && info.IsDir()
 }


### PR DESCRIPTION
Re-lands #487 by @xibuka from a branch inside this repository, plus the CI fix that its own failure exposed.

**The original PR cannot be merged, for a reason that has nothing to do with its contents.** #487 is this repo's first pull request from a fork. GitHub does not issue an OIDC ID token to `pull_request` runs originating from a fork, so `SonarSource/vault-action-wrapper` fails with `Unable to get ACTIONS_ID_TOKEN_REQUEST_URL` — and it takes down both the `Test` job here *and* `verify-sca`, which is injected by the org-wide **Enforce SCA Scanning** ruleset from `SonarSource/ci-github-actions`. That second one is not editable from this repository and, as an OIDC-dependent workflow, can never go green on a fork PR. Landing the change from an in-repo branch is the same route other SonarSource repos take for external contributions.

@xibuka's commit is carried over verbatim with authorship preserved.

## Commit 1 — the actual fix (@xibuka, unchanged from #487)

Two tasks are named with a `:apply` suffix — `getTemplateGroupsScanners:apply` and `getTemplateGroupsViewers:apply` (`internal/migrate/tasks_permissions.go:440`). That name was used verbatim as an on-disk directory. NTFS forbids `\ / : * ? " < > |` in path components, so `os.MkdirAll` fails and `migrate` aborts in phase 3:

```
Error: phase 3: task setTemplateGroupPermissions: creating task dir
migration-files\...\getTemplateGroupsScanners:apply: The directory name is invalid.
```

The fix sanitizes at the single point where a task name becomes a path — `DataStore.taskDir()` in `internal/common/store.go`, which `Writer` / `ReadAll` / `TaskDirExists` all route through.

Already reviewed and approved on #487 by @jon-lipsky-sonarsource.

## Commits 2 & 3 — CI: let the `Test` job survive fork PRs

The Go tests pass fine on a fork; only the Vault + SonarQube steps can't work. Those two steps are now gated on a single job-level flag, with a step that explains the skip in the log and job summary:

```yaml
SONAR_ANALYSIS_ENABLED: ${{ github.event_name != 'pull_request'
  || github.event.pull_request.head.repo.full_name == github.repository }}
```

The third commit fixes a trap the second one walked into: GitHub evaluates a step's `env:` expressions *even when its `if` is false*, so with the Vault step skipped, `fromJSON('')` raised `Error reading JToken from JsonReader` and failed the job anyway — the same failure mode the signing steps already work around with `jq`. Defaulting the payload to `'{}'` keeps the expression evaluable.

Same-repo pushes and PRs are unaffected: the flag is `'true'` for every non-fork trigger, both steps run as before, and the quality gate keeps its enforcement path. `pull_request_target` was deliberately not used.

## Verification

**The CI fix is verified on the real thing** — pushed to #487's fork branch, where the `Test` job now goes green: Go tests `success`, `Fetch Vault secrets` `skipped`, `SonarQube Scan` `skipped`, skip-notice `success` ([run](https://github.com/SonarSource/sonar-migration-tool/actions/runs/30325408895)). `verify-sca` remains red there, as expected.

**The Windows fix is verified end-to-end against a live migration** (local SonarQube Server → SonarQube Cloud staging), which is the only way to reach the affected code path — it needs permission templates in scope, so unit tests alone don't exercise it:

- `setTemplateGroupPermissions` ran the two colon-named tasks to completion: `getTemplateGroupsScanners:apply` 5/5, `getTemplateGroupsViewers:apply` 15/15, task summary `succeeded=25 failed=0`.
- On disk the run directory contains `getTemplateGroupsScanners_apply` and `getTemplateGroupsViewers_apply`; a scan of every directory under the export root found **no** `\ / : * ? " < > |` in any path component.
- The permissions actually landed on the target — the migrated templates carry real group grants (`user`: 7 groups, `codeviewer`: 5, `admin`: 1, `scan`: 1).
- `GOOS=windows GOARCH=amd64` cross-compile succeeds.

**Completeness audit.** `common.DataStore` is the only `DataStore` in the codebase — `internal/extract/store.go` is a type alias — so this one choke point covers both the extract and migrate pipelines. `Writer` / `ReadAll` / `TaskDirExists` are the only methods that turn a task name into a path (`MarkComplete` / `IsComplete` are in-memory). `feed+":apply"` at `tasks_permissions.go:440` is the only site in the codebase that produces a colon-bearing task name, so exactly two task names are affected and neither can collide with another after sanitization.

**Known edge case, accepted on #487.** Resuming a migration that was *started* by a pre-fix build on Linux/macOS will re-run the two colon-named tasks, because `TaskDirExists` now looks for the sanitized name. @jon-lipsky-sonarsource made the call to accept this; the tasks are idempotent and the affected directories are empty markers (the `forEachExtractItem` callback never writes to them). Deliberately not "fixed" here to keep the approved diff intact.

Closes #486. Supersedes #487 — please close that one with credit to @xibuka once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
